### PR TITLE
Update carousel.yml

### DIFF
--- a/docs/gallery/carousel.yml
+++ b/docs/gallery/carousel.yml
@@ -9,7 +9,7 @@
   
 - caption: "Engage readers with interactivity"
   image: "interactive/interactive-jupyter.png"
-  link: "#interactive-documents"
+  link: "#interactive-docs"
 
 - caption: "Publish collections of articles as a website"
   image: "websites/websites-quarto.png"


### PR DESCRIPTION
While checking out the site I noticed the carousel tile for interactive documents was targeting a non-existent id. I just renamed it to be in line with https://github.com/quarto-dev/quarto-web/blob/main/docs/gallery/index.qmd#L29 which works.