### PR TITLE
[tables.qmd] added a tool for grid tables

### DIFF
--- a/docs/authoring/tables.qmd
+++ b/docs/authoring/tables.qmd
@@ -255,3 +255,5 @@ Note that grid tables are quite awkward to write with a plain text editor (becau
 -   Emacs' [table-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Text-Based-Tables.html) (`M-x table-insert`)
 
 -   Quarto [Visual Editor](https://quarto.org/docs/visual-editor/content.html#editing-tables)
+
+-   Tables Generator's [Plain Text mode](https://www.tablesgenerator.com/text_tables) with `Use reStructuredText syntax` enabled


### PR DESCRIPTION
Added the Tables Generator's Plain Text mode to the grid table tools list.
Additionally, to get the header styling, the option `Use reStructuredText syntax` inside the tool below the result needs to be checked.

I've tested it and it works fine!