### PR TITLE
Added a filter extension in the shortcode-and-filters yml file

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -264,3 +264,10 @@
   author: "[Ute Hahn](https://github.com/ute/)"
   description: |
       Automatically search and replace strings in quarto documents upon rendering
+
+- name: interactive-sql
+  path: https://github.com/shafayetShafee/interactive-sql
+  author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee/)"
+  description: |
+      A Quarto filter to run SQL queries interactively from a SQLite database created at render time 
+      in html documents and Revealjs presentations.


### PR DESCRIPTION
I have added an extension [`interactive-sql`](https://github.com/shafayetShafee/interactive-sql) with which it is possible to run SQL queries interactively from an SQLite database created at render time in HTML documents and Revealjs presentations.