### PR TITLE
Added guide on how to enable snippets suggestion

### DIFF
--- a/docs/tools/vscode.qmd
+++ b/docs/tools/vscode.qmd
@@ -143,6 +143,14 @@ Code snippets are templates that make it easier to enter repeating code patterns
 
 ![](images/vscode-snippets.png){.border fig-alt="Quarto document with dropdown 'Select a snippet' dropdown, the first item (bold - insert bold text) is selected."}
 
+### IntelliSense
+
+VSCode uses IntelliSense to suggest snippets or possible values for a specific function while typing. This is turned off by default for snippets, but not for values. To enable snippet suggestions in IntelliSense while typing or when selecting a text snippet and pressing `ctrl+space`, the setting `editor.snippetSuggestions` needs to be set to a value other than `none` (for example to `inline`).
+
+- Press `F1` and search for `Preferences: Open Settings (UI)` or `File` > `Preferences` > `Settings`
+- Search for following term `@lang:quarto editor.snippetSuggestions`. `Editor: Snippet Suggestions` should show up.
+- Change value to a not-`none` value.
+
 ## Document Navigation
 
 If you have a large document use the outline view for quick navigation between sections:


### PR DESCRIPTION
I was looking for a way to enable snippet suggestions in `qmd` files and found a stackoverflow post that explained it. I can't find it anymore though, but I'd like to add a quick guide on how to enable it. Also it seems that the Quarto extension overrides the default setting.