### PR TITLE
Fix broken source links in gallery for interactive docs

### DIFF
--- a/docs/gallery/gallery.yml
+++ b/docs/gallery/gallery.yml
@@ -82,17 +82,17 @@
     - title: Observable
       subtitle: reactive JavaScript
       href: ../interactive/ojs/examples/penguins.html
-      code: https://github.com/quarto-dev/quarto-web/blob/gallery/docs/interactive/ojs/examples/penguins.qmd
+      code: https://github.com/quarto-dev/quarto-web/blob/main/docs/interactive/ojs/examples/penguins.qmd
       thumbnail: interactive/interactive-ojs.png
     - title: Shiny
       subtitle: web framework for R
       href: https://jjallaire.shinyapps.io/diamonds-explorer/
-      code: https://github.com/quarto-dev/quarto-web/blob/gallery/docs/interactive/shiny/_examples/diamonds/diamonds.qmd
+      code: https://github.com/quarto-dev/quarto-web/blob/main/docs/interactive/shiny/_examples/diamonds/shiny-diamonds.qmd
       thumbnail: interactive/interactive-shiny.png
     - title: Jupyter 
       subtitle: interactive widgets
       href: ../interactive/widgets/jupyter.html
-      code: https://github.com/quarto-dev/quarto-web/blob/gallery/docs/interactive/widgets/jupyter.qmd
+      code: https://github.com/quarto-dev/quarto-web/blob/main/docs/interactive/widgets/jupyter.qmd
       thumbnail: interactive/interactive-jupyter.png
   
   


### PR DESCRIPTION
Link rot at https://quarto.org/docs/gallery/#interactive-docs