### PR TITLE
Update filename of category feeds

### DIFF
--- a/docs/websites/website-blog.qmd
+++ b/docs/websites/website-blog.qmd
@@ -321,7 +321,7 @@ listing:
 ---
 ```
 
-This will create an `index.xml` file with the RSS feed for the listing, but also create an `index_news.xml` and `index_posts.xml` file with RSS feeds for the respective categories.
+This will create an `index.xml` file with the RSS feed for the listing, but also create an `index-news.xml` and `index-posts.xml` file with RSS feeds for the respective categories.
 
 ## Publishing
 


### PR DESCRIPTION
Small change to reflect that category feeds appear to use kebab-case rather than snake case (at least for me with quarto version `1.2.335`).