### PR TITLE
Fix minor typos in Extensions docs

### DIFF
--- a/docs/extensions/_formats-common.qmd
+++ b/docs/extensions/_formats-common.qmd
@@ -34,7 +34,7 @@ contributes:
       shortcodes:
         - quarto-ext/fancy-text
     html:
-      # html-speicific
+      # html-specifc
     pdf:
       # pdf-specifc
 ```

--- a/docs/extensions/formats.qmd
+++ b/docs/extensions/formats.qmd
@@ -6,7 +6,7 @@ example-format: lexconf
 
 ## Overview
 
-Quarto format extensions enable you to add new formats to the built-in formats (e.g. `html`, `pdf`, `docx`) already available. Custom formats can provide default document options, style-heets, header, footer, or logo elements, and even bundle other extensions like [filters](filters.qmd) and [shortcodes](shortcodes.qmd). They are a great way to provide a common baseline for authoring documents or presentations within an organization, for a particular type of project or analysis, or for a specific publication.
+Quarto format extensions enable you to add new formats to the built-in formats (e.g. `html`, `pdf`, `docx`) already available. Custom formats can provide default document options, style-sheets, header, footer, or logo elements, and even bundle other extensions like [filters](filters.qmd) and [shortcodes](shortcodes.qmd). They are a great way to provide a common baseline for authoring documents or presentations within an organization, for a particular type of project or analysis, or for a specific publication.
 
 You can specify a custom format beneath the `format` key just like a built-in format. For example:
 


### PR DESCRIPTION
Just following along with creating formats docs and noticed a couple of typos.