### PR TITLE
Add fig-subcap to example of figures produced by executable code blocks

### DIFF
--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -336,6 +336,8 @@ Note that figure layout attributes also work for figures produced by executable 
 #### Jupyter
 
 ``` {{python}}
+#| fig-cap: Charts.
+#| fig-subcap: ["First.", "Second."]
 #| layout-ncol: 2
 
 import matplotlib.pyplot as plt
@@ -351,6 +353,8 @@ plt.show()
 #### Knitr
 
 ``` {{r}}
+#| fig-cap: Charts.
+#| fig-subcap: ["Cars.", "Pressure."]
 #| layout-ncol: 2
 
 plot(cars)


### PR DESCRIPTION
Close https://github.com/quarto-dev/quarto-web/issues/154.

``````
```{r}
#| layout-ncol: 2
#| fig-cap: Main
#| fig-subcap: ["Foo", "Bar"]

plot(cars)
plot(pressure)
```
``````

generates

![Screenshot from 2022-05-06 13-45-54](https://user-images.githubusercontent.com/1506457/167074188-8306c84e-ffe3-45fa-96d8-2a6024612db7.png)

# TODO

I would love a little of mentoring to

- [ ] Fix the caption for the main figure that is missing in the output
- [ ] Update the generated PNG