### PR TITLE
Always quote captions and alt text in examples

### DIFF
--- a/docs/authoring/diagrams.qmd
+++ b/docs/authoring/diagrams.qmd
@@ -102,14 +102,14 @@ Diagrams can be treated as figures the same way that images and plot output are.
 
 ``` {{dot}}
 //| label: fig-simple
-//| fig-cap: This is a simple graphviz graph.
+//| fig-cap: "This is a simple graphviz graph."
 ```
 
 We'd get this output:
 
 ```{dot}
 //| label: fig-simple
-//| fig-cap: This is a simple graphviz graph
+//| fig-cap: "This is a simple graphviz graph."
 graph G {
   layout=neato
   run -- intr;

--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -440,7 +440,7 @@ You can create subcaptions for computational output by combining the the `fig-ca
 
 ``` {{python}}
 #| label: fig-charts
-#| fig-cap: Charts
+#| fig-cap: "Charts"
 #| fig-subcap: 
 #|   - "First"
 #|   - "Second"
@@ -460,7 +460,7 @@ plt.show()
 
 ``` {{r}}
 #| label: fig-charts
-#| fig-cap: Charts
+#| fig-cap: "Charts"
 #| fig-subcap: 
 #|   - "Cars"
 #|   - "Pressure"

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -67,7 +67,7 @@ By default Julia cells will automatically print the value of their last statemen
 
 ``` {{julia}}
 #| label: fig-plots
-#| fig-cap: Multiple Plots
+#| fig-cap: "Multiple Plots"
 #| fig-subcap:
 #|   - "Plot 1"
 #|   - "Plot 2"

--- a/docs/computations/r.qmd
+++ b/docs/computations/r.qmd
@@ -28,7 +28,7 @@ format:
 
 ```{{r}}
 #| label: fig-airquality
-#| fig-cap: Temperature and ozone level.
+#| fig-cap: "Temperature and ozone level."
 #| warning: false
 
 library(ggplot2)

--- a/docs/get-started/authoring/_text-editor.md
+++ b/docs/get-started/authoring/_text-editor.md
@@ -239,7 +239,7 @@ See @eq-stddev to better understand standard deviation.
 
 ```{{python}}
 #| label: fig-simple
-#| fig-cap: Simple Plot
+#| fig-cap: "Simple Plot"
 import matplotlib.pyplot as plt
 plt.plot([1,23,2,4])
 plt.show()
@@ -267,7 +267,7 @@ We cross-referenced sections, figures, and equations. The table below shows how 
 |          |               |                                  |
 |          |               | ``` {.default code-copy="false"} |
 |          |               | #| label: fig-simple             |
-|          |               | #| fig-cap: Simple Plot          |
+|          |               | #| fig-cap: "Simple Plot"        |
 |          |               | ```                              |
 +----------+---------------+----------------------------------+
 | Equation | `@eq-stddev`  | At end of display equation:      |

--- a/docs/get-started/authoring/jupyter.qmd
+++ b/docs/get-started/authoring/jupyter.qmd
@@ -301,7 +301,7 @@ See @eq-stddev to better understand standard deviation.
 
 ```{{python}}
 #| label: fig-simple
-#| fig-cap: Simple Plot
+#| fig-cap: "Simple Plot"
 import matplotlib.pyplot as plt
 plt.plot([1,23,2,4])
 plt.show()
@@ -336,7 +336,7 @@ The table below shows how we expressed each of these.
 |          |               |                                  |
 |          |               | ``` {.default code-copy="false"} |
 |          |               | #| label: fig-simple             |
-|          |               | #| fig-cap: Simple Plot          |
+|          |               | #| fig-cap: "Simple Plot"        |
 |          |               | ```                              |
 +----------+---------------+----------------------------------+
 | Equation | `@eq-stddev`  | At end of display equation:      |
@@ -440,4 +440,3 @@ You can also define custom column spans for figures, tables, or other content.
 See the documentation on [Article Layout](/docs/authoring/article-layout.qmd) for additional details.
 
 {{< include _footer.md >}}
-

