### PR TITLE
Adds explanation for title slide

### DIFF
--- a/docs/presentations/revealjs/index.qmd
+++ b/docs/presentations/revealjs/index.qmd
@@ -389,6 +389,24 @@ You can always omit the title text, and specify only the slide background inform
 (Another slide with no title)
 ```
 
+### Adding backgrounds to Title slide
+
+Title slide is the first slide, which is generated via yaml's metadata. Because of that, the previous methods will not work, and it has to be themed via metadata, too. In order to do so, you need to:
+
+1. indent the background options under `title-slide-attributes`
+2. prepend the background option with `data-`
+
+```yaml
+---
+title: My Slide Show
+parallaxBackgroundImage: /path/to/my/background_image.png
+title-slide-attributes:
+    data-background-image: /path/to/title_image.png
+    data-background-size: contain
+    data-background-opacity: "0.5"
+---
+```
+
 ## Learning More
 
 See these articles lo learn about more advanced capabilities of Reveal:


### PR DESCRIPTION
Title slide needs a different approach for adding backgrounds.
This PR is aimed at explaining the procedure described in Pandoc's documentation https://pandoc.org/MANUAL#on-the-title-slide-reveal.js-pptx, following [this discussion at StackOverflow](https://stackoverflow.com/questions/72884987/custom-background-in-title-slide-using-quartos-reveal-implementation/72893626#72893626)