### PR TITLE
Correct name of package to install with brew

### DIFF
--- a/docs/prerelease/1.3/pdf.qmd
+++ b/docs/prerelease/1.3/pdf.qmd
@@ -6,9 +6,9 @@ title: PDF Format Improvements
 
 Starting in Quarto 1.3, we support rendering of PDF documents that include SVG files, automatically converting them to PDF images if `rsvg-convert` is available on the system path during rendering.
 
-You can learn more about installing `libsvg`{spellcheck="false"} (which provides `rsvg-convert`{spellcheck="false"}), see <https://wiki.gnome.org/Projects/LibRsvg>. To install on specific platforms, follow the below instructions:
+You can learn more about installing `librsvg`{spellcheck="false"} (which provides `rsvg-convert`{spellcheck="false"}), see <https://wiki.gnome.org/Projects/LibRsvg>. To install on specific platforms, follow the below instructions:
 
--   On MacOS, you an use Homebrew (<https://formulae.brew.sh/formula/libsvg>) `brew install libsvg`{spellcheck="false"}
+-   On MacOS, you an use Homebrew (<https://formulae.brew.sh/formula/librsvg>) `brew install librsvg`{spellcheck="false"}
 
 -   Tarballs for Linux are available here: <https://download.gnome.org/sources/librsvg/>
 


### PR DESCRIPTION
`brew install libsvg` doesn't install `rsvg-convert` (but libsvg is a valid package, which made for a short puzzle). This fixes that tiny typo and revises a couple of other references to librsvg instead of libsvg.