### PR TITLE
Propose Adding docx-horizontal-rule extension

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -271,3 +271,9 @@
   description: |
       A Quarto filter to run SQL queries interactively from a SQLite database created at render time 
       in html documents and Revealjs presentations.
+
+- name: docx-horizontal-rule
+  path: https://github.com/ttalVlatt/Quarto-Docx-Horizontal-Rule
+  author: "[Matt Capaldi](https://github.com/ttalVlatt/)"
+  description: |
+    A simple tool to edit the format of a horizontal rule in .docx output


### PR DESCRIPTION
I made a simple extensions that allows users to edit the horizontal rule output for .docx files, since that wasn't editable (as far as I could work out) in a reference-doc. Thought I would share in case you think it's useful for more users