### PR TITLE
output-location is valid when echo is set to true

### DIFF
--- a/docs/presentations/revealjs/index.qmd
+++ b/docs/presentations/revealjs/index.qmd
@@ -272,6 +272,7 @@ By default, output from executable code blocks is displayed immediately after th
 For example, here we display cell output on its own slide:
 
 ``` {{r}}
+#| echo: true
 #| output-location: slide
 library(ggplot2)
 ggplot(airquality, aes(Temp, Ozone)) + 


### PR DESCRIPTION
Otherwise, following warning will be displayed: `WARNING: output-location is only valid for cells that echo their code` and code won't be displayed