### PR TITLE
Emphasize the `sec-` prefix similar to tbl

### DIFF
--- a/docs/books/book-crossrefs.qmd
+++ b/docs/books/book-crossrefs.qmd
@@ -22,11 +22,18 @@ See @fig-penginus-by-island for a breakdown by island.
 
 References made this way will be automatically resolved across chapters (including the requisite chapter number in the reference).
 
-To make a chapter or section reference-able, you add a `#sec` id to its main heading. For example:
+To make a chapter or section reference-able, you add a `#sec` prefix to its main heading. For example:
 
 ``` markdown
 # Introduction {#sec-introduction}
 ```
+
+::: callout-important
+## Label Prefix
+
+In order for a chapter to be cross-referenceable, its label must start with the `sec-` prefix.
+:::
+
 
 To refer to a section, include a cross-reference to it using an `@` identifier as we did above in the figure example:
 


### PR DESCRIPTION
This adds a callout inside of the book section of cross references to emphasize the specific label prefix for referring to sections in a manner that is similar to the `table` subsection of cross references:

https://quarto.org/docs/authoring/cross-references.html#tables
