### PR TITLE
Update installation instructions for jupyterlab

### DIFF
--- a/docs/get-started/hello/jupyter.qmd
+++ b/docs/get-started/hello/jupyter.qmd
@@ -41,15 +41,17 @@ Then, create a new directory to work within and copy the notebook into this dire
 Once you've done that, switch to this directory in a Terminal, install notebook dependencies (if necessary), and open Jupyter Lab to get started working with the notebook.
 The commands you can use for installation and opening Jupyter Lab are given in the table below.
 
-+-----------+--------------------------------------------------------------+
-| Platform  | Commands                                                     |
-+===========+==============================================================+
-| Mac/Linux |     python3 -m pip install jupyter matplotlib plotly         |
-|           |     python3 -m jupyter lab hello.ipynb                       |
-+-----------+--------------------------------------------------------------+
-| Windows   |     py -m pip install jupyter matplotlib plotly              |
-|           |     py -m jupyter lab hello.ipynb                            |
-+-----------+--------------------------------------------------------------+
++-----------+-----------------------------------------------------------------+
+| Platform  | Commands                                                        |
++===========+=================================================================+
+| Mac/Linux |     python3 -m pip install jupyter jupyterlab matplotlib plotly |
+|           |     python3 -m jupyter lab build                                |
+|           |     python3 -m jupyter lab hello.ipynb                          |
++-----------+-----------------------------------------------------------------+
+| Windows   |     py -m pip install jupyter jupyterlab matplotlib plotly      |
+|           |     py -m jupyter lab build                                     |
+|           |     py -m jupyter lab hello.ipynb                               |
++-----------+-----------------------------------------------------------------+
 
 Here is our notebook in Jupyter Lab.
 


### PR DESCRIPTION
In the existing instructions only jupyter was installed, not jupyterlab though. After installation, jupyter lab also throws an error if you don't run the "build" step before using it.
Tested on a Mac with python version 3.10.9 and jupyter lab version 3.6.1. Assuming Linux and Windows behave the same.