### PR TITLE
Bump Quarto Version indicated for `quarto.log.output`

### DIFF
--- a/docs/extensions/lua.qmd
+++ b/docs/extensions/lua.qmd
@@ -40,7 +40,7 @@ Here are some tips for productive development and debugging of Quarto extensions
     end
     ```
 
-    You'll see the output from `quarto.log` in the `quarto preview` terminal output stream . Note that the logging module requires the very latest release of Quarto (1.1.251). If you are using an earlier version you can still use the `quarto.utils.dump()` function for logging as described below.
+    You'll see the output from `quarto.log` in the `quarto preview` terminal output stream . Note that the logging module requires the very latest release of Quarto (1.2.133). If you are using an earlier version you can still use the `quarto.utils.dump()` function for logging as described below.
 
 3.  It can sometimes be helpful to change the output format of your document to `native` --- when you do this you'll see the full Pandoc AST rather than a rendering to HTML, PDF, etc. For example:
 


### PR DESCRIPTION
I tried with the version currently in the docs, and it doesn't seem to work.  However, the latest pre-release does work.