### PR TITLE
gfm-strip-disallowed

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -131,3 +131,9 @@
   author: "[Ziyue Li](https://github.com/feynlee)"
   description: |
     Add markdown/html code immediately before and/or after a post.
+
+- name: gfm-strip-disallowed
+  path: https://github.com/restlessronin/gfm-strip-disallowed
+  author: "[restlessronin](https://github.com/restlessronin)"
+  description: |
+    Remove raw HTML blocks (such as '<style>') that are disallowed by GFM.


### PR DESCRIPTION
I created this extension to solve a problem I was having with the `README.md` generated by the `index.ipynb` file of an `nbdev` project. It seemed like the kind of thing a lot of people might see, but I couldn't find any answers.