### PR TITLE
documentation: use fig-alt instead of fig-cap for Multiple plot examples

### DIFF
--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -59,14 +59,14 @@ There are many options which control the behavior of code execution and output, 
 
 ### Multiple Outputs
 
-By default Julia cells will automatically print the value of their last statement (as with the example above where the call to `plot()` resulted in plot output). If you want to display multiple plots (or other types of output) from a single cell you should call the `display()` function explicitly. For example, here we output two plots side-by-side with sub-captions:
+By default Julia cells will automatically print the value of their last statement (as with the example above where the call to `plot()` resulted in plot output). If you want to display multiple plots (or other types of output) from a single cell you should call the `display()` function explicitly. For example, here we output two plots side-by-side with alt text:
 
 ``` {{julia}}
 #| label: fig-plots
 #| fig-cap: Multiple Plots
-#| fig-subcap:
-#|   - "Plot 1"
-#|   - "Plot 2"
+#| fig-alt:
+#|   - "A blue arc labelled as y1 that starts at 0,0 and ends at 0.9,-0.75"
+#|   - "A blue curve labelled as y1 twisted like a pretzel"
 #| layout-ncol: 2
 
 using Plots


### PR DESCRIPTION
I would suggest using `fig-alt` as an example for demonstrating Multiple Outputs as a more practical (albeit less visible for sighted users) and instructive alternative to `fig-cap`.

By showing it prominently in the docs, the practice of including accessible alt text will be more normalised. My attempts are here, but feel free to provide a better description if you are better at describing curves than I am.