### PR TITLE
added entry for line-highlight filter in shortcodes-and-filters yml

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -137,3 +137,11 @@
   author: "[restlessronin](https://github.com/restlessronin)"
   description: |
     Remove raw HTML blocks (such as '&lt;style&gt;') that are disallowed by GFM.
+
+- name: line-highlight
+  path: https://github.com/shafayetShafee/line-highlight
+  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  description: |
+    Filter to enable source code and output line highlighting 
+    for HTML documents (`format: html`) similar as how 
+    [`code-line-numbers`](https://quarto.org/docs/reference/formats/html.html#code) works for RevealJs output.


### PR DESCRIPTION
I have created a quarto filter [`line-highlight`](https://github.com/shafayetShafee/line-highlight) to enable source code and output line highlighting for HTML documents (`format: html`) similar to how [`code-line-numbers`](https://quarto.org/docs/reference/formats/html.html#code) works for RevealJs output, which I would like to see added to the quarto extension list. Thanks 😊