### PR TITLE
docs: add GHA permission documentation

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -165,7 +165,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-This action will run whenever you push to the `main` branch of your repository. It will also run when you manually trigger the action from the **Actions** tab of your repository. The action will render your content and publish it to GitHub Pages, thus you need to ensure that GitHub Actions has permission to write to your repository. This is done by checking the **Read and write permissions** box in the **Actions** tab of your repository, under **Workflow permissions**.
+This action will run whenever you push to the `main` branch of your repository. It will also run when you manually trigger the action from the **Actions** tab of your repository. The action will render your content and publish it to GitHub Pages, thus you need to ensure that GitHub Actions has permission to write to your repository. This is done by checking the **Read and write permissions** box under **Workflow permissions** in the **Actions** section of your repository **Settings**.
 
 Once you've done this, check all of the newly created files (including the `_freeze` directory) into your repository and then push to GitHub. A GitHub Pages site will be created for your repository, and every time you push a new change to the repository it will be automatically rebuilt to reflect the change. Consult the **Pages** section of your repository **Settings** to see what the URL and publish status for your site is.
 

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -165,6 +165,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+This action will run whenever you push to the `main` branch of your repository. It will also run when you manually trigger the action from the **Actions** tab of your repository. The action will render your content and publish it to GitHub Pages, thus you need to ensure that GitHub Actions has permission to write to your repository. This is done by checking the **Read and write permissions** box in the **Actions** tab of your repository, under **Workflow permissions**.
+
 Once you've done this, check all of the newly created files (including the `_freeze` directory) into your repository and then push to GitHub. A GitHub Pages site will be created for your repository, and every time you push a new change to the repository it will be automatically rebuilt to reflect the change. Consult the **Pages** section of your repository **Settings** to see what the URL and publish status for your site is.
 
 {{< include _github-action-executing-code.md >}}


### PR DESCRIPTION
This PR add[^1] a description of the publish action and add a statement about specifying/checking the write permission for GitHub Actions to write in `gh-pages`.

Default was changed to "read-only" few months back, thus it requires to add write permission for newly created repository.


[^1]: in the following page/section: <https://quarto.org/docs/publishing/github-pages.html#publish-action>