### PR TITLE
Add `R.options` example

### DIFF
--- a/docs/computations/_knitr-options.md
+++ b/docs/computations/_knitr-options.md
@@ -1,6 +1,6 @@
 ## Knitr Options
 
-If you are using the Knitr cell execution engine you can specify default document-level Knitr options in YAML. For example:
+If you are using the Knitr cell execution engine, you can specify default document-level [Knitr chunk options](https://yihui.org/knitr/options/) in YAML. For example:
 
 ``` yaml
 ---
@@ -9,10 +9,14 @@ format: html
 knitr:
   opts_chunk: 
     collapse: true
-    comment: "#>"
+    comment: "#>" 
+    R.options:
+      knitr.graphics.auto_pdf: true
 ---
 ```
 
 You can additionally specify global Knitr options using `opts_knit`.
 
-In the example above we establish default Knitr options for a single document. You can also add shared `knitr` options to a project-wide `_quarto.yml` file or a project-directory scoped `_metadata.yml` file.
+The `R.options` chunk option is a convenient way to define R options that are set temporarily via [`options()`](https://rdrr.io/r/base/options.html) before the code chunk execution, and immediately restored afterwards.
+
+In the example above, we establish default Knitr chunk options for a single document. You can also add shared `knitr` options to a project-wide `_quarto.yml` file or a project-directory scoped `_metadata.yml` file.


### PR DESCRIPTION
I've just stumbled upon [this post](https://github.com/quarto-dev/quarto-cli/issues/997#issuecomment-1139588357) and thought it makes sense to document this very convenient way to set R options for R code chunk execution. I'm not sure though, if `quarto-web/docs/computations/_knitr-options.md` is the best place. `R.options` is currently missing from [`docs/reference/cells/cells-knitr.json`](https://github.com/quarto-dev/quarto-web/blob/main/docs/reference/cells/cells-knitr.json).