### PR TITLE
Update references to old Quarto versions and RStudio versions

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -1,0 +1,3 @@
+rstudio:
+  min_version: "v2022.07"
+  current_release: "v2023.03"

--- a/docs/authoring/diagrams.qmd
+++ b/docs/authoring/diagrams.qmd
@@ -21,8 +21,6 @@ flowchart LR
 
 As illustrated above, diagrams are embedded using `{mermaid}` and `{dot}` executable cells (`dot` is underlying language of Graphviz)
 
-Diagrams are a recent addition to Quarto---you should make sure to update to the [very latest](/docs/get-started/) version of Quarto (v0.9.518 or higher) before trying out the features described below.
-
 ::: callout-note
 For print output formats like `pdf` or `docx`, diagram rendering makes use use of the Chrome or Edge web browser to create a high-quality PNG. Quarto can automatically use an existing version of Chrome or Edge on your system, or alternatively if you don't have either installed, can use a lighter-weight library version of Chrome (see [Chrome Install](#chrome-install) below for details).
 :::

--- a/docs/authoring/videos.qmd
+++ b/docs/authoring/videos.qmd
@@ -2,12 +2,6 @@
 title: "Videos"
 ---
 
-::: callout-note
-## Quarto v1.2 Required
-
-Support for videos is a feature of Quarto v1.2. If you want to use this feature please download and install [Quarto v1.2](https://quarto.org/docs/download/) before proceeding.
-:::
-
 ## Overview
 
 You can embed videos in documents using the `{{{< video >}}}` shortcode. For example, here we embed a YouTube video:

--- a/docs/blog/posts/2022-07-25-feature-extensions/index.qmd
+++ b/docs/blog/posts/2022-07-25-feature-extensions/index.qmd
@@ -20,8 +20,6 @@ Quarto Extensions are a powerful way to modify or extend the behavior of Quarto,
 
 -   [Formats](../../../extensions/formats.qmd) enable you to create new output formats by bundling together document options, templates, stylesheets, and other content.
 
-Extensions are a recently released Quarto feature so you should be sure to install the [very latest version](https://quarto.org/docs/get-started/) of Quarto (at least v1.0.36) if you want to try them out.
-
 Here are some examples of extensions developed and maintained by the core Quarto team:
 
 | **Extension**                                                        | **Description**                                                                                 |

--- a/docs/extensions/_extension-version.qmd
+++ b/docs/extensions/_extension-version.qmd
@@ -1,5 +1,0 @@
-::: {.callout appearance="minimal"}
-### Quarto v1.2 Required
-
-If you are using or developing extensions you should [update to Quarto v1.2](https://quarto.org/docs/download/), which includes significant improvements to the extension API. Many extensions are also likely to require Quarto v1.2.
-:::

--- a/docs/extensions/lua-api.qmd
+++ b/docs/extensions/lua-api.qmd
@@ -54,7 +54,7 @@ Complete documentation for the Pandoc Lua API can be found in the [Lua Filters](
 
 ### Utility Functions
 
-Various utility functions are provided, the most of important of which is the `quarto.utils.dump()` function (indispensable for debugging).
+Various utility functions are provided:
 
 | Function                          | Description                                                                                                                                                                                    |
 |-------------------|-----------------------------------------------------|
@@ -62,15 +62,7 @@ Various utility functions are provided, the most of important of which is the `q
 | `quarto.utils.dump(obj)`          | Dump a text representation of the passed object to stdout.                                                                                                                                     |
 | `quarto.utils.resolve_path(path)` | Compute the full path to a file that is installed alongside your extension's Lua script. This is useful for *internal* resources that your filter needs but should not be visible to the user. |
 
-For example, you can dump an element passed to a filter function as follows:
-
-``` lua
-function Div(el)
-  quarto.utils.dump(el)
-end
-```
-
-Note that newer versions of Quarto (v1.1.251 and higher) include the [pandoc-lua-logging](https://github.com/wlupton/pandoc-lua-logging) library, which should be used in preference to the dump function. For example:
+Quarto includes the [pandoc-lua-logging](https://github.com/wlupton/pandoc-lua-logging) library, which should be used in preference to the dump function. For example, you can examine an element passed to a filter function as follows:
 
 ``` lua
 function Div(el)

--- a/docs/extensions/lua.qmd
+++ b/docs/extensions/lua.qmd
@@ -40,7 +40,7 @@ Some additional learning resources you might find useful include:
 
 ### Quarto Preview
 
-Beginning with v1.2, `quarto preview` is now aware of Lua source files within extensions, and will automatically reload the preview whenever a Lua source file changes.
+Quarto preview, `quarto preview`, is aware of Lua source files within extensions, and will automatically reload the preview whenever a Lua source file changes.
 
 This makes it very easy to incrementally develop and debug Lua code (especially when combined with the [native](#native-format) format a described below). Live reloading for Lua files will work no matter what source code editor you are using (VS Code, RStudio, Neovim, etc.).
 
@@ -66,7 +66,7 @@ Diagnostics check for many common errors including failing to check for `nil`, u
 
 To get started with using VS Code for Lua extension development, install the following software:
 
-1.  Install the latest version of [Quarto v1.2](https://quarto.org/docs/download/)
+1.  Install the latest version (v1.2 or greater) of [Quarto](https://quarto.org/docs/download/)
 
 2.  Install the latest version (v1.40.0 or greater) of the [Quarto VS Code Extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto).
 
@@ -81,12 +81,6 @@ There are many options available for configuring Lua completion and diagnostics.
 Use the functions in the `quarto.log` module to add diagnostic logging to your extension. You can use both temporary logging calls to debug a particular problem as well as add logging calls that are always present but only activated when the `--trace` flag is passed to `quarto render` or `quarto preview`.
 
 The `quarto.log` module is based on the [pandoc-lua-logging](https://github.com/wlupton/pandoc-lua-logging) project from [\@wlupton](https://github.com/wlupton). You'll recognize the functions described below from that module (e.g. `logging.output()`, `logging.warning()`, etc). For documentation on using all of the logging functions see the project [README](https://github.com/wlupton/pandoc-lua-logging) file.
-
-::: callout-note
-#### Version Requirements
-
-Note that the `quarto.log` module requires Quarto v1.2. If you are using an earlier version you can still use the `quarto.utils.dump()` function for logging as described [here](lua-api.qmd#utility-functions).
-:::
 
 ### quarto.log.output
 

--- a/docs/extensions/project-types.qmd
+++ b/docs/extensions/project-types.qmd
@@ -37,7 +37,7 @@ If you are using custom project types within VS Code or RStudio, only the very l
 
 -   For the Quarto VS Code Extension, use [version 1.45](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) or greater.
 
--   For RStudio, use the current daily build of [version 2022.12](https://dailies.rstudio.com/).
+-   For RStudio, use [version 2022.12](https://posit.co/download/rstudio-desktop/) or higher.
 
 Please be sure to update your version(s) of these tools before proceeding.
 

--- a/docs/faq/rmarkdown.qmd
+++ b/docs/faq/rmarkdown.qmd
@@ -92,9 +92,9 @@ Quarto v1.0 was [announced at rstudio::conf(2022)](https://www.rstudio.com/blog/
 
 ### Does the RStudio IDE support Quarto?
 
-Yes! You need to use RStudio v2022.07 or a later version, which includes support for [editing and preview of Quarto documents](https://quarto.org/docs/tools/rstudio.html).
+Yes! You need to use RStudio {{< var rstudio.min_version >}} or a later version, which includes support for [editing and preview of Quarto documents](https://quarto.org/docs/tools/rstudio.html).
 
-You can download the latest release (v2023.03) of RStudio v2023.03 from <https://posit.co/download/rstudio-desktop/>.
+You can download the latest release ({{< var rstudio.current_release >}}) of RStudio {{< var rstudio.current_release >}} from <https://posit.co/download/rstudio-desktop/>.
 
 ### Does Posit Connect support Quarto?
 

--- a/docs/get-started/authoring/rstudio.qmd
+++ b/docs/get-started/authoring/rstudio.qmd
@@ -14,7 +14,7 @@ In this tutorial we'll show you how to author Quarto documents in RStudio.
 In particular, we'll discuss the various document formats you can produce with the same source code and show you how to add components like table of contents, equations, citations, etc.
 The [visual markdown editor](/docs/visual-editor/) in RStudio makes many of these tasks easier so we'll highlight its use in this tutorial, but note that it's possible to accomplish these tasks in the source editor as well.
 
-If you would like to follow along step-by-step in your own environment, make sure that you have the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio (v2023.03), which you can download [here](https://posit.co/download/rstudio-desktop/), installed.
+If you would like to follow along step-by-step in your own environment, make sure that you have the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio ({{< var rstudio.current_release >}}), which you can download [here](https://posit.co/download/rstudio-desktop/), installed.
 
 ## Output Formats
 
@@ -432,4 +432,3 @@ Otherwise, you can download a completed version of `computations.qmd` below.
 :::
 
 {{< include _footer.md >}}
-

--- a/docs/get-started/computations/rstudio.qmd
+++ b/docs/get-started/computations/rstudio.qmd
@@ -23,7 +23,7 @@ We recommend also checking the box for **Render on Save** for a live preview of 
 <i class="bi bi-download"></i> [Download computations.qmd](_computations.qmd){download="computations.qmd"}
 :::
 
-Note that you will need to open this document in RStudio v2022.07 or a later version which you can download [here](https://quarto.org/docs/tools/rstudio.html).
+Note that you will need to open this document in RStudio {{< var rstudio.min_version >}} or later, which you can download [here](https://posit.co/download/rstudio-desktop/).
 
 ## Cell Output
 
@@ -311,5 +311,4 @@ Otherwise, you can download a completed version of `computations.qmd` below.
 :::
 
 {{< include _footer.md >}}
-
 

--- a/docs/get-started/hello/rstudio.qmd
+++ b/docs/get-started/hello/rstudio.qmd
@@ -25,10 +25,10 @@ This is the basic model for Quarto publishing---take a source document and rende
 
 If you would like to follow along step-by-step in your own environment, follow the steps outlined below.
 
-1.  Download and install the latest release of RStudio (v2023.03):
+1.  Download and install the latest release of RStudio ({{< var rstudio.current_release >}}):
 
     ::: {.callout appearance="minimal"}
-    <i class="bi bi-download"></i> [Download RStudio v2023.03](https://posit.co/download/rstudio-desktop/)
+    <i class="bi bi-download"></i> [Download RStudio {{< var rstudio.current_release >}}](https://posit.co/download/rstudio-desktop/)
     :::
 
 2.  Be sure that you have installed the `tidyverse` and `palmerpenguins` packages:
@@ -139,4 +139,3 @@ The Render button encapsulates these actions and executes them in the right orde
 ![](images/rstudio-qmd-how-it-works.png){.border fig-alt="Workflow diagram starting with a qmd file, then knitr, then md, then pandoc, then PDF, MS Word, or HTML." fig-align="center"}
 
 {{< include _footer.md >}}
-

--- a/docs/interactive/shiny/running.qmd
+++ b/docs/interactive/shiny/running.qmd
@@ -20,7 +20,7 @@ install.packages("rmarkdown")
 
 While you are developing an interactive document it will likely be most convenient to run within RStudio.
 
-Note that you need RStudio v2022.07 or a later version in order to run Quarto interactive documents. You can download the latest release (v2023.03) here <https://posit.co/download/rstudio-desktop/>.
+Note that you need RStudio {{< var rstudio.min_version >}} or a later version in order to run Quarto interactive documents. You can download the latest release ({{< var rstudio.current_release >}}) here <https://posit.co/download/rstudio-desktop/>.
 
 Click the **Run Document** button while editing a Shiny interactive document to render and view the document within the IDE:
 

--- a/docs/journals/templates.qmd
+++ b/docs/journals/templates.qmd
@@ -171,12 +171,6 @@ toc.html
 
 ## Revealjs Partials
 
-::: callout-note
-### Quarto v1.2 Required
-
-Revealjs partials are only available in Quarto v1.2, which you can download at <https://quarto.org/docs/download/>.
-:::
-
 View the Quarto Revealjs template and partials [source code here](https://github.com/quarto-dev/quarto-cli/tree/main/src/resources/formats/revealjs/pandoc). Note that `revealjs.template` is a copy of the complete Pandoc template that the Quarto template and partials is based upon.
 
 template.html

--- a/docs/output-formats/_ssg-intro.qmd
+++ b/docs/output-formats/_ssg-intro.qmd
@@ -1,12 +1,4 @@
 
-::: callout-note
-## Quarto v1.2 Required
-
-Support for {{< meta ssg-name >}} websites is a feature of Quarto v1.2. If you want to use this feature please download and install [Quarto v1.2](https://quarto.org/docs/download/) before proceeding.
-
-If you are running the Quarto [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=quarto.quarto) you should also be sure to have the latest version of that installed (v1.41.0 or greater).
-:::
-
 ## Overview
 
 {{< meta ssg-description >}}. Pages in {{< meta ssg-name >}} websites are typically written in plain markdown, so don't have a straightforward way to automatically and reproducibly incorporate computational output.

--- a/docs/output-formats/html-basics.qmd
+++ b/docs/output-formats/html-basics.qmd
@@ -219,10 +219,6 @@ def fizz_buzz(num):
 
 ### Tabset Groups
 
-::: callout-note
-Tabset groups are a new feature of [Quarto v1.1](https://quarto.org/docs/download/) so please be sure you've installed that version before attempting to use them.
-:::
-
 If you have multiple tabsets that include the same tab names, you can define a tabset `group`. Tabs within a `group` are all switched together (so in the example above once a reader switches to R or Python in one tabset the others will follow along). For example:
 
 ``` markdown

--- a/docs/output-formats/html-code.qmd
+++ b/docs/output-formats/html-code.qmd
@@ -203,10 +203,6 @@ code-block-border-left: "#31BAE9"
 
 ## Code Filename
 
-::: callout-note
-Code filenames are a new feature of [Quarto v1.1](https://quarto.org/docs/download/) so please be sure you've installed that version before attempting to use them.
-:::
-
 Use the `filename` attribute on code blocks If you are documenting the contents of a file and want to be especially clear about the name of the file the code is associated with.
 
 For example, the following code:

--- a/docs/output-formats/html-themes.qmd
+++ b/docs/output-formats/html-themes.qmd
@@ -265,7 +265,7 @@ The following Sass Variables can be specified within SCSS files (note that these
 
 #### Code Copy
 
-In Quarto v1.2, you can also customize the colors of the button which appears for `code-copy: true` with the following variables:
+You can also customize the colors of the button which appears for `code-copy: true` with the following variables:
 
 +-------------------------------+---------------------------------------------------------------------------+
 | Variable                      | Notes                                                                     |
@@ -286,12 +286,6 @@ In Quarto v1.2, you can also customize the colors of the button which appears fo
 +---------------+-------------------------------------------------------------------------------------------------+
 
 ### Table of Contents
-
-::: callout-note
-### Quarto v1.2 Required
-
-Sass variables to control the appearance of the the table of contents are available only in Quarto v1.2 or greater, which you can download at <https://quarto.org/docs/download/>.
-:::
 
 +-----------------------------------+------------------------------------------------------------------------+
 | Variable                          | Notes                                                                  |

--- a/docs/output-formats/pdf-engine.qmd
+++ b/docs/output-formats/pdf-engine.qmd
@@ -19,13 +19,13 @@ To install TinyTeX, use the following command:
 quarto install tinytex
 ```
 
-Note that as of [Quarto v1.2](https://quarto.org/docs/download/), TinyTeX is not installed to the system `PATH` so will not affect other applications that use TeX. If you want to use TinyTeX with other applications, add the `--update-path` flag when installing (this will add TinyTex to the system path):
+TinyTeX is not installed to the system `PATH` so will not affect other applications that use TeX. If you want to use TinyTeX with other applications, add the `--update-path` flag when installing (this will add TinyTex to the system path):
 
 ``` {.bash filename="Terminal"}
 quarto install tinytex --update-path
 ```
 
-If you are using Quarto v1.2 and already have another installation of TeX that you prefer to use with Quarto, add the `latex-tinytex: false` in your project or document front matter to prevent Quarto from using its internal version.
+If you already have another installation of TeX that you prefer to use with Quarto, add the `latex-tinytex: false` in your project or document front matter to prevent Quarto from using its internal version.
 
 If you prefer TeX Live, you can find instructions for installing it here: <https://tug.org/texlive/>.
 

--- a/docs/presentations/revealjs/advanced.qmd
+++ b/docs/presentations/revealjs/advanced.qmd
@@ -27,12 +27,6 @@ title-slide-attributes:
 
 ### Custom Template
 
-::: {.callout-note}
-### Quarto v1.2 Required
-
-Custom templates for Reveal title slides are only available in Quarto v1.2, which you can download at <https://quarto.org/docs/download/>.
-:::
-
 You can replace the default title slide entirely with your own template. To do this, specify a `title-slide.html` [template partial](/docs/journals/templates.qmd#template-partials). For example:
 
 ```yaml

--- a/docs/projects/environment.qmd
+++ b/docs/projects/environment.qmd
@@ -2,12 +2,6 @@
 title: "Environment Variables"
 ---
 
-::: callout-note
-#### Quarto v1.2 Required
-
-Project environment variables are a new feature in Quarto v1.2. Before attempting to try it out, please download and install Quarto v1.2 from  <https://quarto.org/docs/download/>.
-:::
-
 ## Overview
 
 You may have one more more environment variables that you want to make sure are set whenever you render your project. For example, you might be using environment variables to:

--- a/docs/projects/profiles.qmd
+++ b/docs/projects/profiles.qmd
@@ -3,12 +3,6 @@ title: "Project Profiles"
 editor: visual
 ---
 
-::: callout-note
-#### Quarto v1.2 Required
-
-Project profiles are a new feature in Quarto v1.2. Before attempting to try it out, please download and install Quarto v1.2 from  <https://quarto.org/docs/download/>.
-:::
-
 ## Overview
 
 Project profiles enable you to adapt the options, environment, and content of your projects for different scenarios. For example:

--- a/docs/reference/projects/_options.md
+++ b/docs/reference/projects/_options.md
@@ -33,12 +33,6 @@ Available `preview` options include:
 
 ### Serve
 
-::: {.callout-note}
-### Quarto v1.2 Required
-
-The `preview: serve` options are only available in Quarto v1.2, which you can download at <https://quarto.org/docs/download/>.
-:::
-
 If you are creating a project extension for another publishing system that includes its own preview server (for example, [Hugo](../../output-formats/hugo.qmd) or [Docusaurus](../../output-formats/docusaurus.qmd)) then use the `preview: serve` options to customize the behavior of the preview server.
 
 ::: {#table-serve}

--- a/docs/tools/_rstudio.md
+++ b/docs/tools/_rstudio.md
@@ -1,8 +1,8 @@
-RStudio v2022.07 and later includes support for editing and preview of Quarto documents (the documentation below assumes you are using this build or a later version). 
+RStudio {{< var rstudio.min_version >}} and later includes support for editing and preview of Quarto documents (the documentation below assumes you are using this build or a later version). 
 
-If you are using Quarto within RStudio it is **strongly** recommended that you use the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio (v2023.03).
+If you are using Quarto within RStudio it is **strongly** recommended that you use the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio ({{< var rstudio.current_release >}}).
 
-You can download RStudio v2023.03 from <https://posit.co/download/rstudio-desktop/>.
+You can download RStudio {{< var rstudio.current_release >}} from <https://posit.co/download/rstudio-desktop/>.
 
 ### Creating Documents
 

--- a/docs/tools/rstudio.qmd
+++ b/docs/tools/rstudio.qmd
@@ -52,7 +52,6 @@ If you have incorrect YAML it will also be highlighted when documents are saved:
 
 ![](images/rstudio-yaml-diagnostics.png){.border fig-alt="Quarto document YAML metadata with an incorrect option underlined in red."}
 
-Note that YAML intelligence features require version 0.9.44 or later of the [Quarto CLI](https://quarto.org).
 
 ## R Package
 

--- a/docs/tools/vscode.qmd
+++ b/docs/tools/vscode.qmd
@@ -145,8 +145,6 @@ If you have incorrect YAML it will also be highlighted when documents are saved:
 
 ![](images/vscode-yaml-diagnostics.png){.border fig-alt="Quarto document YAML metadata with an incorrect option underlined in red."}
 
-Note that YAML intelligence features require version 0.9.44 or later of the [Quarto CLI](https://quarto.org).
-
 ## Code Snippets
 
 Code snippets are templates that make it easier to enter repeating code patterns (e.g. code blocks, callouts, divs, etc.). Execute the **Insert Snippet** command within a Quarto document to insert a markdown snippet:

--- a/docs/visual-editor/index.qmd
+++ b/docs/visual-editor/index.qmd
@@ -22,7 +22,7 @@ Note that you can switch between source and visual mode at any time (editing loc
 
 The Quarto visual editor is currently available as a feature of the [RStudio IDE](https://posit.co/download/rstudio-desktop/). The visual editor will eventually also be made available in standalone form.
 
-To get started with the visual editor, download the latest release of RStudio (v2023.03) for your platform from:
+To get started with the visual editor, download the latest release of RStudio ({{< var rstudio.current_release >}}) for your platform from:
 
 <https://posit.co/download/rstudio-desktop/>
 

--- a/docs/websites/website-navigation.qmd
+++ b/docs/websites/website-navigation.qmd
@@ -170,12 +170,6 @@ For more information on controlling the appearance of the side navigation using 
 
 ### Auto Generation
 
-::: callout-note
-## Quarto v1.2 Required
-
-The sidebar auto generation feature described below is available in Quarto v1.2, which you can download from <https://quarto.org/docs/download/>.
-:::
-
 Above we describe how to explicitly populate the `contents` of your sidebar with navigation items. You can also automatically generate sidebar navigation from the filesystem. The most straightforward way to do this is to specify the `auto: true` option as follows:
 
 ``` yaml


### PR DESCRIPTION
Remove references to require Quarto versions <= 1.2

Standardize references to Rstudio versions using variables.

Closes [#4463](https://github.com/quarto-dev/quarto-cli/issues/4463)