### PR TITLE
Updated RStudio version and link to posit.co

### DIFF
--- a/docs/faq/rmarkdown.qmd
+++ b/docs/faq/rmarkdown.qmd
@@ -92,9 +92,9 @@ Quarto v1.0 was [announced at rstudio::conf(2022)](https://www.rstudio.com/blog/
 
 ### Does the RStudio IDE support Quarto?
 
-Yes! You need to use the [latest release](https://rstudio.com/products/rstudio/download/) of RStudio (v2022.07), which includes support for [editing and preview of Quarto documents](https://quarto.org/docs/tools/rstudio.html).
+Yes! You need to use RStudio v2022.07 or a later version, which includes support for [editing and preview of Quarto documents](https://quarto.org/docs/tools/rstudio.html).
 
-You can download RStudio v2022.07 from <https://rstudio.com/products/rstudio/download/>.
+You can download the latest release (v2023.03) of RStudio v2023.03 from <https://posit.co/download/rstudio-desktop/>.
 
 ### Does Posit Connect support Quarto?
 

--- a/docs/get-started/authoring/rstudio.qmd
+++ b/docs/get-started/authoring/rstudio.qmd
@@ -14,7 +14,7 @@ In this tutorial we'll show you how to author Quarto documents in RStudio.
 In particular, we'll discuss the various document formats you can produce with the same source code and show you how to add components like table of contents, equations, citations, etc.
 The [visual markdown editor](/docs/visual-editor/) in RStudio makes many of these tasks easier so we'll highlight its use in this tutorial, but note that it's possible to accomplish these tasks in the source editor as well.
 
-If you would like to follow along step-by-step in your own environment, make sure that you have the [latest release](https://rstudio.com/products/rstudio/download/) of RStudio (v2022.07), which you can download [here](https://rstudio.com/products/rstudio/download/), installed.
+If you would like to follow along step-by-step in your own environment, make sure that you have the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio (v2023.03), which you can download [here](https://posit.co/download/rstudio-desktop/), installed.
 
 ## Output Formats
 

--- a/docs/get-started/computations/rstudio.qmd
+++ b/docs/get-started/computations/rstudio.qmd
@@ -23,7 +23,7 @@ We recommend also checking the box for **Render on Save** for a live preview of 
 <i class="bi bi-download"></i> [Download computations.qmd](_computations.qmd){download="computations.qmd"}
 :::
 
-Note that you will need to open this document in the [latest release](https://rstudio.com/products/rstudio/download/) of RStudio (v2022.07) which you can download [here](https://rstudio.com/products/rstudio/download/).
+Note that you will need to open this document in RStudio v2022.07 or a later version which you can download [here](https://quarto.org/docs/tools/rstudio.html).
 
 ## Cell Output
 

--- a/docs/get-started/hello/rstudio.qmd
+++ b/docs/get-started/hello/rstudio.qmd
@@ -25,10 +25,10 @@ This is the basic model for Quarto publishing---take a source document and rende
 
 If you would like to follow along step-by-step in your own environment, follow the steps outlined below.
 
-1.  Download and install the latest release of RStudio (v2022.07):
+1.  Download and install the latest release of RStudio (v2023.03):
 
     ::: {.callout appearance="minimal"}
-    <i class="bi bi-download"></i> [Download RStudio v2022.07](https://rstudio.com/products/rstudio/download/)
+    <i class="bi bi-download"></i> [Download RStudio v2023.03](https://posit.co/download/rstudio-desktop/)
     :::
 
 2.  Be sure that you have installed the `tidyverse` and `palmerpenguins` packages:

--- a/docs/interactive/shiny/running.qmd
+++ b/docs/interactive/shiny/running.qmd
@@ -20,7 +20,7 @@ install.packages("rmarkdown")
 
 While you are developing an interactive document it will likely be most convenient to run within RStudio.
 
-Note that you need the [latest release](https://rstudio.com/products/rstudio/download/) of RStudio (v2022.07) in order to run Quarto interactive documents, which you can download here <https://rstudio.com/products/rstudio/download/>.
+Note that you need RStudio v2022.07 or a later version in order to run Quarto interactive documents. You can download the latest release (v2023.03) here <https://posit.co/download/rstudio-desktop/>.
 
 Click the **Run Document** button while editing a Shiny interactive document to render and view the document within the IDE:
 

--- a/docs/tools/_rstudio.md
+++ b/docs/tools/_rstudio.md
@@ -1,9 +1,8 @@
-The [latest release](https://rstudio.com/products/rstudio/download/) of RStudio (v2022.07) includes support for editing and preview of Quarto documents.
+RStudio v2022.07 and later includes support for editing and preview of Quarto documents (the documentation below assumes you are using this build or a later version). 
 
-If you are using Quarto within RStudio it is **strongly** recommended that you use this version (the documentation below assumes you are using this build).
+If you are using Quarto within RStudio it is **strongly** recommended that you use the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio (v2023.03).
 
-You can download RStudio v2022.07 from <https://rstudio.com/products/rstudio/download/>.
-
+You can download RStudio v2023.03 from <https://posit.co/download/rstudio-desktop/>.
 
 ### Creating Documents
 

--- a/docs/visual-editor/index.qmd
+++ b/docs/visual-editor/index.qmd
@@ -20,11 +20,11 @@ Note that you can switch between source and visual mode at any time (editing loc
 
 ## Getting Started
 
-The Quarto visual editor is currently available as a feature of the [RStudio IDE](https://rstudio.com/products/rstudio/download/). The visual editor will eventually also be made available in standalone form.
+The Quarto visual editor is currently available as a feature of the [RStudio IDE](https://posit.co/download/rstudio-desktop/). The visual editor will eventually also be made available in standalone form.
 
-To get started with the visual editor, download the latest release of RStudio (v2022.07) for your platform from:
+To get started with the visual editor, download the latest release of RStudio (v2023.03) for your platform from:
 
-<https://rstudio.com/products/rstudio/download/>
+<https://posit.co/download/rstudio-desktop/>
 
 ## Using the Editor
 


### PR DESCRIPTION
Newest RStudio version 2023.03 is now mentioned and recommended. Clarified that at least v2022.07 is required to work with some of the integrated Quarto features. Links updated to new posit.co website.