### PR TITLE
Fix broken link for "Project Metadata" in `html-multi-format.qmd`

### DIFF
--- a/docs/output-formats/html-multi-format.qmd
+++ b/docs/output-formats/html-multi-format.qmd
@@ -87,7 +87,7 @@ format-links: false
 
 ## Controlling Formats at a Project Level
 
-In a Quarto Project, to control the formats and their behavior for a specific folder, provide the `format`{spellcheck="false"} and `format-links`{spellcheck="false"} options in a `_metadata.yml`{spellcheck="false"} file. Similarly, you can specify these options for an entire project by including them in the `_quarto.yml` project file. See [Directory Metadata](/docs/projects/quarto-projects.qmd#directory-metadata) or [Project Metadata](docs/projects/quarto-projects.html#project-metadata) for additional details.
+In a Quarto Project, to control the formats and their behavior for a specific folder, provide the `format`{spellcheck="false"} and `format-links`{spellcheck="false"} options in a `_metadata.yml`{spellcheck="false"} file. Similarly, you can specify these options for an entire project by including them in the `_quarto.yml` project file. See [Directory Metadata](/docs/projects/quarto-projects.qmd#directory-metadata) or [Project Metadata](/docs/projects/quarto-projects.html#project-metadata) for additional details.
 
 The `format`{spellcheck="false"} option isn't merged like all other [metadata](https://quarto.org/docs/projects/quarto-projects.html#metadata-merging) across `_quarto.yml`{spellcheck="false"}, `_metadata.yml`{spellcheck="false"}, and the document YAML. If you have some formats specified at a project or directory level, you'll also need to explicitly list them in the document YAML. For example, suppose you have HTML options set at the project level:
 


### PR DESCRIPTION
Prepends a slash `/` to the Project Metadata path, so that the link is resolved to:
- https://quarto.org/docs/projects/quarto-projects.html#project-metadata

instead of the current
- https://quarto.org/docs/output-formats/docs/projects/quarto-projects.html#project-metadata