### PR TITLE
Update libraries.qmd

### DIFF
--- a/docs/interactive/ojs/libraries.qmd
+++ b/docs/interactive/ojs/libraries.qmd
@@ -47,7 +47,7 @@ You can find complete documentation for all of the inputs at <https://github.com
 
 Observable Plot is a JavaScript library for exploratory data visualization. Plot is built upon a set of core concepts ([Marks](https://observablehq.com/@observablehq/plot-marks), [Scales](https://observablehq.com/@observablehq/plot-scales), [Transforms](https://observablehq.com/@observablehq/plot-transforms), and [Facets](https://observablehq.com/@observablehq/plot-facets)) that can be composed together to create custom visualizations.
 
-Here's an example of a scatterplot of the height and weight of Olympic athletes created with Plot:
+Here's an example of a histogram of the weight of Olympic athletes created with Plot:
 
 ```{ojs}
 athletes = FileAttachment("athletes.csv").csv({typed: true})


### PR DESCRIPTION
description of plot is misidentified as a _scatterplot of height and weight_.  The actual example is a _histogram of weight_.