### PR TITLE
Adapt Julia callout warning following 1.3 bug fix

### DIFF
--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -13,7 +13,7 @@ Quarto supports executable Julia code blocks within markdown. This allows you to
 Quarto executes Julia code using the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel. Below we'll describe how to [install](#installation) IJulia and related requirements but first we'll cover the basics of creating and rendering documents with Julia code blocks.
 
 ::: {.callout-important}
-An [issue with quarto and Julia 1.8.4+](https://github.com/quarto-dev/quarto-cli/issues/2539) may lead to the error message `Kernel died before replying to kernel_info`. Earlier versions are not known to have this issue; a workaround is adding the argument `--no-execute-daemon` when running `quarto render` or `quarto preview`.
+An [issue with quarto and Julia 1.8.4+](https://github.com/quarto-dev/quarto-cli/issues/2539) may lead to the error message `Kernel died before replying to kernel_info`. Earlier versions are not known to have this issue; A workaround is to install [latest v1.3 pre-release](https://quarto.org/docs/download/prerelease.html) which issue has been fixed.
 :::
 
 ### Code Blocks


### PR DESCRIPTION
 for quarto-dev/quarto-cli#2539

This follows fix in https://github.com/quarto-dev/quarto-cli/pull/4263

@cscheid  is that fix now in pre-release right ? 

It seems to me the workaround to install latest 1.3 is better than running with no daemon. 

But maybe both should be shared. 🤷‍♂️ 

