### PR TITLE
fix typo

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -136,4 +136,4 @@
   path: https://github.com/restlessronin/gfm-strip-disallowed
   author: "[restlessronin](https://github.com/restlessronin)"
   description: |
-    Remove raw HTML blocks (such as '<style>') that are disallowed by GFM.
+    Remove raw HTML blocks (such as '&lt;style&gt;') that are disallowed by GFM.


### PR DESCRIPTION
I made a mistake and left '<' and '>' in the description text, and it's apparently not uuencoded automatically. fixed by replacing it with &lt; and &gt;