### PR TITLE
Fix example open graph YAML

### DIFF
--- a/docs/websites/website-tools.qmd
+++ b/docs/websites/website-tools.qmd
@@ -87,7 +87,7 @@ The [Open Graph protocol](http://ogp.me/) is a specification that enables rich
 
 ``` yaml
 website:
-  opengraph: true
+  open-graph: true
 ```
 
 In this case, Quarto will automatically generate a title, description, and preview image for the content. For more information about how Quarto finds preview images, see [Preview Images].


### PR DESCRIPTION
This PR fixes the example YAML for enabling Open Graph, adding back in the hyphen. As written, the example doesn't work, meaning the instructions for the easy setup of Open Graph metadata don't work properly; users either need to go down to the more advanced section and notice the difference:

https://github.com/quarto-dev/quarto-web/blob/d172e572d369578c7a26d3113ace11893b62c1db/docs/websites/website-tools.qmd#L115-L120

Or check the field on an example website:
https://github.com/quarto-dev/quarto-web/blob/d172e572d369578c7a26d3113ace11893b62c1db/_quarto.yml#L14