### PR TITLE
Update markdown-basics.qmd

### DIFF
--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -187,7 +187,7 @@ For HTML math processed using [MathJax](https://docs.mathjax.org/) (the default)
 
 ## Diagrams
 
-Quarto has native support for embedding [Mermaid](https://mermaid-js.github.io/mermaid/#/) and [Graphviz](https://graphviz.org/) diagrams. This enables you to create flowcharts, sequence diagrams, state diagrams, gnatt charts, and more using a plain text syntax inspired by markdown.
+Quarto has native support for embedding [Mermaid](https://mermaid-js.github.io/mermaid/#/) and [Graphviz](https://graphviz.org/) diagrams. This enables you to create flowcharts, sequence diagrams, state diagrams, Gantt charts, and more using a plain text syntax inspired by markdown.
 
 For example, here we embed a flowchart created using Mermaid:
 


### PR DESCRIPTION
corrected "Gantt" from "gnatt"; it's a proper noun