### PR TITLE
Corrected text Update _computations-complete.qmd

### DIFF
--- a/docs/get-started/computations/_computations-complete.qmd
+++ b/docs/get-started/computations/_computations-complete.qmd
@@ -23,8 +23,8 @@ mean_hwy <- round(mean(mpg$hwy), 2)
 
 The average city mileage of the cars in our data is `r mean_cty` and the average highway mileage is `r mean_hwy`.
 
-The plots in Figure @fig-mpg show the relationship between city and highway mileage for 38 popular models of cars.
-In Figure @fig-mpg-1 the points are colored by the number of cylinders while in Figure @fig-mpg-2 the points are colored by engine displacement.
+The plots in @fig-mpg show the relationship between city and highway mileage for 38 popular models of cars.
+In @fig-mpg-1 the points are colored by the number of cylinders while in @fig-mpg-2 the points are colored by engine displacement.
 
 ```{r}
 #| label: fig-mpg


### PR DESCRIPTION
The plots in @fig-mpg show the relationship between city and highway mileage for 38 popular models of cars.
In @fig-mpg-1 the points are colored by the number of cylinders while in @fig-mpg-2 the points are colored by engine displacement.