--- a/docs/get-started/computations/jupyter.qmd
+++ b/docs/get-started/computations/jupyter.qmd
@@ -240,7 +240,7 @@ Copy and paste the code below into the notebook if you want to try them locally.
 
 ``` python
 #| label: fig-gapminder
-#| fig-cap: Life Expectancy and GDP
+#| fig-cap: "Life Expectancy and GDP"
 #| fig-subcap:
 #|   - "Gapminder: 1957"
 #|   - "Gapminder: 2007"
@@ -272,7 +272,7 @@ Let's discuss some of the new options used here.
 You've seen `fig-cap` before but we've now added a `fig-subcap` option.
 
 ``` python
-#| fig-cap: Life Expectancy and GDP 
+#| fig-cap: "Life Expectancy and GDP"
 #| fig-subcap:
 #|   - "Gapminder: 1957"
 #|   - "Gapminder: 2007"

--- a/docs/get-started/computations/text-editor.qmd
+++ b/docs/get-started/computations/text-editor.qmd
@@ -8,7 +8,6 @@ editor_options:
 
 {{< include ../_tool-chooser.md >}}
 
-
 ## Overview
 
 Quarto has a wide variety of options available for controlling how code and computational output appear within rendered documents.
@@ -17,13 +16,17 @@ In this tutorial we'll take a `.qmd` file that has some numeric output and plots
 This tutorial will make use of the `matplotlib` and `plotly` Python packages.
 The commands you can use to install them are given in the table below.
 
-+-------------+-------------------------------------------------------------+
-| Platform    | Commands                                                    |
-+=============+=============================================================+
-| Mac/Linux   |     python3 -m pip install jupyter matplotlib plotly pandas |
-+-------------+-------------------------------------------------------------+
-| Windows     |     py -m pip install jupyter matplotlib plotly pandas      |
-+-------------+-------------------------------------------------------------+
++-----------+---------------------------------------------------------+
+| Platform  | Commands                                                |
++===========+=========================================================+
+| Mac/Linux | ```                                                     |
+|           | python3 -m pip install jupyter matplotlib plotly pandas |
+|           | ```                                                     |
++-----------+---------------------------------------------------------+
+| Windows   | ```                                                     |
+|           | py -m pip install jupyter matplotlib plotly pandas      |
+|           | ```                                                     |
++-----------+---------------------------------------------------------+
 
 If you want to follow along step-by-step in your own environment, create a `computations.qmd` file and copy the following content into it.
 
@@ -203,7 +206,7 @@ Copy and paste this code into `computations.qmd` if you want to try them locally
 
 ``` python
 #| label: fig-gapminder
-#| fig-cap: Life Expectancy and GDP
+#| fig-cap: "Life Expectancy and GDP"
 #| fig-subcap:
 #|   - "Gapminder: 1957"
 #|   - "Gapminder: 2007"
@@ -234,7 +237,7 @@ Let's discuss some of the new options used here.
 You've seen `fig-cap` before but we've now added a `fig-subcap` option:
 
 ``` python
-#| fig-cap: Life Expectancy and GDP 
+#| fig-cap: "Life Expectancy and GDP"
 #| fig-subcap:
 #|   - "Gapminder: 1957"
 #|   - "Gapminder: 2007"
@@ -261,4 +264,3 @@ This allows our figure display to span out beyond the normal body text column.
 See the documentation on [Article Layout](/docs/authoring/article-layout.qmd) to learn about all of the available layout options.
 
 {{< include _footer.md >}}
-

--- a/docs/get-started/computations/vscode.qmd
+++ b/docs/get-started/computations/vscode.qmd
@@ -8,7 +8,6 @@ editor_options:
 
 {{< include ../_tool-chooser.md >}}
 
-
 ## Overview
 
 Quarto has a wide variety of options available for controlling how code and computational output appear within rendered documents.
@@ -17,13 +16,17 @@ In this tutorial we'll take a `.qmd` file that has some numeric output and plots
 This tutorial will make use of the `matplotlib` and `plotly` Python packages.
 The commands you can use to install them are given in the table below.
 
