### PR TITLE
Specify Cross Ref identifier case constraint

### DIFF
--- a/docs/authoring/cross-references.qmd
+++ b/docs/authoring/cross-references.qmd
@@ -46,6 +46,7 @@ See @fig-elephant for an illustration.
 ```
 
 Note again that cross-reference identifiers must start with their type (e.g. `#fig-`).
+Cross reference identifiers must be all lower case.
 
 ### Subfigures
 


### PR DESCRIPTION
i was going a little crazy as a beginner as to why my reference wasn't working. From guessing and testing it was because i had a couple of uppercase letters sprinkled in. Thought it should be added in the docs. Not sure if there are other simple rules to know but from now on ill be sticking to only hyphens, numbers, and lowercase. Cheers.