### PR TITLE
Fixed spelling of "document"

### DIFF
--- a/docs/get-started/computations/vscode.qmd
+++ b/docs/get-started/computations/vscode.qmd
@@ -188,7 +188,7 @@ jupyter: python3
 ---
 ```
 
-Render the documebt and you'll see that a code menu appears at the top right of the document that provides global control over showing and hiding code.
+Render the document and you'll see that a code menu appears at the top right of the document that provides global control over showing and hiding code.
 
 ![](images/text-editor-code-tools-preview.png){.border fig-alt="Rendered version of the computations.qmd document. A new code widget appears on top right of the document. The screenshot shows that the widget is clicked on, which reveals a drop down menu with three choices: Show All Code, Hide All Code, and View Source. In the background is the rendered document. The title is followed by some text, which is followed by a Code widget that would expand if clicked on, which is followed by the output of the code. The Code widgets are folded, so the code is not visible in the rendered document."}
 


### PR DESCRIPTION
There is a typo in one of the spellings of "document"