### PR TITLE
Update output-formats/html-publishing.qmd - Fix link

### DIFF
--- a/docs/output-formats/html-publishing.qmd
+++ b/docs/output-formats/html-publishing.qmd
@@ -12,7 +12,7 @@ This article covers the various ways you can publish Quarto HTML documents, incl
 
 -   Sharing a standalone HTML file using E-mail, Dropbox, etc.
 
-Note that it's also possible to publish collections of Quarto documents as a website (see the article on [publishing websites](../websites/publishing-websites.md) for additional details).
+Note that it's also possible to publish collections of Quarto documents as a website (see the article on [publishing websites](../websites/publishing-websites.html) for additional details).
 
 ## GitHub Pages
 


### PR DESCRIPTION
Hi, I was reading the docs and faced a broken link.
In this page: https://quarto.org/docs/output-formats/html-publishing.html there is a link to https://quarto.org/docs/websites/publishing-websites.md , which directs to a 'Page not found'. If we change to .html, it redirects to the page https://quarto.org/docs/websites/publishing-websites.html . 

Thanks!