-+--------------+-------------------------------------------------------+
-| Platform     | Commands                                              |
-+==============+=======================================================+
-| Mac/Linux    |     python3 -m pip install jupyter matplotlib plotly  |
-+--------------+-------------------------------------------------------+
-| Windows      |     py -m pip install jupyter matplotlib plotly       |
-+--------------+-------------------------------------------------------+
++-----------+--------------------------------------------------+
+| Platform  | Commands                                         |
++===========+==================================================+
+| Mac/Linux | ```                                              |
+|           | python3 -m pip install jupyter matplotlib plotly |
+|           | ```                                              |
++-----------+--------------------------------------------------+
+| Windows   | ```                                              |
+|           | py -m pip install jupyter matplotlib plotly      |
+|           | ```                                              |
++-----------+--------------------------------------------------+
 
 If you want to follow along step-by-step in your own environment, create a `computations.qmd` file and copy the following content into it.
 
@@ -227,7 +230,7 @@ Copy and paste this code into `computations.qmd` if you want to try them locally
 
 ``` python
 #| label: fig-gapminder
-#| fig-cap: Life Expectancy and GDP
+#| fig-cap: "Life Expectancy and GDP"
 #| fig-subcap:
 #|   - "Gapminder: 1957"
 #|   - "Gapminder: 2007"
@@ -258,7 +261,7 @@ Let's discuss some of the new options used here.
 You've seen `fig-cap` before but we've now added a `fig-subcap` option:
 
 ``` python
-#| fig-cap: Life Expectancy and GDP 
+#| fig-cap: "Life Expectancy and GDP"
 #| fig-subcap:
 #|   - "Gapminder: 1957"
 #|   - "Gapminder: 2007"
@@ -285,5 +288,3 @@ This allows our figure display to span out beyond the normal body text column.
 See the documentation on [Article Layout](/docs/authoring/article-layout.qmd) to learn about all of the available layout options.
 
 {{< include _footer.md >}}
-
-

--- a/docs/prerelease/1.3/embed.qmd
+++ b/docs/prerelease/1.3/embed.qmd
@@ -69,13 +69,13 @@ Code cell options from the source Jupyter Notebook are propagated to the documen
 
 ```{.python filename="penguins.ipynb"}
 #| label: fig-bill-marginal
-#| fig-cap: Marginal distributions of bill dimensions
+#| fig-cap: "Marginal distributions of bill dimensions"
 #| fig-subcap: 
-#|   - Gentoo penguins tend to have thinner bills,
-#|   - and Adelie penguins tend to have shorter bills.
+#|   - "Gentoo penguins tend to have thinner bills,"
+#|   - "and Adelie penguins tend to have shorter bills."
 #| fig-alt:
-#|   - Density plot of bill depth by species.
-#|   - Density plot of bill length by species.
+#|   - "Density plot of bill depth by species."
+#|   - "Density plot of bill length by species."
 #| layout-ncol: 2
 
 sns.displot(penguins, 

--- a/index.qmd
+++ b/index.qmd
@@ -132,7 +132,7 @@ format:
 
 ```{{r}}
 #| label: fig-airquality
-#| fig-cap: Temperature and ozone level.
+#| fig-cap: "Temperature and ozone level."
 #| warning: false
 
 library(ggplot2)


### PR DESCRIPTION
Added quotes around captions and alt text where it was missing so the examples are consistent across various pages.

Here are a few I haven't touched though as I wasn't sure if I could just update the plain text version of these notebooks and I don't have Jupyter installed:

- https://github.com/quarto-dev/quarto-web/blob/main/docs/blog/posts/2023-03-17-jupyter-cell-embedding/penguins.ipynb
- https://github.com/quarto-dev/quarto-web/blob/main/docs/get-started/authoring/_notebooks/crossref.ipynb
- https://github.com/quarto-dev/quarto-web/blob/main/docs/prerelease/1.3/penguins.ipynb

And these two screenshots (and their corresponding alt texts):

- https://github.com/quarto-dev/quarto-web/blob/main/docs/tools/images/jupyter-lab-output-options.png (Note that this screenshot doesn't match the plain text version underneath it, which has the quotes for the caption: https://quarto.org/docs/tools/jupyter-lab.html#plain-text-editing.)
- https://github.com/quarto-dev/quarto-web/blob/main/docs/tools/images/vscode-cell-options.png

Additionally, the screenshot above https://quarto.org/docs/tools/jupyter-lab.html doesn't match the plain text version which has the quotes for the caption.