### PR TITLE
Update shortcodes-and-filters.yml with critic-markup filter

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -252,3 +252,9 @@
   author: "[Dialoa/Julien Dutant](https://github.com/dialoa/)"
   description: |
       Handle self-citing bibliographies.
+
+- name: Critic-markup
+  path: https://github.com/mloubout/critic-markup
+  author: "[Mathias Louboutin](https://github.com/mloubout/)"
+  description: |
+      Handle critic markup syntx for tracking changes.

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -257,4 +257,4 @@
   path: https://github.com/mloubout/critic-markup
   author: "[Mathias Louboutin](https://github.com/mloubout/)"
   description: |
-      Handle critic markup syntx for tracking changes.
+      Handle critic markup syntax for tracking changes.


### PR DESCRIPTION
Here is a filter I made to handle critic markup syntax that we use extensively for academic writing since it allows us to easily track contributors' modifications.

There are a few things that could be added such as options to choose which version to export but I think this would still be a good addition to the community.

Here is the rendered example for illustration

https://mloubout.github.io/critic-markup/