### PR TITLE
Changed execute: key to format:html: in Code Folding examples

### DIFF
--- a/docs/get-started/computations/text-editor.qmd
+++ b/docs/get-started/computations/text-editor.qmd
@@ -139,8 +139,9 @@ Remove the `echo` option we previously added and add the `code-fold` HTML format
 ``` yaml
 ---
 title: Quarto Computations
-execute:
-   code-fold: true
+format:
+  html:
+    code-fold: true
 jupyter: python3
 ---
 ```
@@ -156,7 +157,8 @@ Try adding `code-tools: true` to the HTML format options.
 ``` yaml
 ---
 title: Quarto Computations
-execute:
+format:
+  html:
    code-fold: true
    code-tools: true
 jupyter: python3


### PR DESCRIPTION
As best I can tell, `code-fold` and `code-tools` _seem_ to belong under `format:html:` instead of `execute:`?