### PR TITLE
Update github-pages.qmd

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -80,7 +80,7 @@ Before attempting to publish you should ensure that the **Source** branch for yo
 
 ### Publishing
 
-Once you have configured the source branch and updated your `.gitignore`, navigate to the directory where your project / git repository is located, and from your main branch execute the `quarto publish` command for GitHub Pages.
+Once you have configured the source branch and updated your `.gitignore`, navigate to the directory where your project / git repository is located, make sure you are not on the `gh-pages` branch, and execute the `quarto publish` command for GitHub Pages:
 
 ``` {.bash filename="Terminal"}
 quarto publish gh-pages

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -80,7 +80,7 @@ Before attempting to publish you should ensure that the **Source** branch for yo
 
 ### Publishing
 
-Once you have configured the source branch and updated your `.gitignore`, navigate to the directory where your project / git repository is located and execute the `quarto publish` command for GitHub Pages:
+Once you have configured the source branch and updated your `.gitignore`, navigate to the directory where your project / git repository is located, and from your main branch execute the `quarto publish` command for GitHub Pages.
 
 ``` {.bash filename="Terminal"}
 quarto publish gh-pages


### PR DESCRIPTION
I got confused today about whether I should be running the `quarto publish` from the main branch or the `gh-pages`. Running from `gh-pages` infinitely hangs on the `Deploying gh-pages branch to website (this may take a few minutes)` step. I think clarifying that this should be run from the other branch would help.