### PR TITLE
Adds `pandas` to `computations.qmd` tutorial

### DIFF
--- a/docs/get-started/computations/text-editor.qmd
+++ b/docs/get-started/computations/text-editor.qmd
@@ -17,13 +17,13 @@ In this tutorial we'll take a `.qmd` file that has some numeric output and plots
 This tutorial will make use of the `matplotlib` and `plotly` Python packages.
 The commands you can use to install them are given in the table below.
 
-+-------------+------------------------------------------------------+
-| Platform    | Commands                                             |
-+=============+======================================================+
-| Mac/Linux   |     python3 -m pip install jupyter matplotlib plotly |
-+-------------+------------------------------------------------------+
-| Windows     |     py -m pip install jupyter matplotlib plotly      |
-+-------------+------------------------------------------------------+
++-------------+-------------------------------------------------------------+
+| Platform    | Commands                                                    |
++=============+=============================================================+
+| Mac/Linux   |     python3 -m pip install jupyter matplotlib plotly pandas |
++-------------+-------------------------------------------------------------+
+| Windows     |     py -m pip install jupyter matplotlib plotly pandas      |
++-------------+-------------------------------------------------------------+
 
 If you want to follow along step-by-step in your own environment, create a `computations.qmd` file and copy the following content into it.
 


### PR DESCRIPTION
At least on Ubuntu 22.04 with Python 3.11.1, `computations.qmd` otherwise errs with:

```
$ quarto preview computations.qmd

Starting python3 kernel...Done

Executing 'computations.ipynb'
  Cell 1/3...Done
  Cell 2/3...Done
  Cell 3/3...ERROR: 

An error occurred while executing the following cell:
------------------
import plotly.express as px
import plotly.io as pio
gapminder = px.data.gapminder()
gapminder2007 = gapminder.query("year == 2007")
fig = px.scatter(gapminder2007, 
                 x="gdpPercap", y="lifeExp", color="continent", 
                 size="pop", size_max=60,
                 hover_name="country")
fig.show()
------------------

---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[3], line 1
----> 1 import plotly.express as px
      2 import plotly.io as pio
      3 gapminder = px.data.gapminder()

File ~/.local/lib/python3.11/site-packages/plotly/express/__init__.py:10
      8 pd = optional_imports.get_module("pandas")
      9 if pd is None:
---> 10     raise ImportError(
     11         """\
     12 Plotly express requires pandas to be installed."""
     13     )
     15 from ._imshow import imshow
     16 from ._chart_types import (  # noqa: F401
     17     scatter,
     18     scatter_3d,
   (...)
     51     density_mapbox,
     52 )

ImportError: Plotly express requires pandas to be installed.
ImportError: Plotly express requires pandas to be installed.
```

In case helpful!