### PR TITLE
Correcting error in website-basics.qmd

### DIFF
--- a/docs/websites/website-basics.qmd
+++ b/docs/websites/website-basics.qmd
@@ -43,7 +43,7 @@ format:
     toc: true
 ```
 
-This will create the scaffolding for a simple website in the `mysite` sub-directory. To build and view the site use the `preview` command:
+To build and view the site use the `preview` command:
 
 ``` {.bash filename="Terminal"}
 quarto preview mysite


### PR DESCRIPTION
The sentence "This will create the scaffolding for a simple website in the `mysite` sub-directory." was written two times.