### PR TITLE
Explain how to use with python virtual environments

### DIFF
--- a/docs/computations/python.qmd
+++ b/docs/computations/python.qmd
@@ -116,6 +116,67 @@ If you are using a kernel that is contained within an external conda environment
 Note that this step is not required if you are merely using conda with Quarto. It applies to using kernels other than the default Python kernel that happen to be installed within a conda environment separate from the one you are using.
 :::
 
+## Kernels with Virtual Environments
+
+To use Quarto with a virtual environment, you need to install a kernel within the virtual environment. Follow these instructions to create a new virtual environment and install a kernel.
+
+:::{.panel-tabset}
+
+## Windows
+
+```{.bash filename="Terminal"}
+# Create a new virtual environment
+python -m venv .venv
+
+# Activate the virtual environment
+.venv\Scripts\activate.bat
+
+# Install ipykernel
+python3 -m pip install jupyter
+
+# Install a new kernel
+python3 -m ipykernel install --name my-project-kernel --display-name "Python Kernel for My Project" --user
+```
+
+## Mac/Linux
+
+```{.bash filename="Terminal"}
+# Create a new virtual environment
+python -m venv .venv
+
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Install ipykernel
+python3 -m pip install jupyter
+
+# Install a new kernel
+python3 -m ipykernel install --name my-project-kernel --display-name "Python Kernel for My Project" --user
+```
+
+:::
+
+Then, in your Quarto document, reference the new kernel you installed by name:
+
+``` yaml
+---
+title: "My Document"
+jupyter: my-project-kernel
+---
+```
+
+Note that you can also provide a full `kernelspec`, for example:
+
+``` yaml
+---
+title: "My Document"
+jupyter: 
+  kernelspec:
+    name: "my-project-kernel"
+    language: "python"
+    display_name: "Python Kernel for My Project"
+---
+```
 
 ``` include
 _jupyter-daemon.md


### PR DESCRIPTION
Hi Quarto team,

I was recently using Quarto to document a Python package I am developing. It took me some time to figure out how to get Quarto to use my virtual environment. Eventually, I realized I needed to install a kernel within my virtual environment. Documenting how to do this could be helpful as other users may run into the same problem.

I have added a new section to the docs/computations/python.qmd page to explain how to use Quarto with a virtual environment.

Note that it is already documented how to select your kernel:

https://github.com/quarto-dev/quarto-web/blob/81540c76b5c84be6e3e5f402c7796e55de58f6a5/docs/computations/python.qmd#L83-L105

I hope that my PR makes it clear to users that you need to install a kernel in your virtual environment.