### PR TITLE
Update ms-word.qmd example yaml

### DIFF
--- a/docs/output-formats/ms-word.qmd
+++ b/docs/output-formats/ms-word.qmd
@@ -13,7 +13,7 @@ title: "My Document"
 format:
   docx:
     toc: true
-    section-numbers: true
+    number-sections: true
     highlight-style: github
 ---
 ```


### PR DESCRIPTION
Is the currently shown `section-numbers` out of date? 

The syntax `number-sections` works, and is consistent with documenation here: https://quarto.org/docs/output-formats/ms-word.html#section-numbering