### PR TITLE
Fixed typo in Black-Scholes equation

### DIFF
--- a/docs/authoring/cross-references.qmd
+++ b/docs/authoring/cross-references.qmd
@@ -231,7 +231,7 @@ Black-Scholes (@eq-black-scholes) is a mathematical model that seeks to explain 
 
 $$
 \frac{\partial \mathrm C}{ \partial \mathrm t } + \frac{1}{2}\sigma^{2} \mathrm S^{2}
-\frac{\partial^{2} \mathrm C}{\partial \mathrm C^2}
+\frac{\partial^{2} \mathrm C}{\partial \mathrm S^2}
   + \mathrm r \mathrm S \frac{\partial \mathrm C}{\partial \mathrm S}\ =
   \mathrm r \mathrm C 
 $$ {#eq-black-scholes}


### PR DESCRIPTION
"C" should be "S". See https://en.wikipedia.org/wiki/Black%E2%80%93Scholes_equation.