### PR TITLE
RStudio -> Posit

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -27,7 +27,7 @@ website:
   page-footer:
     left: |
       Proudly supported by
-      [![](https://www.rstudio.com/wp-content/uploads/2018/10/RStudio-Logo-flat.svg){fig-alt="RStudio" width=65px}](https://www.rstudio.com)
+      [![](https://www.rstudio.com/assets/img/posit-logo-fullcolor-TM.svg){fig-alt="Posit" width=65px}](https://posit.co)
     center:
       - text: "About"
         href: about.qmd

--- a/about.qmd
+++ b/about.qmd
@@ -25,7 +25,7 @@ At the core of Quarto is [Pandoc](https://pandoc.org), a powerful and flexible d
 
 3.  A project system for rendering groups of documents at once, sharing options across documents, and producing aggregate output like [websites](docs/websites/website-basics.qmd) and [books](docs/books/book-basics.qmd).
 
-Development of Quarto is sponsored by [RStudio, PBC](https://www.rstudio.com), where we previously created a similar system ([R Markdown](https://rmarkdown.rstudio.com/)) that shared the same goals, but was targeted principally at users of the R language. The same core team works on both Quarto and R Markdown:
+Development of Quarto is sponsored by [Posit, PBC](https://www.posit.co), where we previously created a similar system ([R Markdown](https://rmarkdown.rstudio.com/)) that shared the same goals, but was targeted principally at users of the R language. The same core team works on both Quarto and R Markdown:
 
 -   J.J. Allaire ([\@jjallaire](https://github.com/jjallaire/))
 -   Christophe Dervieux ([\@cderv](https://github.com/cderv))
@@ -35,7 +35,7 @@ Development of Quarto is sponsored by [RStudio, PBC](https://www.rstudio.com), w
 
 With Quarto, we are hoping to bring these tools to a much wider audience.
 
-Quarto is a registered trademark of RStudio. Please see our [trademark policy](trademark.qmd) for guidelines on usage of the Quarto trademark.
+Quarto is a registered trademark of Posit. Please see our [trademark policy](trademark.qmd) for guidelines on usage of the Quarto trademark.
 
 ## Contribute
 

--- a/docs/faq/index.qmd
+++ b/docs/faq/index.qmd
@@ -44,27 +44,27 @@ Yes! The copyright on Quarto does not cover the content that you generate using 
 
 ### How can I share documents and have people comment on them?
 
-You can publish Quarto content to various locations. See the user guides for [publishing](https://quarto.org/docs/publishing/) for details on using Quarto Pub, GitHub Pages, Netlify, RStudio Connect, and other services with Quarto. Once documents are published you can use  [hypothes.is](https://web.hypothes.is/), [Utterances](https://utteranc.es/), or [Giscus](https://giscus.app/) for commenting. Learn more in the documentation on [commenting](https://quarto.org/docs/output-formats/html-basics.html#commenting).
+You can publish Quarto content to various locations. See the user guides for [publishing](https://quarto.org/docs/publishing/) for details on using Quarto Pub, GitHub Pages, Netlify, Posit Connect, and other services with Quarto. Once documents are published you can use  [hypothes.is](https://web.hypothes.is/), [Utterances](https://utteranc.es/), or [Giscus](https://giscus.app/) for commenting. Learn more in the documentation on [commenting](https://quarto.org/docs/output-formats/html-basics.html#commenting).
 
 ### Can I do collaborative editing with Quarto?
 
 There is not yet anything specific for collaborative editing in Quarto. You can collaborate on .qmd files in the same way you currently do for any text or code files. 
 
-RStudio Workbench allows for [Project Sharing](https://support.rstudio.com/hc/en-us/articles/211659737-Sharing-Projects-in-RStudio-Workbench-RStudio-Server-Pro) for interactive editing and collaboration on the same document.
+Posit Workbench allows for [Project Sharing](https://support.rstudio.com/hc/en-us/articles/211659737-Sharing-Projects-in-RStudio-Workbench-RStudio-Server-Pro) for interactive editing and collaboration on the same document.
 
 ### Where can I publish Quarto websites?
 
 There are a wide variety of ways to publish Quarto websites. Website content is by default written to the `\_site` sub-directory (you can customize this using the output-dir option). Publishing is simply a matter of copying the output directory to a web server or web hosting service.
 
-The [publishing documentation](https://quarto.org/docs/publishing/other.html) describes several convenient options for Quarto website deployment including RStudio Connect, Netlify, GitHub Pages, Firebase, Site44, and Amazon S3. We'll mostly defer to the documentation provided by those various services, but will note any Quarto website specific configuration required.
+The [publishing documentation](https://quarto.org/docs/publishing/other.html) describes several convenient options for Quarto website deployment including Posit Connect, Netlify, GitHub Pages, Firebase, Site44, and Amazon S3. We'll mostly defer to the documentation provided by those various services, but will note any Quarto website specific configuration required.
 
-### Does RStudio Connect support Quarto?
+### Does Posit Connect support Quarto?
 
-Yes! You can publish Quarto content to RStudio Connect v2021.08.0 or later. Quarto has to be enabled as documented in the RStudio Connect [admin guide](https://docs.rstudio.com/connect/admin/appendix/configuration/#Quarto). Connect's user [documentation](https://docs.rstudio.com/connect/user/quarto/) refers to [Quarto.org docs](https://quarto.org/docs/websites/publishing-websites.html#rstudio-connect) on how to publish from the RStudio IDE. To publish Python-based Quarto content, you can use the [rsconnect-python CLI](https://docs.rstudio.com/rsconnect-python/) from various locations, including VSCode, JupyterLab or the terminal.
+Yes! You can publish Quarto content to Posit Connect v2021.08.0 or later. Quarto has to be enabled as documented in the Posit Connect [admin guide](https://docs.rstudio.com/connect/admin/appendix/configuration/#Quarto). Connect's user [documentation](https://docs.rstudio.com/connect/user/quarto/) refers to [Quarto.org docs](https://quarto.org/docs/websites/publishing-websites.html#rstudio-connect) on how to publish from the RStudio IDE. To publish Python-based Quarto content, you can use the [rsconnect-python CLI](https://docs.rstudio.com/rsconnect-python/) from various locations, including VSCode, JupyterLab or the terminal.
 
 ### Who are the developers of Quarto?
 
-Development of Quarto is sponsored by [RStudio, PBC](https://www.rstudio.com/). The same core team works on both Quarto and R Markdown:
+Development of Quarto is sponsored by [Posit, PBC](https://www.posit.co/). The same core team works on both Quarto and R Markdown:
 
 -   Carlos Scheidegger ([\@cscheid](https://github.com/cscheid))
 

--- a/docs/faq/rmarkdown.qmd
+++ b/docs/faq/rmarkdown.qmd
@@ -17,7 +17,7 @@ The goal of Quarto is to make the process of creating and collaborating on scien
 
 The number of languages and runtimes used for scientific discourse is very broad (and the Jupyter ecosystem in particular is extraordinarily popular). Quarto is at its core multi-language and multi-engine (supporting Knitr, Jupyter, and Observable today and potentially other engines tomorrow).
 
-On the other hand, R Markdown is fundamentally tied to R which severely limits the number of practitioners it can benefit. Quarto is RStudio's attempt to bring R Markdown to everyone! Unlike R Markdown, Quarto doesn't have a dependency or requirement for R. Quarto was developed to be multilingual, beginning with R, Python, Javascript, and Julia, with the idea that it will work even for languages that don't yet exist.
+On the other hand, R Markdown is fundamentally tied to R which severely limits the number of practitioners it can benefit. Quarto is Posit's attempt to bring R Markdown to everyone! Unlike R Markdown, Quarto doesn't have a dependency or requirement for R. Quarto was developed to be multilingual, beginning with R, Python, Javascript, and Julia, with the idea that it will work even for languages that don't yet exist.
 
 While it is a "new" system, it should also be noted that it is highly compatible with existing content: you can render most R Markdown documents and Jupyter notebooks unmodified with Quarto. The concept is to make a major, long term investment in reproducible research, while keeping it compatible with existing formats and adaptable to the various environments users work in.
 
@@ -96,6 +96,6 @@ Yes! You need to use the [latest release](https://rstudio.com/products/rstudio/d
 
 You can download RStudio v2022.07 from <https://rstudio.com/products/rstudio/download/>.
 
-### Does RStudio Connect support Quarto?
+### Does Posit Connect support Quarto?
 
-Yes! You can publish Quarto content to RStudio Connect v2021.08.0 or later. Quarto has to be enabled as documented in the RStudio Connect [admin guide](https://docs.rstudio.com/connect/admin/appendix/configuration/#Quarto). Connect's user [documentation](https://docs.rstudio.com/connect/user/quarto/) refers to [Quarto.org docs](https://quarto.org/docs/websites/publishing-websites.html#rstudio-connect) on how to publish from the RStudio IDE. To publish Python-based Quarto content, you can use the [rsconnect-python CLI](https://docs.rstudio.com/rsconnect-python/) from various locations, including VSCode, JupyterLab or the terminal.
+Yes! You can publish Quarto content to Posit Connect v2021.08.0 or later. Quarto has to be enabled as documented in the Posit Connect [admin guide](https://docs.rstudio.com/connect/admin/appendix/configuration/#Quarto). Connect's user [documentation](https://docs.rstudio.com/connect/user/quarto/) refers to [Quarto.org docs](https://quarto.org/docs/websites/publishing-websites.html#rstudio-connect) on how to publish from the RStudio IDE. To publish Python-based Quarto content, you can use the [rsconnect-python CLI](https://docs.rstudio.com/rsconnect-python/) from various locations, including VSCode, JupyterLab or the terminal.

--- a/docs/guide/guide.yml
+++ b/docs/guide/guide.yml
@@ -126,7 +126,7 @@
        href: ../publishing/quarto-pub.qmd
      - text: GitHub Pages
        href: ../publishing/github-pages.qmd
-     - text: RStudio Connect
+     - text: Posit Connect
        href: ../publishing/rstudio-connect.qmd
      - text: Netlify
        href: ../publishing/netlify.qmd

--- a/docs/interactive/shiny/running.qmd
+++ b/docs/interactive/shiny/running.qmd
@@ -77,9 +77,9 @@ If you are using RStudio you can also use the **Publish** button <kbd>![](../../
 
 Note that you should always **Run Document** locally prior to publishing your document (as this will create the `.html` file that is served on ShinyApps.
 
-### RStudio Connect
+### Posit Connect
 
-[RStudio Connect](https://www.rstudio.com/products/connect/) is a server product from RStudio for secure sharing of applications, reports, and plots. You can publish Shiny interactive documents to RStudio Connect in much the same way as described above for [ShinyApps].
+[Posit Connect](https://www.rstudio.com/products/connect/) is a server product from Posit for secure sharing of applications, reports, and plots. You can publish Shiny interactive documents to Posit Connect in much the same way as described above for [ShinyApps].
 
 First, make sure you very latest development versions of the **rsconnect** and **quarto** R packages. You can install them as follows:
 
@@ -88,7 +88,7 @@ install.packages("rsconnect")
 install.packages("quarto")
 ```
 
-Next, deploy your interactive document using the `quarto_publish_app()` function of the **quarto** package, providing the domain name or IP address of your RStudio Connect installation via the `server` parameter. You can do this as follows (working from the directory that contains your document):
+Next, deploy your interactive document using the `quarto_publish_app()` function of the **quarto** package, providing the domain name or IP address of your Posit Connect installation via the `server` parameter. You can do this as follows (working from the directory that contains your document):
 
 ``` r
 library(quarto)
@@ -99,4 +99,4 @@ If you are using RStudio you can also use the **Publish** button <kbd>![](../../
 
 ![](images/rstudio-ide-rsc-publish.png){.border width="573"}
 
-As with ShinyApps, you should always **Run Document** locally prior to publishing your document (as this will create the `.html` file that is served by RStudio Connect).
+As with ShinyApps, you should always **Run Document** locally prior to publishing your document (as this will create the `.html` file that is served by Posit Connect).

--- a/docs/output-formats/html-publishing.qmd
+++ b/docs/output-formats/html-publishing.qmd
@@ -10,7 +10,7 @@ Note that it's also possible to publish collections of Quarto documents as a web
 
 ## Publish Command
 
-The `quarto publish` command provides a straightforward way to publish documents to [Quarto Pub](../publishing/quarto-pub.qmd), [GitHub Pages](../publishing/github-pages.qmd), [Netlify](../publishing/netlify.qmd), and [RStudio Connect](../publishing/rstudio-connect.qmd).
+The `quarto publish` command provides a straightforward way to publish documents to [Quarto Pub](../publishing/quarto-pub.qmd), [GitHub Pages](../publishing/github-pages.qmd), [Netlify](../publishing/netlify.qmd), and [Posit Connect](../publishing/rstudio-connect.qmd).
 
 For example, here are the commands to publish `document.qmd` to each of these services:
 
@@ -29,7 +29,7 @@ Here's a brief overview of the various supported services and when they might be
 |------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Quarto Pub](../publishing/quarto-pub.html)                | Publishing service for Quarto documents, websites, and books. Use Quarto Pub when you want a free, easy to use service for publicly available content.                                          |
 | [GitHub Pages](../publishing/github-pages.html)            | Publish content based on source code managed within a GitHub repository. Use GitHub Pages when the source code for your document or site is hosted on GitHub.                                   |
-| [RStudio Connect](../docs/publishing/rstudio-connect.html) | Publishing platform for secure sharing of data products within an organization. Use RStudio Connect when you want to publish content within an organization rather than on the public internet. |
+| [Posit Connect](../docs/publishing/rstudio-connect.html) | Publishing platform for secure sharing of data products within an organization. Use Posit Connect when you want to publish content within an organization rather than on the public internet. |
 | [Netlify](../publishing/netlify.html)                      | Professional web publishing platform. Use Netlify when you want support for custom domains, authentication, previewing branches, and other more advanced capabilities.                          |
 | [Other Services](../publishing/other.html)                 | Content rendered with Quarto uses standard formats (HTML, PDFs, MS Word, etc.) that can be published anywhere. Use this if one of the methods above don't meet your requirements.               |
 

--- a/docs/presentations/revealjs/presenting.qmd
+++ b/docs/presentations/revealjs/presenting.qmd
@@ -290,7 +290,7 @@ There are two main ways to publish Reveal presentations:
     Note that specifying `embed-resources` can slow down rendering by a couple of seconds, so you may want to enable `embed-resources` only when you are ready to publish. Also note that Reveal plugin [Chalkboard] is not compatible with `embed-resources` --- when [Chalkboard] plugin is enabled, specifying `embed-resources: true` will result an error.
     :::
 
-See the documentation on [Publishing HTML](../../publishing/index.qmd) for details on additional ways to publish Reveal presentations including GitHub Pages and RStudio Connect.
+See the documentation on [Publishing HTML](../../publishing/index.qmd) for details on additional ways to publish Reveal presentations including GitHub Pages and Posit Connect.
 
 ## Navigation Options
 

--- a/docs/projects/environment.qmd
+++ b/docs/projects/environment.qmd
@@ -85,7 +85,7 @@ Frequently, credentials or authorization tokens are provided to code via environ
 
 It's especially critical that these credentials are not checked in to version control. Typically, this is accomplished by a combination of:
 
-1.  When running on a server or CI service, provide the environment variable as an encrypted secret. Details on how to do this vary between services (GitHub Actions has [deployed secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets), RStudio Connect supports [content variables](https://docs.rstudio.com/connect/user/content-settings/#content-vars), etc.)
+1.  When running on a server or CI service, provide the environment variable as an encrypted secret. Details on how to do this vary between services (GitHub Actions has [deployed secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets), Posit Connect supports [content variables](https://docs.rstudio.com/connect/user/content-settings/#content-vars), etc.)
 
 2.  For local development, define variables in the `_environment.local` file (and ignore this file in version control, as Quarto does by default). For example, here we specify AWS credentials in a local environment file:
 

--- a/docs/publishing/ci.qmd
+++ b/docs/publishing/ci.qmd
@@ -12,7 +12,7 @@ Continuous Integration (CI) refers to the practice of automatically publishing c
 
 -   Not checking rendered output into version control makes diffs smaller and reduces merge conflicts.
 
-This article covers how to implement CI for Quarto using GitHub Actions (a service run by GitHub), ordinary shell commands (which can be made to work with any CI service), and with RStudio Connect.
+This article covers how to implement CI for Quarto using GitHub Actions (a service run by GitHub), ordinary shell commands (which can be made to work with any CI service), and with Posit Connect.
 
 ## Rendering for CI
 
@@ -34,7 +34,7 @@ In light of the above, you can think about rendering as a continuum that extends
 
 -   **CI Execution and Rendering** --- Execute all code and perform rendering on the CI server. While this is the gold standard of automation and reproducibility, it will require you to capture your R, Python, or Julia dependencies (e.g. in an `renv.lock` file or `requirements.txt` file) and arrange for them to be installed on the CI server. You will also need to make sure that permissions (e.g. database access) required by your code are available on the CI server.
 
-Below we'll describe how to implement each of these strategies using [GitHub Actions], ordinary [Shell Commands] (which you should be able to adapt to any CI environment), or [RStudio Connect](rstudio-connect.qmd).
+Below we'll describe how to implement each of these strategies using [GitHub Actions], ordinary [Shell Commands] (which you should be able to adapt to any CI environment), or [Posit Connect](rstudio-connect.qmd).
 
 ## GitHub Actions
 
@@ -48,11 +48,11 @@ Learn about using GitHub Actions with various publishing services here:
 
 If you want to use the standard Quarto actions as part of another workflow see the [GitHub Actions for Quarto](https://github.com/quarto-dev/quarto-actions) repository.
 
-## RStudio Connect
+## Posit Connect
 
-If you are publishing a source code version of your content to RStudio Connect it's possible to configure Connect to retrieve the code from a Git repository and then render and execute on the Connect Server.
+If you are publishing a source code version of your content to Posit Connect it's possible to configure Connect to retrieve the code from a Git repository and then render and execute on the Connect Server.
 
-To learn more about this, see the documentation on [Git Backed Content](https://docs.rstudio.com/connect/user/git-backed/) for RStudio Connect.
+To learn more about this, see the documentation on [Git Backed Content](https://docs.rstudio.com/connect/user/git-backed/) for Posit Connect.
 
 ## Shell Commands
 
@@ -131,7 +131,7 @@ You can specify publishing credentials either using environment variables or via
 |-----------------|----------------------------------------|
 | Quarto Pub      | `QUARTO_PUB_AUTH_TOKEN`                |
 | Netlify         | `NETLIFY_AUTH_TOKEN`                   |
-| RStudio Connect | `CONNECT_SERVER` and `CONNECT_API_KEY` |
+| Posit Connect   | `CONNECT_SERVER` and `CONNECT_API_KEY` |
 
 Set these environment variables within your script before calling `quarto publish`. For example:
 

--- a/docs/publishing/index.qmd
+++ b/docs/publishing/index.qmd
@@ -4,7 +4,7 @@ title: "Publishing Basics"
 
 ## Overview
 
-There are a wide variety of ways to publish documents, presentations, and websites created using Quarto. Since content rendered with Quarto uses standard formats (HTML, PDFs, MS Word, etc.) it can be published anywhere. Additionally, there is a `quarto publish` command available for easy publishing to various popular services (GitHub, Netlify, RStudio Connect, etc.) as well as various tools to make it easy to publish from a Continuous Integration (CI) system.
+There are a wide variety of ways to publish documents, presentations, and websites created using Quarto. Since content rendered with Quarto uses standard formats (HTML, PDFs, MS Word, etc.) it can be published anywhere. Additionally, there is a `quarto publish` command available for easy publishing to various popular services (GitHub, Netlify, Posit Connect, etc.) as well as various tools to make it easy to publish from a Continuous Integration (CI) system.
 
 ## Getting Started
 
@@ -14,7 +14,7 @@ To get started, review the documentation for using one of the following publishi
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Quarto Pub](quarto-pub.qmd)           | Publishing service for Quarto documents, websites, and books. Use Quarto Pub when you want a free, easy to use service for publicly available content.                                          |
 | [GitHub Pages](github-pages.qmd)       | Publish content based on source code managed within a GitHub repository. Use GitHub Pages when the source code for your document or site is hosted on GitHub.                                   |
-| [RStudio Connect](rstudio-connect.qmd) | Publishing platform for secure sharing of data products within an organization. Use RStudio Connect when you want to publish content within an organization rather than on the public internet. |
+| [Posit Connect](rstudio-connect.qmd) | Publishing platform for secure sharing of data products within an organization. Use Posit Connect when you want to publish content within an organization rather than on the public internet. |
 | [Netlify](netlify.qmd)                 | Professional web publishing platform. Use Netlify when you want support for custom domains, authentication, previewing branches, and other more advanced capabilities.                          |
 | [Other Services](other.qmd)            | Content rendered with Quarto uses standard formats (HTML, PDFs, MS Word, etc.) that can be published anywhere. Use this if one of the methods above don't meet your requirements.               |
 

--- a/docs/publishing/other.qmd
+++ b/docs/publishing/other.qmd
@@ -4,7 +4,7 @@ title: "Other Services"
 
 ## Overview
 
-There are a wide variety of ways to publish Quarto websites. Other articles cover publishing to [Quarto Pub](quarto-pub.qmd), [GitHub Pages](github-pages.qmd), [Netlify](netlify.qmd), and [RStudio Connect](rstudio-connect.qmd). Below we'll describe some general guidelines as well as offer some specific advice for [Firebase](#google-firebase), [Site44], and [Amazon S3]. We'll mostly defer to the documentation provided by the various services, but will note any Quarto website specific configuration required.
+There are a wide variety of ways to publish Quarto websites. Other articles cover publishing to [Quarto Pub](quarto-pub.qmd), [GitHub Pages](github-pages.qmd), [Netlify](netlify.qmd), and [Posit Connect](rstudio-connect.qmd). Below we'll describe some general guidelines as well as offer some specific advice for [Firebase](#google-firebase), [Site44], and [Amazon S3]. We'll mostly defer to the documentation provided by the various services, but will note any Quarto website specific configuration required.
 
 The most important thing to understand is that website content is by default written to the `_site` sub-directory and book content to the `_book` directory (you can customize either using the `output-dir` option). Publishing is simply a matter of copying the output directory to a web server or web hosting service.
 

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -1,18 +1,18 @@
 ---
-title: "RStudio Connect"
+title: "Posit Connect"
 editor: visual
 heading-pad: '#'
 ---
 
 ## Overview
 
-[RStudio Connect](https://www.rstudio.com/products/connect/) is a publishing platform for secure sharing of data products within an organization. Use RStudio Connect when you want to publish content within an organization rather than on the public internet.
+[Posit Connect](https://www.rstudio.com/products/connect/) is a publishing platform for secure sharing of data products within an organization. Use Posit Connect when you want to publish content within an organization rather than on the public internet.
 
-There are several ways to publish Quarto content to RStudio Connect:
+There are several ways to publish Quarto content to Posit Connect:
 
 1.  Use the `quarto publish` command to publish static content rendered on your local machine.
 
-2.  Use the [rsconnect-python](https://docs.rstudio.com/rsconnect-python/) Python package or [quarto](https://quarto-dev.github.io/quarto-r/) R package to publish code for rendering on an RStudio Connect server (e.g. for a scheduled report).
+2.  Use the [rsconnect-python](https://docs.rstudio.com/rsconnect-python/) Python package or [quarto](https://quarto-dev.github.io/quarto-r/) R package to publish code for rendering on an Posit Connect server (e.g. for a scheduled report).
 
 3.  Use Connect's support for [Git backed content](https://docs.rstudio.com/connect/user/git-backed/) to automatically re-publish content when code is checked in to a Git repository.
 
@@ -74,7 +74,7 @@ The tools for publishing code differ depending on whether you are using the Knit
 
 ### Knitr (R)
 
-The [quarto](https://quarto-dev.github.io/quarto-r/) R package includes a set of publishing functions that you can use for publishing Quarto projects with R code to RStudio Connect. For example, here we publish a document and a website:
+The [quarto](https://quarto-dev.github.io/quarto-r/) R package includes a set of publishing functions that you can use for publishing Quarto projects with R code to Posit Connect. For example, here we publish a document and a website:
 
 ``` r
 library(quarto)
@@ -105,7 +105,7 @@ See the article on [Quarto Publishing from R](https://quarto-dev.github.io/quart
 
 #### RStudio IDE
 
-If you are using the RStudio IDE, there is also support for push-button publishing to RStudio Connect. Use the publish button <kbd>![](images/publish-button.png){width="23" height="20"}</kbd> from the source editor or viewer pane to publish a document or a website:
+If you are using the RStudio IDE, there is also support for push-button publishing to Posit Connect. Use the publish button <kbd>![](images/publish-button.png){width="23" height="20"}</kbd> from the source editor or viewer pane to publish a document or a website:
 
 ![](images/rstudio-publish.png){.border}
 
@@ -113,9 +113,9 @@ See the Connect documentation on [Publishing from the RStudio IDE](https://docs.
 
 ### Jupyter (Python)
 
-The [rsconnect-python](https://docs.rstudio.com/rsconnect-python/) Python package provides a command line interface (CLI) that you can use to publish Quarto documents and websites that use Jupyter to RStudio Connect. To use the CLI:
+The [rsconnect-python](https://docs.rstudio.com/rsconnect-python/) Python package provides a command line interface (CLI) that you can use to publish Quarto documents and websites that use Jupyter to Posit Connect. To use the CLI:
 
-1.  First, install the rsconnect-python package and configure an RStudio Connect server for publishing: <https://docs.rstudio.com/connect/user/connecting-cli/>
+1.  First, install the rsconnect-python package and configure an Posit Connect server for publishing: <https://docs.rstudio.com/connect/user/connecting-cli/>
 
 2.  Then, use the `rsconnect deploy quarto` command from your project directory:
 
@@ -139,13 +139,13 @@ See the article on [Publishing Jupyter Notebooks](https://docs.rstudio.com/conne
 
 ## Publishing from Git
 
-Content may be deployed to RStudio Connect directly from a remote Git repository. Content will automatically fetch from the associated remote Git repository and re-deploy. This allows for integration with Git-centric workflows and continuous deployment automation.
+Content may be deployed to Posit Connect directly from a remote Git repository. Content will automatically fetch from the associated remote Git repository and re-deploy. This allows for integration with Git-centric workflows and continuous deployment automation.
 
-In order to deploy Git-backed content to RStudio Connect you'll follow a two step process:
+In order to deploy Git-backed content to Posit Connect you'll follow a two step process:
 
 1.  Create and commit a manifest file (this includes information on the R or Python dependencies required to render your content)
 
-2.  Link RStudio Connect to the Git repository
+2.  Link Posit Connect to the Git repository
 
 Note that Quarto must be installed on the Connect server before you attempt to publish from Git (this is typically done by an administrator, see the [Quarto Installation](https://docs.rstudio.com/resources/install-quarto/) documentation for additional details).
 
@@ -199,8 +199,8 @@ You can publish Quarto content to Connect using any CI service by scripting the 
 
 | Variable          | Description                                                                |
 |------------------|------------------------------------------------------|
-| `CONNECT_SERVER`  | Address of RStudio Connect server (e.g., `https://connect.example.com`).    |
-| `CONNECT_API_KEY` | RStudio Connect [API Key](https://docs.rstudio.com/connect/user/api-keys/) |
+| `CONNECT_SERVER`  | Address of Posit Connect server (e.g., `https://connect.example.com`).    |
+| `CONNECT_API_KEY` | Posit Connect [API Key](https://docs.rstudio.com/connect/user/api-keys/) |
 
 You will furthermore need to specify the ID of the target content to update. This will most frequently be drawn from the `_publish.yml` file that is saved into your project directory during publishing. For example:
 
@@ -233,7 +233,7 @@ If your CI service is [GitHub Actions](https://docs.github.com/en/actions) then 
 
 Before creating the publish action, you need to ensure that your repository has the credentials required for publishing to Connect. You can do this as follows:
 
-1.  If you don't already have one, create an RStudio Connect [API Key](https://docs.rstudio.com/connect/user/api-keys/) from the requisite Connect server and then copy it to the clipboard.
+1.  If you don't already have one, create an Posit Connect [API Key](https://docs.rstudio.com/connect/user/api-keys/) from the requisite Connect server and then copy it to the clipboard.
 
 2.  Add the Connect API Key to your repository's action **Secrets** (accessible within repository **Settings**). You will see a **New repository secret** button at the top right:
 

--- a/docs/websites/website-basics.qmd
+++ b/docs/websites/website-basics.qmd
@@ -11,7 +11,7 @@ Quarto Websites are a convenient way to publish groups of documents. Documents p
 
 Website navigation can be provided through a global navbar, a sidebar with links, or a combination of both for sites that have multiple levels of content. You can also enable full text search for websites.
 
-Quarto websites can be published to a wide variety of destinations including GitHub Pages, Netlify, RStudio Connect, or any other static hosting service or intranet web server. See the documentation on [Publishing Websites](../publishing/index.qmd) for additional details.
+Quarto websites can be published to a wide variety of destinations including GitHub Pages, Netlify, Posit Connect, or any other static hosting service or intranet web server. See the documentation on [Publishing Websites](../publishing/index.qmd) for additional details.
 
 ## Quick Start
 
@@ -169,4 +169,4 @@ Once you've got a basic website up and running check out these articles for vari
 
 [Code Execution](../projects/code-execution.qmd) provides tips for optimizing the rendering of sites with large numbers of documents or expensive computations.
 
-[Publishing Websites](../publishing/index.qmd) enumerates the various options for publishing websites including GitHub Pages, Netlify, and RStudio Connect.
+[Publishing Websites](../publishing/index.qmd) enumerates the various options for publishing websites including GitHub Pages, Netlify, and Posit Connect.

--- a/docs/websites/website-blog.qmd
+++ b/docs/websites/website-blog.qmd
@@ -332,7 +332,7 @@ The article on [Publishing Websites](../publishing/index.qmd) describes in more 
 -   [Quarto Pub](../publishing/quarto-pub.qmd)
 -   [GitHub Pages](../publishing/github-pages.qmd)
 -   [Netlify](../publishing/netlify.qmd)
--   [RStudio Connect](../publishing/rstudio-connect.qmd)
+-   [Posit Connect](../publishing/rstudio-connect.qmd)
 -   [Firebase](../publishing/other.qmd#google-firebase)
 -   [Site44](../publishing/other.qmd#site44)
 -   [Amazon S3](../publishing/other.qmd#amazon-s3)

--- a/index.qmd
+++ b/index.qmd
@@ -110,7 +110,7 @@ plt.show()
 
 <div class="tab-pane fade" id="knitr" role="tabpanel" aria-labelledby="knitr-tab">
 
-Quarto is a multi-language, next generation version of R Markdown from RStudio, with many new new features and capabilities. Like R Markdown, Quarto uses [Knitr](https://yihui.org/knitr/) to execute R code, and is therefore able to render most existing Rmd files without modification.
+Quarto is a multi-language, next generation version of R Markdown from Posit, with many new new features and capabilities. Like R Markdown, Quarto uses [Knitr](https://yihui.org/knitr/) to execute R code, and is therefore able to render most existing Rmd files without modification.
 
 ::: {.grid}
 ::: {.g-col-lg-6 .g-col-12}

--- a/license.qmd
+++ b/license.qmd
@@ -6,7 +6,7 @@ Quarto is open source software licensed under the [GNU GPL v2](https://www.gnu.o
 
 The Quarto source code is available at <https://github.com/quarto-dev/>
 
-Quarto is a registered trademark of RStudio. Please see our [trademark policy](trademark.qmd) for guidelines on usage of the Quarto trademark.
+Quarto is a registered trademark of Posit. Please see our [trademark policy](trademark.qmd) for guidelines on usage of the Quarto trademark.
 
 Quarto also makes use of several other open-source projects, the distribution of which is subject to their respective licenses. Major components and their licenses include:
 

--- a/trademark.qmd
+++ b/trademark.qmd
@@ -8,7 +8,7 @@ This policy is adapted directly from the WordPress Foundation's [trademark polic
 
 ## Goals
 
-[RStudio, PBC](https://www.rstudio.com/about/) owns and oversees the trademark for the Quarto name and logo. We have developed this trademark usage policy with the following goals in mind:
+[Posit, PBC](https://www.posit.co/about/) owns and oversees the trademark for the Quarto name and logo. We have developed this trademark usage policy with the following goals in mind:
 
 1.  We'd like to make it easy for anyone to use the Quarto name or logo for community-oriented efforts that help spread and improve Quarto.
 
@@ -20,7 +20,7 @@ Please note that it is not the goal of this policy to limit open source or comme
 
 ## Permission
 
-Permission from RStudio is required to use the Quarto name or logo as part of any project, product, service, domain name, or company name.
+Permission from Posit is required to use the Quarto name or logo as part of any project, product, service, domain name, or company name.
 
 We will grant permission to use the Quarto name and logo for projects that meet the following criteria:
 
@@ -42,4 +42,4 @@ A consulting company can describe its business as "123 Publishing Services, offe
 
 Similarly, it's OK to use the Quarto logo as part of a page that describes your products or services, but it is not OK to use it as part of your company or product logo or branding itself. Under no circumstances is it permitted to use Quarto as part of a domain name or top-level domain name.
 
-When in doubt about your use of the Quarto name or logo, please contact RStudio at [permissions\@rstudio.com](mailto:permissions@rstudio.com) for clarification.
+When in doubt about your use of the Quarto name or logo, please contact Posit at [permissions\@rstudio.com](mailto:permissions@rstudio.com) for clarification.


### PR DESCRIPTION
Update documentation site for name change to Posit.

In particular:

- Footer logo and link
- References to Posit the company, and commercial products (e.g. RStudio Connect -> Posit Connect)

I updated URLs that pointed to the RStudio home page, but didn't touch any other URLs on the rstudio.com domain assuming the redirects will take care of them.

Fixes #612