### PR TITLE
Fix quotes for title-delim

### DIFF
--- a/docs/authoring/cross-references.qmd
+++ b/docs/authoring/cross-references.qmd
@@ -406,7 +406,7 @@ title: "My Document"
 crossref:
   fig-title: Fig     # (default is "Figure")
   tbl-title: Tbl     # (default is "Table")
-  title-delim: —     # (default is ":")
+  title-delim: "—"   # (default is ":")
 ---
 ```
 


### PR DESCRIPTION
This doesn't seem to work

```
---
crossref:
  title-delim: -
---
```

but this does

```
---
crossref:
  title-delim: "-"
---
```