### PR TITLE
adding links to rstudioconf talk recordings

### DIFF
--- a/docs/blog/posts/2022-06-21-rstudio-conf-2022-quarto/index.qmd
+++ b/docs/blog/posts/2022-06-21-rstudio-conf-2022-quarto/index.qmd
@@ -31,7 +31,7 @@ Here is a list of Quarto-related talks and workshops (and scroll down for detail
 
 ## Keynote
 
-[**Reimagine + Collaborate + Share with Quarto**](https://sched.co/11iZo) **(Keynote)**:
+[**Reimagine + Collaborate + Share with Quarto**](https://sched.co/11iZo) **(Keynote)**: [(Talk recording)](https://www.rstudio.com/conference/2022/keynotes/collaborate-with-quarto/)
 
 -   Presented by [Julia Stewart Lowndes](https://jules32.github.io/) (Director, Openscapes) and [Mine Çetinkaya-Rundel](http://mine-cr.com/) (Developer Educator at RStudio and Professor at Duke University).
 -   Thursday July 28, 9:00am - 10:00am EDT.
@@ -58,19 +58,19 @@ We will have two Quarto workshops at the conference, held on July 25-26, one for
 
 ## Talks
 
--   [**Quarto for R Markdown users**](https://sched.co/11iZa):
+-   [**Quarto for R Markdown users**](https://sched.co/11iZa): [(Talk recording)](https://www.rstudio.com/conference/2022/talks/quarto-for-rmarkdown-users/)
     -   Presented by [Tom Mock](https://themockup.blog/about.html), Customer Enablement Lead at RStudio.
     -   Wednesday July 27, 3:20pm - 3:40pm EDT.
     -   Are you curious about Quarto? Maybe you saw it on Twitter or the RStudio::conf agenda. Perhaps this raised questions like: What exactly is Quarto? What about RMarkdown? (don't worry it's not going away!) What features does Quarto add? What should I do with my existing Rmd/ipynb files? This talk will answer all of those questions and more! I'll present Quarto as a next-gen version of RMarkdown, compare the similarities, and then discuss the new features in Quarto for publishing documents, presentations, blog posts, lab notebooks and more! Lastly, I'll cover what this means for our customers using RStudio Team, and the exciting new world for Python users.
--   [**These are a few of my favorite things (about Quarto presentations)**](https://sched.co/11ibN):
+-   [**These are a few of my favorite things (about Quarto presentations)**](https://sched.co/11ibN): [(Talk recording)](https://www.rstudio.com/conference/2022/talks/my-favorite-things-quarto-presentations/)
     -   Presented by [Tracy Teal](https://twitter.com/tracykteal), Open Source Program Director at RStudio.
     -   Thursday July 28, 2022 3:20pm - 3:40pm EDT.
     -   Quarto is the next generation of RMarkdown, and comes with a new presentation format, revealjs. In this talk, I'll show a few of my favorite things about making interactive HTML presentations with Quarto. Along the way you'll learn about the visual editor, multiple columns, delivering an effective talk with speaker notes and mode, making your presentations pop with transitions, effective ways to incorporate code into your presentation, beautiful themes (and how to match your corporate style guide), and sharing it as pdf and HTML. I'll finish off with a brief look at generating a PowerPoint presentation from a template.
--   [**Literate Programming With Jupyter Notebooks and Quarto**](https://sched.co/11ibe):
+-   [**Literate Programming With Jupyter Notebooks and Quarto**](https://sched.co/11ibe): [(Talk recording)](https://www.rstudio.com/conference/2022/talks/literate-programming-quarto/)
     -   Presented by [Hamel Husain](https://hamel.dev/), head of Data Science at [Outerbounds](https://outerbounds.com/) (the developers of [Metaflow](https://metaflow.org/)) and core developer at [fast.ai](https://www.fast.ai/).
     -   Thursday July 28, 3:40pm - 4:00pm EDT.
     -   Jupyter Notebooks play a critical role in in the workflow of many users. Notebooks are used to document existing code, to quickly prototype and iterate on ideas, and as a medium of technical communication. However, package developers typically use an entirely separate set of more traditional development tools, and the context switching between these tools and notebooks can be frustrating. Not only do you lose the ability to iterate fast, but you lose the ability to document and test your code in-situ, requiring you to create documentation and tests separately from source code. Nbdev is a literate programming framework that allows you to develop Python libraries within Jupyter Notebooks. This talk will describe the integration between Nbdev and Quarto, which enables library developers to author their documentation right alongside their code, and automatically produce a Quarto website for their package. The result is a seamless workflow for developing, documenting, and testing software packages all within Jupyter Notebooks, with no context-switching required.
--   [**Websites & Books & Blogs, oh my! Creating Rich Content with Quarto**](https://sched.co/11ibV):
+-   [**Websites & Books & Blogs, oh my! Creating Rich Content with Quarto**](https://sched.co/11ibV): [(Talk recording)](https://www.rstudio.com/conference/2022/talks/sessions/quarto-deep-dive/websites-books-blogs-quarto/)
     -   Presented by [Devin Pastoor](https://github.com/dpastoor), Solutions Engineer at RStudio.
     -   Thursday July 28, 4:00pm - 4:20pm EDT.
     -   A number of packages have emerged in the R ecosystem to help create websites (hugodown), books (bookdown), and blogs (blogdown). In this talk, I'll show you how Quarto handles creating these types of content and more. Whether you're a grad student considering your first blog post about R, or a python expert about to write a technical book, I'll show you how Quarto enables you to focus on content while it takes care of the rest. In addition, I'll show the RStudio team is making it as easy as possible to publish and share content within your organization and to the whole community.


### PR DESCRIPTION
Adding in links to the rstudio::conf(2022) talk recordings for Quarto talks on the conf talks blog post, so it can be a landing page for all the Quarto talks at conf. 