### PR TITLE
fix: qmd title inconsistent with screenshots

### DIFF
--- a/docs/get-started/hello/rstudio/_hello.qmd
+++ b/docs/get-started/hello/rstudio/_hello.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Penguins, meet Quarto!"
+title: "Hello, Quarto"
 format: html
 editor: visual
 ---


### PR DESCRIPTION
Fixes <https://github.com/quarto-dev/quarto-cli/issues/4973>

It appears screenshots for RStudio tutorial were updated last year with a different title, but the Quarto document for user to download was not.