### PR TITLE
Lists recursive-citeproc filter

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -246,3 +246,9 @@
   author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee/)"
   description: |
       Format the codes in python code-chunk using [black](https://black.readthedocs.io/en/stable/index.html) formatter.
+
+- name: recursive-citeproc
+  path: https://github.com/dialoa/recursive-citeproc
+  author: "[Dialoa/Julien Dutant](https://github.com/dialoa/)"
+  description: |
+      Handle self-citing bibliographies

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -251,4 +251,4 @@
   path: https://github.com/dialoa/recursive-citeproc
   author: "[Dialoa/Julien Dutant](https://github.com/dialoa/)"
   description: |
-      Handle self-citing bibliographies
+      Handle self-citing bibliographies.


### PR DESCRIPTION
Tested with Quarto and Pandoc, a filter to handle self-citing bibliographies (e.g. BibTeX containing `\citet` commands).