### PR TITLE
Update publish.yml example.

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -146,7 +146,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
Updated the `publish.yml` GitHub Action example to use the new `actions/checkout@v3`. This resolves quarto-dev/quarto-web#569