### PR TITLE
Regenerate docx reference to remove code-line-numbers as an option

### DIFF
--- a/docs/reference/formats/docx.json
+++ b/docs/reference/formats/docx.json
@@ -90,10 +90,6 @@
     "title": "Code",
     "options": [
       {
-        "name": "code-line-numbers",
-        "description": "Include line numbers in code block output (`true` or `false`).\n\nFor revealjs output only, you can also specify a string to highlight\nspecific lines (and/or animate between sets of highlighted lines).\n\n* Sets of lines are denoted with commas:\n  * `3,4,5`\n  * `1,10,12`\n* Ranges can be denoted with dashes and combined with commas:\n  * `1-3,5` \n  * `5-10,12,14`\n* Finally, animation steps are separated by `|`:\n  * `1-3|1-3,5` first shows `1-3`, then `1-3,5`\n  * `|5|5-10,12` first shows no numbering, then 5, then lines 5-10\n    and 12\n"
-      },
-      {
         "name": "highlight-style",
         "description": "Specifies the coloring style to be used in highlighted source code.\n\nInstead of a *STYLE* name, a JSON file with extension\n` .theme` may be supplied.  This will be parsed as a KDE\nsyntax highlighting theme and (if valid) used as the\nhighlighting style.\n"
       },


### PR DESCRIPTION
Regenerate Reference section based on change to schema (https://github.com/quarto-dev/quarto-cli/pull/4268). Fixes #608