### PR TITLE
Instructions to create an empty gh-pages branch

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -64,9 +64,20 @@ The `quarto publish` command is an easy way to publish locally rendered document
 
 ### Source Branch {#source-branch}
 
-Before attempting to publish you should ensure that the **Source** branch for your repository is `gh-pages` and that the site directory is set to the repository root (`/`). You can modify these options in **Settings** : **Pages** for your repository. For example:
+Before attempting to publish you should ensure that the **Source** branch for your repository is `gh-pages` and that the site directory is set to the repository root (`/`). You can modify these options in **Settings** : **Pages** for your repository. For example, if you already have a `gh-pages` branch:
 
 ![](images/gh-pages-user-site.png){.border}
+
+If you do not already have a `gh-pages` branch, you can create one as follows. First, make sure you have commited all changes to your current working branch with `git status`. Then:
+
+``` {.bash filename="Terminal"}
+git checkout --orphan gh-pages
+git reset --hard
+git commit --allow-empty -m "Initialising gh-pages branch"
+git push origin gh-pages
+```
+
+Double-check that the last `git push` action has indeed set the **Settings** : **Pages** for your repository as expected in the previous figure. Get back to your original repository branch with, for example, `git checkout main`.
 
 ### Ignoring Output {#ignoring-output}
 


### PR DESCRIPTION
While migrating [this documentation repository](https://github.com/csiro-hydroinformatics/streamflow-forecasting-tools-onboard/) to use Quarto, I am bumping into a bit of a slightly confusing step in the `Publish Command` section. Instructions state that:

> Before attempting to publish you should ensure that the **Source** branch for your repository is `gh-pages`

but typically a repository would not have a pre-existing `gh-pages` branch.

I submit a few command lines to set up an empty stub `gh-pages` branch.