### PR TITLE
Add a helpful warning about mermaid / pdf docs

### DIFF
--- a/docs/authoring/diagrams.qmd
+++ b/docs/authoring/diagrams.qmd
@@ -6,6 +6,10 @@ title: "Diagrams"
 
 Quarto has native support for embedding [Mermaid](https://mermaid-js.github.io/mermaid/#/) and [Graphviz](https://graphviz.org/) diagrams. This enables you to create flowcharts, sequence diagrams, state diagrams, gantt charts, and more using a plain text syntax inspired by markdown.
 
+::: {.callout-important}
+ An [issue with quarto and puppeteer](https://github.com/quarto-dev/quarto-cli/issues/3809) means that Mermaid and Graphviz diagrams cannot be included in PDFs for the time being.
+ :::
+
 For example, here we embed a flowchart created using Mermaid:
 
 ```{mermaid}


### PR DESCRIPTION
Idea is to save people from writing extensive mermaid diagrams only to realize they cannot be included in their PDF document.