### PR TITLE
Add quarto revealjs illinois theme

### DIFF
--- a/docs/extensions/listings/revealjs-formats.yml
+++ b/docs/extensions/listings/revealjs-formats.yml
@@ -46,3 +46,9 @@
   author: "[Shafayet Khan Shafee](https://github.com/shafayetShafee)"
   description: |
     Beamer Metropolis like format for Revealjs.
+
+- name: illinois-revealjs
+  path: https://github.com/coatless/quarto-illinois
+  author: "[James Joseph Balamuta](https://github.com/coatless)"
+  description: |
+    University of Illinois Urbana-Champaign inspired theme for the reveal.js format based on Metropolis.


### PR DESCRIPTION
Adds to the custom revealjs slide format a University of Illinois Urbana-Champaign quarto extension theme.