### PR TITLE
Add section on Bootstrap table class support

### DIFF
--- a/docs/prerelease/1.3/tables.qmd
+++ b/docs/prerelease/1.3/tables.qmd
@@ -26,6 +26,20 @@ With that said, it's possible that our processing of HTML tables interferes with
 
 :::
 
+### Bootstrap classes can be added to tables
+
+Bootstrap table classes given as attributes next to a table caption are now inserted into the `<table>` element. The classes permitted are those that apply expressly to the entire table, and these are: `"primary"`, `"secondary"`, `"success"`, `"danger"`, `"warning"`, `"info"`, `"light"`, `"dark"`, `"striped"`, `"hover"`, `"active"`, `"bordered"`, `"borderless"`, `"sm"`, `"responsive"`, `"responsive-sm"`, `"responsive-md"`, `"responsive-lg"`, `"responsive-xl"`, `"responsive-xxl"`. For example, the following Markdown table will be rendered with row stripes and the rows will also be highlighted on hover:
+
+```
+| fruit  | price  |
+|--------|--------|
+| apple  | 2.05   |
+| pear   | 1.37   |
+| orange | 3.09   |
+
+: Fruit prices {.striped .hover}
+```
+
 ### Embedded Markdown content can be specified
 
 In addition, Quarto now supports the specification of embedded Markdown content in tables. This is done by providing a data attribute `qmd` or `qmd-base64` in an embedded `span` or `div` node. These nodes can appear anywhere that such content is allowed: table headers, footers, cells, captions, etc. For example, consider following table:


### PR DESCRIPTION
For the v1.3 prerelease notes, a short section on Bootstrap table class support (insertable via table caption) has been added here.