### PR TITLE
Add clarification about pdf book formats

### DIFF
--- a/docs/output-formats/pdf-basics.qmd
+++ b/docs/output-formats/pdf-basics.qmd
@@ -49,7 +49,11 @@ format:
     papersize: letter
 ```
 
-You can set `documentclass` to the standard `article`, `report` or `book` classes, to the KOMA Script equivalents `scrartcl`, `scrbook`, and `scrreprt`, or to any other class made available by LaTeX packages you have installed.
+You can set `documentclass` to the standard `article`, `report` or `book` classes, to the KOMA Script equivalents `scrartcl`, `scrreprt`, and `srcbook` respectively, or to any other class made available by LaTeX packages you have installed.
+
+::: callout-note
+Setting your `documentclass` to either `book` or `srcbook` will automatically handle many of the common needs for printing and binding PDFs into a physical book (i.e., chapters start on odd pages, alternating margin sizes, etc).
+:::
 
 See the [Output Options] section below for additional details on customizing LaTeX document options.
 


### PR DESCRIPTION
Just adding a short bit of docs about PDFs that I would have appreciated seeing last week. I went down a rabbit hole of hunting for these options so thought it might be useful to others to call this out early

Note, I'm getting an error thrown on compiling the .qmd due to

```
In file _quarto.yml
(line 18, columns 3--12) property name issue-url is invalid
```

but this seems unrelated to my change