### PR TITLE
Update broken links and small tweaks in FAQ

### DIFF
--- a/docs/faq/index.qmd
+++ b/docs/faq/index.qmd
@@ -40,7 +40,7 @@ You can write your Quarto documentation in your human language of choice. The [l
 
 ### How can I share documents and have people comment on them?
 
-You can publish Quarto content to various locations. See the user guides for [publishing] for details on using Quarto Pub, GitHub Pages, Netlify, RStudio Connect, and other services. with Quarto. Once documents are published you can use  [hypothes.is](https://web.hypothes.is/), [Utterances](https://utteranc.es/), or [Giscus](https://giscus.app/) for commenting. Learn more in the documentation on [commenting](https://quarto.org/docs/output-formats/html-basics.html#commenting).
+You can publish Quarto content to various locations. See the user guides for [publishing](https://quarto.org/docs/publishing/) for details on using Quarto Pub, GitHub Pages, Netlify, RStudio Connect, and other services with Quarto. Once documents are published you can use  [hypothes.is](https://web.hypothes.is/), [Utterances](https://utteranc.es/), or [Giscus](https://giscus.app/) for commenting. Learn more in the documentation on [commenting](https://quarto.org/docs/output-formats/html-basics.html#commenting).
 
 ### Can I do collaborative editing with Quarto?
 
@@ -50,7 +50,7 @@ RStudio Workbench allows for [Project Sharing](https://support.rstudio.com/hc/en
 
 ### Where can I publish Quarto websites?
 
-There are a wide variety of ways to publish Quarto websites. Website content is by default written to the \_site sub-directory (you can customize this using the output-dir option). Publishing is simply a matter of copying the output directory to a web server or web hosting service.
+There are a wide variety of ways to publish Quarto websites. Website content is by default written to the `\_site` sub-directory (you can customize this using the output-dir option). Publishing is simply a matter of copying the output directory to a web server or web hosting service.
 
 The [publishing documentation](https://quarto.org/docs/publishing/other.html) describes several convenient options for Quarto website deployment including RStudio Connect, Netlify, GitHub Pages, Firebase, Site44, and Amazon S3. We'll mostly defer to the documentation provided by those various services, but will note any Quarto website specific configuration required.
 

--- a/docs/faq/index.qmd
+++ b/docs/faq/index.qmd
@@ -40,7 +40,7 @@ You can write your Quarto documentation in your human language of choice. The [l
 
 ### How can I share documents and have people comment on them?
 
-You can publish Quarto content to various locations. See the user guides for [publishing documents](https://quarto.org/docs/output-formats/html-publishing.html) and [publishing websites](https://quarto.org/docs/websites/publishing-websites.html)  for details on using GitHub Pages, Netlify, RStudio Connect, and other services. with Quarto. Once documents are published you can use  [hypothes.is](https://web.hypothes.is/), [Utterances](https://utteranc.es/), or [Giscus](https://giscus.app/) for commenting. Learn more in the documentation on [commenting](https://quarto.org/docs/output-formats/html-basics.html#commenting).
+You can publish Quarto content to various locations. See the user guides for [publishing] for details on using Quarto Pub, GitHub Pages, Netlify, RStudio Connect, and other services. with Quarto. Once documents are published you can use  [hypothes.is](https://web.hypothes.is/), [Utterances](https://utteranc.es/), or [Giscus](https://giscus.app/) for commenting. Learn more in the documentation on [commenting](https://quarto.org/docs/output-formats/html-basics.html#commenting).
 
 ### Can I do collaborative editing with Quarto?
 
@@ -52,7 +52,7 @@ RStudio Workbench allows for [Project Sharing](https://support.rstudio.com/hc/en
 
 There are a wide variety of ways to publish Quarto websites. Website content is by default written to the \_site sub-directory (you can customize this using the output-dir option). Publishing is simply a matter of copying the output directory to a web server or web hosting service.
 
-The [publishing documentation](https://quarto.org/docs/websites/publishing-websites.html) describes several convenient options for Quarto website deployment including RStudio Connect, Netlify, GitHub Pages, Firebase, Site44, and Amazon S3. We'll mostly defer to the documentation provided by those various services, but will note any Quarto website specific configuration required.
+The [publishing documentation](https://quarto.org/docs/publishing/other.html) describes several convenient options for Quarto website deployment including RStudio Connect, Netlify, GitHub Pages, Firebase, Site44, and Amazon S3. We'll mostly defer to the documentation provided by those various services, but will note any Quarto website specific configuration required.
 
 ### Does RStudio Connect support Quarto?
 


### PR DESCRIPTION
The pages https://quarto.org/docs/websites/publishing-websites.html and https://quarto.org/docs/output-formats/html-publishing.html are no longer available in the documentation. 
I have updated the links and tweaked the text to fit the new website structure and added `QuartoPub` as a publishing platform and added backticks around `_site`