### PR TITLE
Clarify saving and restoring conda env behavior

### DIFF
--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -173,7 +173,7 @@ You should generally check the `environment.yml` file into version control.
 To reproduce the environment on another machine you just pass the `environment.yml` file as an argument to `conda create`:
 
 ```{.bash filename="Terminal"}
-conda create --prefix env -f environment.yml
+conda env create --prefix env -f environment.yml
 ```
 
 ## Using renv

--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -170,7 +170,7 @@ You should generally check the `environment.yml` file into version control.
 
 ### Restoring Environments
 
-To reproduce the environment on another machine you just pass the `environment.yml` file as an argument to `conda create`:
+To reproduce the environment on another machine you just pass the `environment.yml` file as an argument to `conda env create`:
 
 ```{.bash filename="Terminal"}
 conda env create --prefix env -f environment.yml


### PR DESCRIPTION
The ability to programmatically save and restore a conda environment via an `environment.yml` file is currently a functionality of `conda env`, not `conda`. Corrected the documentation to match.