### PR TITLE
Fixed errors in VS Code docs RE `convert` cmd

### DIFF
--- a/docs/tools/vscode.qmd
+++ b/docs/tools/vscode.qmd
@@ -140,8 +140,8 @@ If you are doing most of your work in .qmd files you should consider using RStud
 You can convert between .ipynb and .qmd representations of a notebook using the `quarto convert` command. For example:
 
 ``` bash
-quarto convert basics-jupyter.ipynb --to markdown
-quarto convert basics-jupyter.qmd --to notebook
+quarto convert basics-jupyter.ipynb
+quarto convert basics-jupyter.qmd
 ```
 
 See `quarto convert help` for additional details on converting notebooks.


### PR DESCRIPTION
At least in Quarto version 0.3.76 the `quarto convert` command doesn't work like this.
I fixed it to reflect the current version.