### PR TITLE
remove duplicate entry for link-external-icon

### DIFF
--- a/docs/reference/formats/html.json
+++ b/docs/reference/formats/html.json
@@ -351,10 +351,6 @@
         "description": "Show a special icon next to links that leave the current site."
       },
       {
-        "name": "link-external-icon",
-        "description": "Show a special icon next to links that leave the current site."
-      },
-      {
         "name": "link-external-newwindow",
         "description": "Open external links in a new browser window or tab (rather than navigating the current tab)."
       },


### PR DESCRIPTION
there are duplicate entries in https://quarto.org/docs/reference/formats/html.html#links

![image](https://user-images.githubusercontent.com/5782147/152916943-ae5eab7b-6018-411c-a7f4-64e9ae002707.png)

Note: I did not try to re-render the site in this PR. I just fixed up the `json` file.