### PR TITLE
Add a more precise id on the 404 page section

### DIFF
--- a/docs/websites/website-navigation.qmd
+++ b/docs/websites/website-navigation.qmd
@@ -302,7 +302,7 @@ aliases:
 Depending on where you are deploying your site there may be more powerful tools available for defining redirects based on patterns. For example, Netlify [`_redirects`](https://docs.netlify.com/routing/redirects/) files or [`.htaccess`](https://www.danielmorell.com/guides/htaccess-seo/redirects/introduction-to-redirects) files. Search your web host's documentation for "redirects" to see if any of these tools are available.
 :::
 
-## 404 Pages
+## 404 Pages {#pages-404}
 
 When a browser can't find a requested web page, it displays a [404 error](https://en.wikipedia.org/wiki/HTTP_404) indicating that the file can't be found. Browser default 404 pages can be pretty stark, so you may want to create a custom page with a more friendly message and perhaps pointers on how users might find what they are looking for.
 


### PR DESCRIPTION
Currently the link on the 404 pages sections is https://quarto.org/docs/websites/website-navigation.html#pages

The header is `# 404 pages` but the id has been trimmed form leading non alphabet character. 

This is because extensions [auto-identifier](https://pandoc.org/MANUAL.html#extension-auto_identifiers) will 
> Remove everything up to the first letter  (identifiers may not begin with a number or punctuation mark)

I think it would be better to have the 404 mention in the link. so I suggestion we put the 404 mention at the end of the id 

````
## 404 Pages {#pages-404}
```` 

This is what this PR is about so that the link will become

https://quarto.org/docs/websites/website-navigation.html#pages-404

If it is not too late to change the identifier of this heading.

I understand if this idea is rejected though - it is not so important. 

Thanks!