### PR TITLE
Document language-specific alternate text values

### DIFF
--- a/docs/authoring/language.qmd
+++ b/docs/authoring/language.qmd
@@ -65,6 +65,35 @@ language: custom.yml
 
 You can discover all of the `language` values that can be customized by referencing this file: <https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/language/_language.yml>.
 
+### Alternates for Different Document Languages
+
+Alternate values can be restricted to a particular document language using the language tag as subkey. This way, different values can be defined for different languages. For example, you can override the English and French versions of the "Published" caption:
+
+``` yaml
+---
+title: "My Document"
+author: "Norah Jones"
+date: 5/22/2022
+lang: fr
+language:
+  en:
+    title-block-published: "Updated"
+  fr:
+    title-block-published: "Mis à jour"
+---
+```
+
+In this case the French "Mis à jour" will be used since `lang` is set to `fr`.
+
+These language-specific alternate values can also be provided in a standalone YAML file. For example, the following file could be used by setting `language: custom.yml` in the metadata:
+
+``` {.yaml filename="custom.yml"}
+en:
+  title-block-published: "Updated"
+fr:
+  title-block-published: "Mis à jour"
+```
+
 ## Custom Translations
 
 You can create and use a custom translation for a new language not supported by Quarto as follows:


### PR DESCRIPTION
This documents that different alternate text values can be specified for different languages. See https://github.com/quarto-dev/quarto-cli/issues/2812