### PR TITLE
Fix Notebook Embed docs to show example shortcodes

### DIFF
--- a/docs/authoring/notebook-embed.qmd
+++ b/docs/authoring/notebook-embed.qmd
@@ -14,7 +14,7 @@ You can include the output of an external Jupyter notebook in a Quarto document 
 
 You can use the following shortcode to embed the output of this cell:
 
-``` markdown
+```{.markdown shortcodes=false}
 {{< embed penguins.ipynb#fig-bill-scatter >}}
 ```
 
@@ -57,7 +57,7 @@ For example, to embed the output of a cell that you have given the tag `bill-rat
 
 You would use the following embed:
 
-``` markdown
+```{.markdown shortcodes=false}
 {{< embed penguins.ipynb#bill-ratio >}}
 ```
 
@@ -94,7 +94,7 @@ plt.show()
 
 When this cell is embedded:
 
-``` markdown
+```{.markdown shortcodes=false}
 {{< embed penguins.ipynb#fig-bill-marginal >}}
 ```
 
@@ -106,7 +106,7 @@ The following output is produced:
 
 You may include the code from a cell along with the output by using the `echo=true` option. For example, to include the code and the plot from the cell labelled `species-counts` the embed would be:
 
-``` markdown
+```{.markdown shortcodes=false}
 {{< embed penguins.ipynb#species-counts echo=true >}}
 ```
 


### PR DESCRIPTION
Needed to add `shortcodes=false` to examples