### PR TITLE
fix: typo in callout example

### DIFF
--- a/docs/authoring/callouts.qmd
+++ b/docs/authoring/callouts.qmd
@@ -105,7 +105,7 @@ which appears as:
 ::: {.callout-note appearance="simple"}
 ## Pay Attention
 
-Using callouts is an effect way to highlight content that your reader give special consideration or attention.
+Using callouts is an effective way to highlight content that your reader give special consideration or attention.
 :::
 
 ### Icons


### PR DESCRIPTION
This PR fixes a typo in a callout example.