### PR TITLE
added two filters for revealjs in revealjs listings

### DIFF
--- a/docs/extensions/listings/revealjs.yml
+++ b/docs/extensions/listings/revealjs.yml
@@ -33,4 +33,19 @@
   path: https://github.com/ArthurData/quarto-confetti
   author: "[ArthurData](https://github.com/ArthurData)"
   description:
-    Add some fun and send confetti into your presentation. 
+    Add some fun and send confetti into your presentation.
+
+- name: reveal-header
+  path: https://github.com/shafayetShafee/reveal-header
+  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  description: |
+    Filter that provides options to add a header text and header logo
+    in top-left corner of the RevealJs slides.
+
+- name: style-speaker-note
+  path: https://github.com/shafayetShafee/style-speaker-note
+  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  description: |
+    Filter that allows to style the Speaker Notes of the RevealJs slides 
+    from a CSS file.
+

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -54,7 +54,7 @@
 
 - name: bsicons
   path: https://github.com/shafayetShafee/bsicons
-  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
   description: |
       Use [Bootstrap Icons](https://icons.getbootstrap.com/) in HTML documents.
 
@@ -121,7 +121,7 @@
 
 - name: collapse-callout
   path: https://github.com/shafayetShafee/collapse-callout
-  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
   description: |
     Filter that provides global options to make the [`Callout Blocks`](https://quarto.org/docs/authoring/callouts.html)
     [`collapsible`](https://quarto.org/docs/authoring/callouts.html#collapse) in HTML documents
@@ -146,11 +146,11 @@
 
 - name: line-highlight
   path: https://github.com/shafayetShafee/line-highlight
-  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
   description: |
     Filter to enable source code and output line highlighting 
     for HTML documents (`format: html`) similar as how 
-    [`code-line-numbers`](https://quarto.org/docs/reference/formats/html.html#code) works for RevealJs output.
+    [`code-line-numbers`](https://quarto.org/docs/reference/formats/html.html#code) works for RevealJs.
 
 - name: authors-block
   path: https://github.com/kapsner/authors-block
@@ -160,3 +160,17 @@
     - "[Robert Winkler](https://github.com/robert-winkler)"
   description: |
      Add author-related header block when rendering docx-documents.
+
+- name: collapse-social-embeds
+  path: https://github.com/shafayetShafee/collapse-social-embeds
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
+  description: |
+    Filter to create collapsible callouts with [`social-embeds`](https://github.com/sellorm/quarto-social-embeds)
+    for HTML format.
+
+- name: nameref
+  path: https://github.com/shafayetShafee/nameref
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
+  description: |
+    Filter that allows to refer a section/image/table using a name for both pdf and
+    HTML format.


### PR DESCRIPTION
I have made two filters for revealjs output format, [`reveal-header`](https://github.com/shafayetShafee/reveal-header) and [`style-speaker-note`](https://github.com/shafayetShafee/style-speaker-note), and added these two in the revealjs.yml listings. I have actually made these filters by extending the idea of the answers (answered by me) to the following questions in Stackoverflow,

- https://stackoverflow.com/questions/74616971/quarto-revealjs-header-on-all-slides
- https://stackoverflow.com/questions/75213819/how-to-change-the-default-font-size-in-quarto-speaker-notes/
- https://stackoverflow.com/questions/74060565/adding-a-logo-at-top-left-corner-for-all-slides-in-quarto-presentation/