### PR TITLE
`linestretch` option must be a string instead of a numeric

### DIFF
--- a/docs/output-formats/html-themes.qmd
+++ b/docs/output-formats/html-themes.qmd
@@ -95,7 +95,7 @@ format:
   html: 
     theme: cosmo
     fontsize: 1.1em
-    linestretch: 1.7
+    linestretch: "1.7"
 ```
 
 ## Theme Options


### PR DESCRIPTION
fixes https://github.com/quarto-dev/quarto-cli/issues/1081 (sorry, opened issue in the wrong repo)

