### PR TITLE
reference template partials

### DIFF
--- a/docs/authoring/title-blocks.qmd
+++ b/docs/authoring/title-blocks.qmd
@@ -90,3 +90,7 @@ The labels for the metadata included in the title block have default values that
 | `description-title` | Description    | `plain`, `default`         |
 | `published-title`   | Date Published | `plain`, `default`         |
 | `doi-title`         | DOI            | `plain`, `default`         |
+
+## Custom Titlepage
+
+To change the title block or page, see the Quarto [template partials](https://quarto.org/docs/journals/templates.html#template-partials).


### PR DESCRIPTION
When searching for example for "quarto custom title page" I get the title blocks page, which explains on how to customize the blocks. I think a guide or reference on how to change specific parts of a document, one of it being the title page/block could be useful for others.

Any thoughts on it?