### PR TITLE
docs: add shinylive filter in the extension listing

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -113,3 +113,9 @@
   description: |
     Filter that provides global options to make the [`Callout Blocks`](https://quarto.org/docs/authoring/callouts.html)
     [`collapsible`](https://quarto.org/docs/authoring/callouts.html#collapse) in HTML documents.
+
+- name: shinylive
+  path: https://github.com/quarto-ext/shinylive
+  author: "[quarto-ext](https://github.com/quarto-ext)"
+  description: |
+    This extension lets you embed [Shinylive](https://shiny.rstudio.com/py/docs/shinylive.html) applications in a Quarto document.


### PR DESCRIPTION
This PR adds the `shinylive` Quarto extension to the extension listing page on Quarto website.

This PR echoes to the recent published blog post.