### PR TITLE
Fix gantt chart typo

### DIFF
--- a/docs/authoring/diagrams.qmd
+++ b/docs/authoring/diagrams.qmd
@@ -4,7 +4,7 @@ title: "Diagrams"
 
 ## Overview
 
-Quarto has native support for embedding [Mermaid](https://mermaid-js.github.io/mermaid/#/) and [Graphviz](https://graphviz.org/) diagrams. This enables you to create flowcharts, sequence diagrams, state diagrams, gnatt charts, and more using a plain text syntax inspired by markdown.
+Quarto has native support for embedding [Mermaid](https://mermaid-js.github.io/mermaid/#/) and [Graphviz](https://graphviz.org/) diagrams. This enables you to create flowcharts, sequence diagrams, state diagrams, gantt charts, and more using a plain text syntax inspired by markdown.
 
 For example, here we embed a flowchart created using Mermaid:
 


### PR DESCRIPTION
Correct spelling is gantt, not gnatt [Wikipedia](https://en.wikipedia.org/wiki/Gantt_chart)