### PR TITLE
Correct `$callout-border-width` description

### DIFF
--- a/docs/output-formats/html-themes.qmd
+++ b/docs/output-formats/html-themes.qmd
@@ -267,7 +267,7 @@ The following Saas Variables can be specified within SCSS files (note that these
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Variable                 | Notes                                                                                                                                                              |
 +==========================+====================================================================================================================================================================+
-| `$callout-border-width`  | By default, Quarto does not display a left border on code blocks. Set this variable to a truthy value or a CSS color to enable the left border. Defaults to `5px`. |
+| `$callout-border-width`  | By default, Quarto does not display a left border on callouts. Set this variable to a truthy value or a CSS color to enable the left border. Defaults to `5px`. |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | `$callout-border-scale`  | The border color of callouts computed by shifting the callout color by this amount. Defaults to `0%`.                                                              |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Changes "code blocks" to "callouts" for description of `$callout-border-width` variable.

Pretty sure this was a mixup 🙂