### PR TITLE
Make it clear to the reader how to change page properties in Word

### DIFF
--- a/docs/output-formats/ms-word-templates.qmd
+++ b/docs/output-formats/ms-word-templates.qmd
@@ -5,7 +5,7 @@ format: html
 
 ## Using Templates
 
-If you want to customize the appearance of MS Word output, Pandoc supports a special type of template called a *reference document*. Here's an example of specifying a custom reference document for `docx`:
+If you want to customize the appearance (from font type to page size) of MS Word output, Pandoc supports a special type of template called a *reference document*. Here's an example of specifying a custom reference document for `docx`:
 
 ``` yaml
 format:
@@ -25,6 +25,10 @@ To create a new reference doc based on the Pandoc default, execute the following
        --print-default-data-file reference.docx
 
 Then, open `custom-reference-doc.docx` in MS Word and modify styles as you wish:
+
+![You can open the Page pane from the HOME tab in the MS Word toolbar.](images/word-page.png){.preview-image fig-alt="Screenshot of Microsoft Word document open with Page  pane open in a pane over the left side of the document."}
+
+To change the page properties, for example to use A4 instead of letter, go to the Page pane.
 
 ![You can open the Styles pane from the HOME tab in the MS Word toolbar.](images/word-styles.png){.preview-image fig-alt="Screenshot of Microsoft Word document open with Styles pane open in a pane over the left side of the document."}
 


### PR DESCRIPTION
To PDF produced by LaTeX, I can change the page by having

```
format:
  pdf:
    papersize: a4paper
```

in the YAML header. I was looking how to do the same with Word and it strikes me that the documentation doesn't clear states it. [Pandoc's manual](https://pandoc.org/MANUAL.html) says

> The contents of the reference docx are ignored, but its stylesheets and document properties (including margins, page size, header, and footer) are used in the new docx.

This PR add a paragraphs about changing document properties.

**Help needed!**

- [ ] Create correct screenshot. I don't MS Word in my machine.
- [ ] Replace wrong screenshot.