### PR TITLE
fix potential typo for qmd files after quarto create-project

### DIFF
--- a/docs/books/book-basics.qmd
+++ b/docs/books/book-basics.qmd
@@ -43,7 +43,7 @@ This will build the HTML version of the book and run a local web server to view 
 
 ![](images/book-scaffold.png){.border .preview-image fig-alt="A screenshot of the page rendered by starter code for a Quarto book project."}
 
-The book's chapters are contained in the files `index.md`, `introduction.md`, `summary.md`. Try adding some content to one of these files and saving---you'll notice that the book preview is automatically updated in the browser.
+The book's chapters are contained in the files `index.qmd`, `intro.qmd`, `summary.qmd`. Try adding some content to one of these files and saving---you'll notice that the book preview is automatically updated in the browser.
 
 You'll also notice that a Quarto project file (`_quarto.yml`) was created in the `mybook` directory. This file contains the initial configuration for your book:
 


### PR DESCRIPTION
After running `quarto create-project` this is the folder contents:

```
>ls -l
total 63
drwxr-xr-x 1 Danie Danie     0 Dec 27 00:20 _book
-rw-r--r-- 1 Danie Danie   270 Dec 27 00:16 _quarto.yml
-rw-r--r-- 1 Danie Danie   272 Dec 27 00:23 bigbookofpython.Rproj
-rw-r--r-- 1 Danie Danie 51194 Dec 27  2021 cover.png
-rw-r--r-- 1 Danie Danie   121 Dec 27 00:16 index.qmd
-rw-r--r-- 1 Danie Danie   139 Dec 27 00:16 intro.qmd
-rw-r--r-- 1 Danie Danie   436 Dec 27  2021 references.bib
-rw-r--r-- 1 Danie Danie    44 Dec 27 00:16 references.qmd
-rw-r--r-- 1 Danie Danie    60 Dec 27 00:16 summary.qmd
```

the current site makes references to `index.md`, `introduction.md`, and `summary.md`