### PR TITLE
Specify "Insert Anything" requires visual editor

### DIFF
--- a/docs/get-started/authoring/rstudio.qmd
+++ b/docs/get-started/authoring/rstudio.qmd
@@ -215,7 +215,7 @@ See the output format documentation (e.g. [HTML](/docs/output-formats/html-basic
 
 ## Equations
 
-You can add LaTeX equations to Quarto documents in RStudio using the [Insert Anything](/docs/visual-editor/index.qmd#insert-anything) tool.
+If you are using the visual editor mode, you can add LaTeX equations to Quarto documents in RStudio using the [Insert Anything](/docs/visual-editor/index.qmd#insert-anything) tool.
 You can access it with <kbd>/</kbd> at the beginning of an empty block or <kbd>Cmd+/</kbd> anywhere else.
 
 ![](images/rstudio-insert-equation.png){.border fig-alt="Insert anything tool in the RStudio visual editor being used to insert a display math." fig-align="center" width="600"}


### PR DESCRIPTION
For the Insert Anything option to work, the user must be in Visual Editor mode.  The YAML header does not specify that mode, so when the user gets to this part of the tutorial it fails to work.