### PR TITLE
Add option resources in docs

### DIFF
--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -241,6 +241,16 @@ By default, `quarto publish` will re-render your project before publishing it. H
     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 ```
 
+Netlify [`_redirects`](https://docs.netlify.com/routing/redirects/) files or [`.htaccess`](https://www.danielmorell.com/guides/htaccess-seo/redirects/introduction-to-redirects) files are powerful tools for defining [redirects](https://quarto.org/docs/websites/website-navigation.html#redirects) based on patterns. In order to include these files in the rendered content written to the `_site` sub-directory, add the option [`resources`](https://quarto.org/docs/websites/website-tools.html#site-resources) to the Quarto project file:
+
+``` yaml
+project:
+  type: website
+  resources:
+  - netlify.toml
+  - .htaccess
+```
+
 ## Continuous Integration
 
 You can publish Quarto content to Netlify using any CI service by scripting the `quarto publish` command.


### PR DESCRIPTION
In case one uses [GitHub Actions](https://quarto.org/docs/publishing/netlify.html#github-action) to render and deploy content to Netlify, you may need to include a `netlify.toml` file with URL redirects for old blog posts into the _site subdirectory. A description of how to do this may be added to the Quarto docs if you like.