### PR TITLE
Order callout types more consistently

### DIFF
--- a/docs/authoring/callouts.qmd
+++ b/docs/authoring/callouts.qmd
@@ -9,11 +9,11 @@ Callouts are an excellent way to draw extra attention to certain concepts, or to
 
 There are five different types of callouts available.
 
--   note
--   tip
--   important
--   caution
--   warning
+-   `note`
+-   `warning`
+-   `important`
+-   `tip`
+-   `caution`
 
 The color and icon will be different depending upon the type that you select. Here are what the various types look like in HTML output:
 
@@ -21,10 +21,8 @@ The color and icon will be different depending upon the type that you select. He
 Note that there are five types of callouts, including: `note`, `tip`, `warning`, `caution`, and `important`.
 :::
 
-::: callout-tip
-## Tip With Caption
-
-This is an example of a callout with a caption.
+::: callout-warning
+Callouts provide a simple way to attract attention, for example, to this warning.
 :::
 
 ::: callout-important
@@ -33,8 +31,10 @@ This is an example of a callout with a caption.
 Danger, callouts will really improve your writing.
 :::
 
-::: callout-warning
-Callouts provide a simple way to attract attention, for example, to this warning.
+::: callout-tip
+## Tip With Caption
+
+This is an example of a callout with a caption.
 :::
 
 ::: {.callout-caution collapse="true"}
@@ -50,7 +50,7 @@ Create callouts in markdown using the following syntax (note that the first mark
 ``` markdown
 :::{.callout-note}
 Note that there are five types of callouts, including:
-`note`, `tip`, `warning`, `caution`, and `important`.
+`note`, `warning`, `important`, `tip`, and `caution`.
 :::
 
 :::{.callout-tip}
@@ -77,7 +77,7 @@ You can create 'folded' callouts that can be expanded by the user by settings th
 Callouts have 3 different looks you can use.
 
 |           |                                                                                                                 |
-|-------------|-----------------------------------------------------------|
+|-----------|-----------------------------------------------------------------------------------------------------------------|
 | `default` | The default appearance with colored header and an icon.                                                         |
 | `simple`  | A lighter weight appearance that doesn't include a colored header background.                                   |
 | `minimal` | A minimal treatment that applies borders to the callout, but doesn't include a header background color or icon. |


### PR DESCRIPTION
This way it's easier to understand which example corresponds to which callout type (especially `warning`, `important` and `caution`).