### PR TITLE
fix: displaying of mutiple authors

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -140,7 +140,7 @@
 
 - name: authors-block
   path: https://github.com/kapsner/authors-block
-  authors:
+  author:
     - "[Lorenz A. Kapsner](https://github.com/kapsner)"
     - "[Albert Krewinkel](https://github.com/tarleb)"
     - "[Robert Winkler](https://github.com/robert-winkler)"


### PR DESCRIPTION
Currently, mutiple authors of an extension specified with the yml field "authors" are not shown on the HTML page with the listed quarto extensions. This PR indends to fix the displaying of muliple authors shown in the table that lists quarto extensions. (However, not sure if it really does so.)