### PR TITLE
Update vscode.qmd

### DIFF
--- a/docs/get-started/computations/vscode.qmd
+++ b/docs/get-started/computations/vscode.qmd
@@ -164,7 +164,8 @@ Remove the `echo` option we previously added and add the `code-fold` HTML format
 ``` yaml
 ---
 title: Quarto Computations
-execute:
+format:
+  html:
    code-fold: true
 jupyter: python3
 ---


### PR DESCRIPTION
on line 167, the "execute:" command does not apply "code-fold" anymore. At least on my quarto version? Therefore, alternative found in another tuto.