### PR TITLE
Add aria-labels to icon-only menu items

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,8 +36,10 @@ website:
     right:
       - icon: twitter
         href: https://twitter.com/quarto_pub
+        aria-label: Quarto Twitter
       - icon: github
         href: https://github.com/quarto-dev/quarto-cli
+        aria-label: Quarto GitHub
   navbar:
     background: light
     logo: quarto.png
@@ -67,8 +69,10 @@ website:
     right:
       - icon: twitter
         href: https://twitter.com/quarto_pub
+        aria-label: Quarto Twitter
       - icon: github
         href: https://github.com/quarto-dev/quarto-cli
+        aria-label: Quarto GitHub
 
   sidebar:
     - id: get-started


### PR DESCRIPTION
Adds `aria-label` params to icons in the header and footer for accessibility (n.b. I did not re-render the site, as it looks like that occurs on GitHub).