### PR TITLE
Added a custom format for revealjs

### DIFF
--- a/docs/extensions/listings/revealjs-formats.yml
+++ b/docs/extensions/listings/revealjs-formats.yml
@@ -40,3 +40,9 @@
   author: "[Mickaël CANOUIL](https://github.com/mcanouil)"
   description: |
     R Lille (R User Group) format for Revealjs
+
+- name: metropolis-revealjs
+  path: https://github.com/shafayetShafee/metropolis
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
+  description: |
+    Beamer Metropolis like format for Revealjs.

--- a/docs/extensions/listings/revealjs.yml
+++ b/docs/extensions/listings/revealjs.yml
@@ -43,14 +43,14 @@
 
 - name: reveal-header
   path: https://github.com/shafayetShafee/reveal-header
-  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
   description: |
     Filter that provides options to add a header text and header logo
     in top-left corner of the RevealJs slides.
 
 - name: style-speaker-note
   path: https://github.com/shafayetShafee/style-speaker-note
-  author: "[shafayetShafee](https://github.com/shafayetShafee)"
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
   description: |
     Filter that allows to style the Speaker Notes of the RevealJs slides 
     from a CSS file.
@@ -60,3 +60,10 @@
   author: "[Mickaël CANOUIL](https://github.com/mcanouil)"
   description: |
     A Quarto extension for Reveal.js allowing to highlight the current mouse position with a spotlight.
+
+- name: code-fullscreen
+  path: https://github.com/shafayetShafee/code-fullscreen
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
+  description: |
+    Filter that adds a fullscreen button in the code blocks in Revealjs 
+    slides and html documents.


### PR DESCRIPTION
I have added a custom format [`metropolis-revealjs`](https://github.com/shafayetShafee/metropolis) in the revealjs-formats.yml file.

Also changed my name to my full name for the previously added revealjs filter. And I have also added [`code-fullscreen`](https://github.com/shafayetShafee/code-fullscreen) in the revealjs listing. 

Note that, `code-fullscreen` already exists in the shortcode and filter listing, but I have added it in the reveals listing too, because I believe it is more useful when used in revealjs presentations.