### PR TITLE
typo

### DIFF
--- a/docs/authoring/callouts.qmd
+++ b/docs/authoring/callouts.qmd
@@ -48,18 +48,18 @@ This is an example of a 'collapsed' caution callout that can be expanded by the 
 Create callouts in markdown using the following syntax (note that the first markdown heading used within the callout is used as the callout heading):
 
 ``` markdown
-:::{.callout-note}
+::: {.callout-note}
 Note that there are five types of callouts, including:
 `note`, `warning`, `important`, `tip`, and `caution`.
 :::
 
-:::{.callout-tip}
+::: {.callout-tip}
 ## Tip With Caption
 
 This is an example of a callout with a caption.
 :::
 
-:::{.callout-caution collapse="true"}
+::: {.callout-caution collapse="true"}
 ## Expand To Learn About Collapse
 
 This is an example of a 'folded' caution callout that can be expanded by the user. You can use `collapse="true"` to collapse it by default or `collapse="false"` to make a collapsible callout that is expanded by default.


### PR DESCRIPTION
Add space between `...` and `{.callout}` for consistency