### PR TITLE
Add documentation for date-modified (blogs)

### DIFF
--- a/docs/websites/website-blog.qmd
+++ b/docs/websites/website-blog.qmd
@@ -190,6 +190,19 @@ draft: true
 
 To publish the post when it is complete, simply remove `draft: true` from the document options and then render it.
 
+### Last Updated
+To indicate the date of the last modification, but preserve the original publication date, you can add the `date-modified` field to the document options. For example:
+
+``` yaml
+---
+title: "My Post"
+description: "Post description"
+author: "Fizz McPhee"
+date: "5/22/2021"
+date-modified: "5/23/2021"
+---
+```
+
 ### Freezing Posts
 
 Blogs posts that contain executable code often have the problem that posts created last year can't be rendered this year (for example, because the packages used by the post have changed). A similar problem can also arise when a blog has multiple contributors and not everyone has the right software (or the right versions) to render all of the posts. Finally, posts that include computations can often take a while to render, and you don't want the cumulative time required to render the site to grow too large.


### PR DESCRIPTION
The YAML header field `date-modified` is implemented (see [this issue](https://github.com/quarto-dev/quarto-cli/issues/1241)) but not documented yet. As this is an important feature when updating blog posts, it seems reasonable to include it in the main documentation.

Feel free to adjust the phrasing as needed.