### PR TITLE
Fix tbl-colwidths column header example

### DIFF
--- a/docs/authoring/tables.qmd
+++ b/docs/authoring/tables.qmd
@@ -74,7 +74,7 @@ You can also explicitly specify columns widths using the `tbl-colwidths` attribu
 
 ``` markdown
 | fruit  | price  |
-|--------|--------:
+|--------|--------|
 | apple  | 2.05   |
 | pear   | 1.37   |
 | orange | 3.09   |


### PR DESCRIPTION
I think that ending the column header with `:` may have been a typo, or it's intentional and valid. But its presentation seems to indicate that one would need to end the column header with `:` to enable the `tbl-colwidth` attribute, which is not the case.