### PR TITLE
fix: typo `enableEmjoi`

### DIFF
--- a/docs/visual-editor/content.qmd
+++ b/docs/visual-editor/content.qmd
@@ -64,7 +64,7 @@ To insert an emoji, you can use either the **Insert** menu or the requisite mark
 |----------------------------------------------|-------------------------------------------------|
 | ![](images/visual-editing-emoji-dialog.png)  | ![](images/visual-editing-emoji-completion.png) |
 
-For markdown formats that support text representations of emojis (e.g. `:grinning:`), the text version will be written. For other formats the literal emoji character will be written. Currently, the [gfm](../output-formats/gfm.qmd) and [hugo](../output-formats/hugo.qmd) (with `enableEmjoi = true` in the site config) formats both support text representation of emojis.
+For markdown formats that support text representations of emojis (e.g. `:grinning:`), the text version will be written. For other formats the literal emoji character will be written. Currently, the [gfm](../output-formats/gfm.qmd) and [hugo](../output-formats/hugo.qmd) (with `enableEmoji = true` in the site config) formats both support text representation of emojis.
 
 If you want to add support for markdown emoji output to another Quarto format, you can add the `emoji` extension to the `from` option in document metadata. For example:
 


### PR DESCRIPTION
Fix a typo (most likely) in [`docs/visual-editor/content.qmd`](./docs/visual-editor/content.qmd) `enableEmjoi = true` instead of `enableEmoji = true`.

This is related to two (built) files in `_site`.