### PR TITLE
Add `.luaarc.json` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /_site/
 
 
+.luarc.json


### PR DESCRIPTION
I got the `.luarc.json` file created automatically when opening the project in VSCODE. 

Doc saus: 
> The .luarc.json file will also be automatically added to .gitignore since it points to the absolute path of Quarto on the local system.

So we should add to `.gitignore` right ? 