### PR TITLE
Fix link to aria-label page by mozilla

### DIFF
--- a/docs/websites/website-navigation.qmd
+++ b/docs/websites/website-navigation.qmd
@@ -71,7 +71,7 @@ Here are the options available for individual navigation items:
 | `href`       | Link to file contained with the project or external URL.                                                                                                    |
 | `text`       | Text to display for navigation item (defaults to the document `title` if not provided).                                                                     |
 | `icon`       | Name of one of the standard [Bootstrap 5 icons](https://icons.getbootstrap.com/) (e.g. "github", "twitter", "share", etc.).                                 |
-| `aria-label` | [Accessible label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) for the navigation item. |
+| `aria-label` | [Accessible label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) for the navigation item. |
 | `menu`       | List of navigation items to populate a drop-down menu.                                                                                                      |
 
 For more information on controlling the appearance of the navigation bar using HTML themes, see [HTML Themes - Navigation](/docs/output-formats/html-themes.qmd#navigation).


### PR DESCRIPTION
Old link was broken and resulted in "page not found". Hope it is fine to create a pull request immediately :)