### PR TITLE
Correct possibly misleading info on bibliography file extensions

### DIFF
--- a/docs/authoring/footnotes-and-citations.qmd
+++ b/docs/authoring/footnotes-and-citations.qmd
@@ -11,13 +11,13 @@ Quarto will use Pandoc to automatically generate citations and a bibliography in
 
 -   A quarto document formatted with citations (see [Citation Markdown](#sec-citations)).
 
--   A bibliographic data source, for example a BibTeX (`.bib`) file.
+-   A bibliographic data source, for example a BibLaTeX (`.bib`) or BibTeX (`.bibtex`) file.
 
 -   Optionally, a `CSL` file which specifies the formatting to use when generating the citations and bibliography.
 
 ### Bibliography Files
 
-Quarto supports bibliography files in a wide variety of formats including BibTeX and CSL. Add a bibliography to your document using the `bibliography` YAML metadata field. For example:
+Quarto supports bibliography files in a wide variety of formats including BibLaTeX and CSL. Add a bibliography to your document using the `bibliography` YAML metadata field. For example:
 
 ``` yaml
 ---


### PR DESCRIPTION
[Quarto Citations section](https://quarto.org/docs/authoring/footnotes-and-citations.html#sec-citations) says, 

> A bibliographic data source, for example a *BibTeX (.bib)* file

However, this description may be possibly misleading b/c Pandoc uses `*.bib` file extension for BibLaTeX and `*.bibtex` for BibTeX: https://pandoc.org/MANUAL.html#specifying-bibliographic-data