### PR TITLE
Removing duplicate entries

### DIFF
--- a/docs/reference/projects/book.json
+++ b/docs/reference/projects/book.json
@@ -57,11 +57,7 @@
   },
   {
     "name": "doi",
-    "description": "The Digital Object Identifier for this book."
-  },
-  {
-    "name": "abstract",
-    "description": "Abstract of the item (e.g. the abstract of a journal article)"
+    "description": "Digital Object Identifier of the book (e.g. \"10.1128/AEM.02591-07\")"
   },
   {
     "name": "abstract-url",
@@ -90,10 +86,6 @@
   {
     "name": "archive-place",
     "description": "Geographic location of the archive."
-  },
-  {
-    "name": "author",
-    "description": "The author(s) of the item."
   },
   {
     "name": "authority",
@@ -170,10 +162,6 @@
   {
     "name": "division",
     "description": "Minor subdivision of a court with a `jurisdiction` for a legal item"
-  },
-  {
-    "name": "doi",
-    "description": "Digital Object Identifier (e.g. \"10.1128/AEM.02591-07\")"
   },
   {
     "name": "edition",
@@ -376,10 +364,6 @@
     "description": "Recipient (e.g. of a letter)."
   },
   {
-    "name": "references",
-    "description": "Resources related to the procedural history of a legal case or legislation;\n\nCan also be used to refer to the procedural history of other items (e.g. \n\"Conference canceled\" for a presentation accepted as a conference that was subsequently \ncanceled; details of a retraction or correction notice)\n"
-  },
-  {
     "name": "reviewed-author",
     "description": "Author of the item reviewed by the current item."
   },
@@ -424,10 +408,6 @@
     "description": "Supplement number of the item or container holding the item (e.g. for secondary legal items that are regularly updated between editions)."
   },
   {
-    "name": "title",
-    "description": "The primary title of the item."
-  },
-  {
     "name": "translator",
     "description": "Translator"
   },
@@ -454,10 +434,6 @@
   {
     "name": "year-suffix",
     "description": "Disambiguating year suffix in author-date styles (e.g. \"a\" in \"Doe, 1999a\")."
-  },
-  {
-    "name": "description",
-    "description": "Website description"
   },
   {
     "name": "favicon",


### PR DESCRIPTION
Some entries were duplicated, and in one case ('references') it had a second definition that did not correspond to the use.

This PR will fix issue #566.