### PR TITLE
Language subtag is pr in the docs, but sould be pt (for Portuguese) (fix typo)

### DIFF
--- a/docs/authoring/language.qmd
+++ b/docs/authoring/language.qmd
@@ -31,7 +31,7 @@ Quarto includes built-in translations for the following languages:
 -   Chinese (`zh`)
 -   French (`fr`)
 -   German (`de`)
--   Portuguese (`pr`)
+-   Portuguese (`pt`)
 
 You can also create and use a custom translation as follows:
 


### PR DESCRIPTION
Hi! In the website https://quarto.org/docs/authoring/language.html#translations the language subtag for Portuguese is `pr` but should be  `pt` (as it is in https://r12a.github.io/app-subtags/ and used in https://github.com/quarto-dev/quarto-cli/tree/main/src/resources/language )

