### PR TITLE
State unique affiliations (?) in authors.qmd

### DIFF
--- a/docs/journals/authors.qmd
+++ b/docs/journals/authors.qmd
@@ -18,7 +18,7 @@ Quarto's answer to this challenge is two-fold:
 Below we'll explore these facilities in more detail from the standpoint of both template authors and article writers.
 
 ::: callout-note
-Note that while there is a great deal of variety afforded in how authors and affiliations are specified, for a given Journal `template.qmd` you will likely have a preferred approach, and its good form to seed the template with an example of this approach.
+Note that while there is a great deal of variety afforded in how authors and affiliations are specified, for a given Journal `template.qmd` you will likely have a preferred approach, and it's good form to seed the template with an example of this approach.
 :::
 
 ## Author Metadata
@@ -58,7 +58,7 @@ The `authors` metadata key contains the normalized author data structure. Affili
 
 ### affiliations
 
-The `affiliations` metadata key contains the normalized affiliation data structure. Ids are automatically assigned if not defined. Affiliations contain no reference to their authors, so are typically not used by templates to output affiliation data. The order the affiliations appear in the metadata will be preserved.
+The `affiliations` metadata key contains the normalized affiliation data structure. Ids are automatically assigned if not defined. Affiliations contain no reference to their authors, so are typically not used by templates to output affiliation data. The order the affiliations appear in the metadata will be preserved. Duplicate affiliations are removed.
 
 ### by-author
 


### PR DESCRIPTION
- trivial typo
- clarify that only unique affiliations are listed in affiliations – I assume this is the case, but it's not explicitly stated