### PR TITLE
Switch to RC Mode

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -447,4 +447,4 @@ editor: visual
 
 profile:
   group: 
-    - [prerelease, rc]
+    - [rc, prerelease]


### PR DESCRIPTION
Switch the website into RC mode, which will promote the pre-release into the 'Get Started' download list and will use the label `Release Candidate` for the pre-release builds.