### PR TITLE
fix: github action checkout v2 deprecated

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: 
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Get latest pre-release from github
         id: github-release

--- a/.github/workflows/upload-index.yml
+++ b/.github/workflows/upload-index.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -29,4 +29,3 @@ jobs:
           QUARTO_INDEX_PATH: search.json
           
           
-

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -190,7 +190,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -230,7 +230,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/quarto-pub.qmd
+++ b/docs/publishing/quarto-pub.qmd
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -208,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
GitHub is entering its final deprecation stage of Node12 which is used in the checkout v2 action.
See <https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/>.

Actions in <https://github.com/quarto-dev/quarto-actions> are already using V3, but the website was still showing v2.

This PR fixes the actions, in the website itself and in the CI of this repository.