### PR TITLE
Add preview links for Journal templates

### DIFF
--- a/docs/journals/index.qmd
+++ b/docs/journals/index.qmd
@@ -20,13 +20,13 @@ A major focus is single-source publishing: the same Quarto document source shoul
 
 The Quarto team has developed several Journal formats and made them available within the [quarto-journals](https://github.com/quarto-journals/) GitHub organization. These formats include:
 
--   [ACM](https://github.com/quarto-journals/acm)
--   [PLOS](https://github.com/quarto-journals/plos)
--   [ASA](https://github.com/quarto-journals/jasa)
--   [Elsevier](https://github.com/quarto-journals/elsevier)
--   [Biophysical](https://github.com/quarto-journals/biophysical-journal)
--   [ACS](https://github.com/quarto-journals/acs)
--   [JSS](https://github.com/quarto-journals/jss)
+-   [ACM](https://github.com/quarto-journals/acm) [(preview)](https://quarto-journals.github.io/acm/)
+-   [PLOS](https://github.com/quarto-journals/plos) [(preview)](https://quarto-journals.github.io/plos/)
+-   [ASA](https://github.com/quarto-journals/jasa) [(preview)](https://quarto-journals.github.io/asa/)
+-   [Elsevier](https://github.com/quarto-journals/elsevier) [(preview)](https://quarto-journals.github.io/elsevier/)
+-   [Biophysical](https://github.com/quarto-journals/biophysical-journal) [(preview)](https://quarto-journals.github.io/biophysical/)
+-   [ACS](https://github.com/quarto-journals/acs) [(preview)](https://quarto-journals.github.io/acs/)
+-   [JSS](https://github.com/quarto-journals/jss) [(preview)](https://quarto-journals.github.io/jss/)
 
 Many more formats will be added over time and we welcome proposals from the community for contributed formats (please post an issue at <https://github.com/quarto-journals/article-format-template/issues> if you are interested in contributing a format).
 


### PR DESCRIPTION
While previews of the different journal templates are already available from their respective repositories, they are much harder to find and compare from within the repositories.

Having the preview links readily available in the docs would be quite beneficial IMO, so I made a quick commit / PR to add them. (I can't properly verify whether all links work atm., since I'm on a limited internet connection, but will try to do so later)