### PR TITLE
Fix typo in python.qmd

### DIFF
--- a/docs/computations/python.qmd
+++ b/docs/computations/python.qmd
@@ -2,7 +2,7 @@
 title: "Using Python"
 jupyter-language: "Python"
 jupyter-screenshot: "![](../get-started/hello/images/jupyter-basics.png){.border}"
-vscode-extension: "[Python Extension]https://marketplace.visualstudio.com/items?itemName=ms-python.python)"
+vscode-extension: "[Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)"
 vscode-screenshot: "![](images/python-vscode){.border}"
 ---
 


### PR DESCRIPTION
Fix the unclosed bracket for the vscode quarto extension link under the python page