### PR TITLE
Including my website in the gallery.

### DIFF
--- a/docs/gallery/gallery.yml
+++ b/docs/gallery/gallery.yml
@@ -135,6 +135,12 @@
       href: https://www.mm218.dev/
       code: https://github.com/mikemahoney218/mm218.dev
       thumbnail: websites/websites-mike-mahoney.png
+    - title: ForBo7 // Salman Naqvi
+      subtitle: personal website + blog + portfolio
+      href: https://forbo7.github.io
+      code: https://github.com/ForBo7/forbo7.github.io
+      # Thumbnail is in my code, which is linked above. It's in the root directory.
+      thumbnail: cover.png
     - title: LTM Data Workflows w/ Arrow
       subtitle: workshop
       href: https://arrow-user2022.netlify.app/


### PR DESCRIPTION
My website makes use of many different Quarto features, and as such, can show what Quarto is capable of. For example, the landing page includes a dynamic dual listing in conjunction with an about me template — this was achieved through using CSS grids. My website also features two pages that have their own listings, one which showcases the default listing style and the other showcasing the grid style. Tabsets are used in my about me page, reducing clutter. Lots of other Quarto features are sprinkled around the site, from page layouts to margin headers to figure layouts to embeds and more!

I also plan to update the website and make more use of Quarto extensions, such as the scroll-to-the-top button, text animations, and image lightboxes — the latter for when I shift my 3D CG works to the site.

My website 👉 https://forbo7.github.io