### PR TITLE
change rmd to qmd

### DIFF
--- a/docs/get-started/hello/rstudio.qmd
+++ b/docs/get-started/hello/rstudio.qmd
@@ -61,7 +61,7 @@ Note that documents can also be rendered from the R console via the **quarto** p
 
 ``` r
 install.packages("quarto")
-quarto::quarto_render("notebook.Rmd")
+quarto::quarto_render("hello.qmd")
 ```
 
 When rendering, Quarto generates a new file that contains selected text, code, and results from the .qmd file.


### PR DESCRIPTION
I would also opt for using the same example qmd also in the `quarto::quarto_render` example.