### PR TITLE
Fixed typo in fig-pos

### DIFF
--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -274,7 +274,7 @@ format:
 
 ```
 
-![](figure.png){fig.pos='b'}
+![](figure.png){fig-pos='b'}
 ````
 
 See [this article](https://www.latex-project.org/publications/2014-FMi-TUB-tb111mitt-float-placement.pdf) for additional details on LaTeX figure positioning.


### PR DESCRIPTION
Hi,
there is a small typo in LaTex figure position setting.