### PR TITLE
Fix typo in title of extension

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -10,7 +10,7 @@
   description: |
     PDF format for creating letters.
 
-- name: hikmax-pdf
+- name: hikmah-pdf
   path: https://github.com/andrewheiss/hikmah-academic-quarto
   author: "[andrewheiss](https://github.com/andrewheiss)"
   description: |


### PR DESCRIPTION
Changed "hikmax" to "hikmah"

(addresses https://github.com/andrewheiss/hikmah-academic-quarto/issues/3)