### PR TITLE
add extension: code-insertion.

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -3,7 +3,7 @@
   author: "[quarto-ext](https://github.com/quarto-ext)"
   description: |
     Create [lightbox](https://biati-digital.github.io/glightbox/) treatments for images in your HTML documents.
-  
+
 - name: molstar
   path: https://github.com/jmbuhr/quarto-molstar
   author: "[jmbuhr](https://github.com/jmbuhr)"
@@ -14,26 +14,26 @@
   path: https://github.com/quarto-ext/shinylive
   author: "[quarto-ext](https://github.com/quarto-ext)"
   description: |
-    This extension lets you embed [Shinylive](https://shiny.rstudio.com/py/docs/shinylive.html) applications in a Quarto document.  
-  
+    This extension lets you embed [Shinylive](https://shiny.rstudio.com/py/docs/shinylive.html) applications in a Quarto document.
+
 - name: abstract-section
   path: https://github.com/pandoc-ext/abstract-section
   author: "[pandoc-ext](https://github.com/pandoc-ext/abstract-section)"
   description: |
     Write an article abstract in a normal section, not the YAML metadata.
-  
+
 - name: social-share
   path: https://github.com/schochastics/quarto-social-share
   author: "[schochastics](https://github.com/schochastics)"
   description: |
     Add buttons to share articles on various social media platforms.
-  
+
 - name: social-embeds
   path: https://github.com/sellorm/quarto-social-embeds
   author: "[sellorm](https://github.com/sellorm)"
   description: |
     Embed content from across the web into HTML documents using a shortcode.
-  
+
 - name: fontawesome
   path: https://github.com/quarto-ext/fontawesome
   author: "[quarto-ext](https://github.com/quarto-ext)"
@@ -57,7 +57,7 @@
   author: "[mcanouil](https://github.com/mcanouil)"
   description: |
     Use [Iconify](https://icon-sets.iconify.design/) icons in HTML documents.
-    
+
 - name: lordicon
   path: https://github.com/jmgirard/lordicon
   author: "[jmgirard](https://github.com/jmgirard)"
@@ -80,7 +80,7 @@
   path: https://github.com/quarto-ext/fancy-text
   author: "[quarto-ext](https://github.com/quarto-ext)"
   description: |
-    Output nicely formatted versions of fancy strings such as LaTeX and BibTeX 
+    Output nicely formatted versions of fancy strings such as LaTeX and BibTeX
     in multiple formats.
 
 - name: animate
@@ -88,7 +88,7 @@
   author: "[mcanouil](https://github.com/mcanouil)"
   description: |
     Shortcode for animating text using [Animate.css](https://animate.style/).
-    
+
 - name: qrcode
   path: https://github.com/jmbuhr/quarto-qrcode
   author: "[jmbuhr](https://github.com/jmbuhr)"
@@ -100,13 +100,13 @@
   author: "[mcanouil](https://github.com/mcanouil)"
   description: |
     Shortcode for using [Elevator.js](https://tholman.com/elevator.js/) in HTML documents.
-    
+
 - name: nutshell
   path: https://github.com/schochastics/quarto-nutshell
   author: "[schochastics](https://github.com/schochastics)"
   description: |
     Embed [Nutshell](https://ncase.me/nutshell/) expandable explanations in HTML documents.
-    
+
 - name: code-visibility
   path: https://github.com/jjallaire/code-visibility
   author: "[jjallaire](https://github.com/jjallaire)"
@@ -119,10 +119,15 @@
   description: |
     Filter that provides global options to make the [`Callout Blocks`](https://quarto.org/docs/authoring/callouts.html)
     [`collapsible`](https://quarto.org/docs/authoring/callouts.html#collapse) in HTML documents
-    
+
 - name: forms
   path: https://github.com/jlgraves-ubc/forms
   author: "[Jonathan Graves](https://github.com/jlgraves-ubc)"
   description: |
     Embed flexible [HTML forms](https://www.w3schools.com/html/html_forms.asp) in documents.
 
+- name: code-insertion
+  path: https://github.com/feynlee/code-insertion
+  author: "[Ziyue Li](https://github.com/feynlee)"
+  description: |
+    Add markdown/html code immediately before and/or after a post.


### PR DESCRIPTION
Add extension `code-insertion` to add markdown/html code immediately before or after the post.