### PR TITLE
fix: uses `embed-resources` instead of `self-contained`

### DIFF
--- a/docs/presentations/revealjs/presenting.qmd
+++ b/docs/presentations/revealjs/presenting.qmd
@@ -329,7 +329,7 @@ format:
 ```
 
 ::: {.callout-warning appearance="simple"}
-Note that Reveal plugin [Chalkboard] is not compatible with `self-contained` output --- when [Chalkboard] plugin is enabled, specifying `self-contained: true` will result an error.
+Note that Reveal plugin [Chalkboard] is not compatible with `embed-resources` output --- when [Chalkboard] plugin is enabled, specifying `embed-resources: true` will result an error.
 :::
 
 Here are what the notes canvas and chalkboard look like when activated:


### PR DESCRIPTION
This PR fix the last file where `self-contained` was still mentionned (inside a callout).
See <https://quarto.org/docs/presentations/revealjs/presenting.html#chalkboard>.

With this PR, #422 can be closed I think.

To note, there is one file in `_freeze` still mentionning the deprecated option: <https://github.com/quarto-dev/quarto-web/tree/main/_freeze/site_libs/revealjs/plugin/reveal-chalkboard/plugin.yml>