### PR TITLE
Add note that OJS won't work using the file protocol. 

### DIFF
--- a/docs/interactive/ojs/index.qmd
+++ b/docs/interactive/ojs/index.qmd
@@ -10,7 +10,7 @@ Quarto includes native support for [Observable JS](https://observablehq.com/@obs
 
 The creators of Observable JS (Observable, Inc.) run a hosted service at <https://observablehq.com/> where you can create and publish notebooks. Additionally, you can use Observable JS ("OJS") in standalone documents and websites via its [core libraries](https://github.com/observablehq). Quarto uses these libraries along with a [compiler](https://github.com/asg017/unofficial-observablehq-compiler/tree/beta) that is run at render time to enable the use of OJS within Quarto documents.
 
-OJS works in any Quarto document (plain markdown as well as Jupyter and Knitr documents). Just include your code in an `{ojs}` executable code block. Documents that use OJS need to run on the http:// or https:// protocol and not the file:// protocol. The rest of this article explains the basics of using OJS with Quarto.
+OJS works in any Quarto document (plain markdown as well as Jupyter and Knitr documents). Just include your code in an `{ojs}` executable code block. Documents that use OJS need to run on the `http://` or `https://` protocol and not the `file://` protocol. The rest of this article explains the basics of using OJS with Quarto.
 
 ## Example
 

--- a/docs/interactive/ojs/index.qmd
+++ b/docs/interactive/ojs/index.qmd
@@ -10,7 +10,7 @@ Quarto includes native support for [Observable JS](https://observablehq.com/@obs
 
 The creators of Observable JS (Observable, Inc.) run a hosted service at <https://observablehq.com/> where you can create and publish notebooks. Additionally, you can use Observable JS ("OJS") in standalone documents and websites via its [core libraries](https://github.com/observablehq). Quarto uses these libraries along with a [compiler](https://github.com/asg017/unofficial-observablehq-compiler/tree/beta) that is run at render time to enable the use of OJS within Quarto documents.
 
-OJS works in any Quarto document (plain markdown as well as Jupyter and Knitr documents). Just include your code in an `{ojs}` executable code block. The rest of this article explains the basics of using OJS with Quarto.
+OJS works in any Quarto document (plain markdown as well as Jupyter and Knitr documents). Just include your code in an `{ojs}` executable code block. Documents that use OJS need to run on the http:// or https:// protocol and not the file:// protocol. The rest of this article explains the basics of using OJS with Quarto.
 
 ## Example
 


### PR DESCRIPTION
Following this [discussion ](
https://github.com/quarto-dev/quarto-cli/discussions/5680)I thought an additional note in the OJS section about the file protocol not working might be useful. 

Let me know if there is a better place for this or if the discussion is sufficient and the note is overkill. 

My intended use case was to send HTML files for another user to open so this piece of information was important. 
