### PR TITLE
add fancy-doc extension to custom-formats list of Quarto extensions

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -34,4 +34,8 @@
   description: |
     HTML format providing light and dark themes and suitable for documents, books and websites
  
- 
+- name: fancy-doc
+  path: https://github.com/DamonCharlesRoberts/fancy-doc
+  author: "[DamonCharlesRoberts](https://github.com/DamonCharlesRoberts/)"
+  description: |
+    A PDF format that brings LaTeX's `fancyhdr` package into Quarto for miscellaneous documents.


### PR DESCRIPTION
Adds the fancy-doc Quarto extension that contains a custom PDF template to the list of custom formats on the Quarto Extensions section of the webpage.