### PR TITLE
Add alt text for logo in navbar.

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -47,6 +47,7 @@ website:
   navbar:
     background: light
     logo: quarto.png
+    logo-alt: "Quarto logo."
     title: false
     collapse-below: lg
     left:


### PR DESCRIPTION
Uses new `logo-alt` parameter (https://github.com/quarto-dev/quarto-cli/commit/eab69da389ae4b9e9ac0c7382a6948e14939dc87) to add alt text to the navbar brand (which previously was a WCAG failure). 