### PR TITLE
fix: remove invalid `section-divs` option for `revealjs`

### DIFF
--- a/docs/reference/formats/presentations/revealjs.json
+++ b/docs/reference/formats/presentations/revealjs.json
@@ -42,10 +42,6 @@
         "description": "One or more CSS style sheets."
       },
       {
-        "name": "section-divs",
-        "description": "Wrap sections in `<section>` tags and attach identifiers to the enclosing `<section>`\nrather than the heading itself.\n"
-      },
-      {
         "name": "identifier-prefix",
         "description": "Specify a prefix to be added to all identifiers and internal links in HTML and\nDocBook output, and to footnote numbers in Markdown and Haddock output. \nThis is useful for preventing duplicate identifiers when generating fragments\nto be included in other pages.\n"
       },


### PR DESCRIPTION
This PR removes `section-divs` from `revealjs` reference guide page, indeed, headers are by design already embedded in `section` tags in Reveal.js, thus by design can't be disabled.

For short, `section-divs` is invalid and has no effect in `revealjs` format, which can lead to confusion for users.

<table>
<tr><th>HTML</th><th>Reveal.js</th></tr>
<tr>
<td>

<img width="1624" alt="Screenshot 2023-05-29 at 15 31 55" src="https://github.com/quarto-dev/quarto-web/assets/8896044/af90cf93-9838-445e-8ec9-f0abd568527b">

</td>
<td>
<img width="1624" alt="Screenshot 2023-05-29 at 15 34 53" src="https://github.com/quarto-dev/quarto-web/assets/8896044/feb8053d-3670-4496-9d48-c6627ada350f">
</td>
</tr>
</table>