### PR TITLE
fix: update Bootstrap version to 5.1.3 according to code

### DIFF
--- a/license.qmd
+++ b/license.qmd
@@ -13,8 +13,8 @@ Quarto also makes use of several other open-source projects, the distribution of
 | Project                                                       | License                                                            |
 |---------------------------------------------------------------|--------------------------------------------------------------------|
 | [Pandoc](https://pandoc.org/)                                 | [GNU GPL v2](https://github.com/jgm/pandoc/blob/master/COPYING.md) |
-| [Bootstrap 5.0](https://getbootstrap.com/docs/5.0/)           | [MIT](https://github.com/twbs/bootstrap/blob/v5.0.2/LICENSE)       |
-| [Bootswatch 5.0](https://bootswatch.com/)                     | [MIT](https://github.com/thomaspark/bootswatch/blob/v5/LICENSE)    |
+| [Bootstrap 5.1](https://getbootstrap.com/docs/5.1/)           | [MIT](https://github.com/twbs/bootstrap/blob/v5.1.3/LICENSE)       |
+| [Bootswatch 5.1](https://bootswatch.com/)                     | [MIT](https://github.com/thomaspark/bootswatch/blob/v5/LICENSE)    |
 | [Deno](https://deno.land/)                                    | [MIT](https://github.com/denoland/deno/blob/main/LICENSE.md)       |
 | [esbuild](https://esbuild.github.io/)                         | [MIT](https://github.com/evanw/esbuild/blob/master/LICENSE.md)     |
 | [Dart Sass](https://sass-lang.com/dart-sass)                  | [MIT](https://github.com/sass/dart-sass/blob/main/LICENSE)         |


### PR DESCRIPTION
This PR update the license page to reflect the same version of Boostrap/Bootswatch as internally used by Quarto.