### PR TITLE
Add examples of how markdown divs and spans translate into HTML

### DIFF
--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -226,6 +226,14 @@ This content can be styled with a border
 :::
 ```
 
+Once rendered to HTML, Quarto will translate the markdown into:
+
+``` html
+<div class="border">
+  <p>This content can be styled with a border</p>
+</div>
+```
+
 Divs start with a fence containing at least three consecutive colons plus some attributes. The attributes may optionally be followed by another string of consecutive colons. The Div ends with another line containing a string of at least three consecutive colons. The Div should be separated by blank lines from preceding and following blocks. Divs may also be nested. For example
 
 ``` markdown
@@ -239,11 +247,32 @@ More content.
 :::::
 ```
 
+Once rendered to HTML, Quarto will translate the markdown into:
+
+``` html
+<div id="special" class="sidebar">
+  <div class="warning">
+    <p>Here is a warning.</p>
+</div>
+  <p>More content.</p>
+</div>
+```
+
 Fences without attributes are always closing fences. Unlike with fenced code blocks, the number of colons in the closing fence need not match the number in the opening fence. However, it can be helpful for visual clarity to use fences of different lengths to distinguish nested divs from their parents.
 
 A bracketed sequence of inlines, as one would use to begin a link, will be treated as a `Span` with attributes if it is followed immediately by attributes:
 
-    [This is *some text*]{.class key="val"}
+``` markdown
+[This is *some text*]{.class key="val"}
+```
+
+Once rendered to HTML, Quarto will translate the markdown into:
+
+``` html
+<span class="class" data-key="val">
+  This is <em>some text</em>
+</span>
+```
 
 Typically, you'll use CSS and/or a [Filter](/docs/extensions/filters.qmd) along with Divs and Spans to provide styling or other behavior within rendered documents.
 


### PR DESCRIPTION
After reading the docs, I was still confused about how the markdown-flavoured divs and spans would translate into HTML.

https://quarto.org/docs/authoring/markdown-basics.html#divs-and-spans

After each markdown example, I added what the HTML output would look like. I hope this helps readers understand the div/span markdown syntax more easily.