### PR TITLE
Fix link to Revise.jl docs

### DIFF
--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -92,7 +92,7 @@ Once you've installed IJulia Quarto has the basic components required to execute
 
 ### Revise.jl
 
-In addition to IJulia, you'll want to install [Revise.jl](https://timholy.github.io/Revise.jl) and configure it for use with IJulia. Revise.jl is a library that helps you keep your Julia sessions running longer, reducing the need to restart when you make changes to code.
+In addition to IJulia, you'll want to install [Revise.jl](https://timholy.github.io/Revise.jl/stable) and configure it for use with IJulia. Revise.jl is a library that helps you keep your Julia sessions running longer, reducing the need to restart when you make changes to code.
 
 Quarto maintains a persistent [kernel daemon](#kernel-daemon) for each document to mitigate Jupyter start up time during iterative work. Revise.jl will make this persistent process robust in the face of package updates, git branch checkouts, etc. Install Revise.jl with:
 
@@ -111,7 +111,7 @@ catch e
 end
 ```
 
-You can learn more about Revise.jl at <https://timholy.github.io/Revise.jl>.
+You can learn more about Revise.jl at <https://timholy.github.io/Revise.jl/stable>.
 
 ``` include
 _jupyter-authoring-tools.md


### PR DESCRIPTION
The current link leads to a 404, by adding `/stable` we get to the docs