### PR TITLE
Add an example of using params in an arquero query

### DIFF
--- a/docs/interactive/ojs/examples/arquero.qmd
+++ b/docs/interactive/ojs/examples/arquero.qmd
@@ -15,7 +15,7 @@ penguins.view()
 
 penguins
   .groupby('species')
-  .filter(p => p.body_mass > 0)
+  .filter(d => d.body_mass > 0)
   .rollup({
     count: op.count(),
     avg_mass: op.average('body_mass')
@@ -23,3 +23,29 @@ penguins
   .view()
 ```
 
+If you want to use inputs in an arquero query, you can use the `params` method of table.
+Below is a simple example of filtering a dataset by the values provided.
+
+```{ojs}
+//| panel: input
+viewof bill_length_min = Inputs.range(
+  [32, 50],
+  {value: 35, step: 1, label: "Bill length (min):"}
+)
+viewof islands = Inputs.checkbox(
+  ["Torgersen", "Biscoe", "Dream"],
+  { value: ["Torgersen", "Biscoe"],
+    label: "Islands:"
+  }
+)
+```
+
+```{ojs}
+penguins
+  .params({
+    blm: bill_length_min,
+    i: islands
+  })
+  .filter((d, $) => op.includes($.i, d.island) && d.bill_length > $.blm)
+  .view()
+```


### PR DESCRIPTION
Users of ojs code blocks will expect interactive documentation, so it would be useful to include an example of manipulating arquero filtering via an input panel in the example.
(I had a hard time getting to this one!)

I also modified the existing example slightly because it appeared that the arquero documentation often used `d` instead of `p`.