### PR TITLE
style: allow code block to be copied using the copy button

### DIFF
--- a/docs/computations/_jupyter-cache.md
+++ b/docs/computations/_jupyter-cache.md
@@ -7,12 +7,12 @@ To use Jupyter Cache you'll want to first install the `jupyter-cache` package:
 +------------------+-----------------------------------------------+
 | Platform         | Command                                       |
 +==================+===============================================+
-| Windows          | ``` bash                                      |
-|                  | py -m pip install jupyter-cache               |
+| Mac/Linux        | ``` {.bash filename="Terminal"}               |
+|                  | python3 -m pip install jupyter-cache          |
 |                  | ```                                           |
 +------------------+-----------------------------------------------+
-| Mac/Linux        | ``` bash                                      |
-|                  | python3 -m pip install jupyter-cache          |
+| Windows          | ``` {.powershell filename="Terminal"}         |
+|                  | py -m pip install jupyter-cache               |
 |                  | ```                                           |
 +------------------+-----------------------------------------------+
 
@@ -44,5 +44,3 @@ execute:
 Note that changes within a document that aren't within code cells (e.g. markdown narrative) do not invalidate the document cache. This makes caching a very convenient option when you are working exclusively on the prose part of a document.
 
 Jupyter Cache include a `jcache` command line utility that you can use to analyze and manage the notebook cache. See the [Jupyter Cache](https://jupyter-cache.readthedocs.io/en/latest/) documentation for additional details.
-
-

--- a/docs/computations/_jupyter-install.md
+++ b/docs/computations/_jupyter-install.md
@@ -6,11 +6,11 @@ If you are in a fresh Python 3 environment, installing the `jupyter` package wil
 | Pkg. Manager | Command                        |
 +==============+================================+
 | Pip\         | ``` bash                       |
-| (Windows)    | py -m pip install jupyter      |
+| (Mac/Linux)  | python3 -m pip install jupyter |
 |              | ```                            |
 +--------------+--------------------------------+
 | Pip\         | ``` bash                       |
-| (Mac/Linux)  | python3 -m pip install jupyter |
+| (Windows)    | py -m pip install jupyter      |
 |              | ```                            |
 +--------------+--------------------------------+
 | Conda        | ``` bash                       |

--- a/docs/computations/_jupyter-install.md
+++ b/docs/computations/_jupyter-install.md
@@ -2,21 +2,21 @@ If you don't yet have Python 3 on your system, we recommend you install a versio
 
 If you are in a fresh Python 3 environment, installing the `jupyter` package will provide everything required to execute Jupyter kernels with Quarto:
 
-+--------------+--------------------------------+
-| Pkg. Manager | Command                        |
-+==============+================================+
-| Pip\         | ``` bash                       |
-| (Mac/Linux)  | python3 -m pip install jupyter |
-|              | ```                            |
-+--------------+--------------------------------+
-| Pip\         | ``` bash                       |
-| (Windows)    | py -m pip install jupyter      |
-|              | ```                            |
-+--------------+--------------------------------+
-| Conda        | ``` bash                       |
-|              | conda install jupyter          |
-|              | ```                            |
-+--------------+--------------------------------+
++--------------+--------------------------------------+
+| Pkg. Manager | Command                              |
++==============+======================================+
+| Pip\         | ```{.bash filename="Terminal"}       |
+| (Mac/Linux)  | python3 -m pip install jupyter       |
+|              | ```                                  |
++--------------+--------------------------------------+
+| Pip\         | ```{.powershell filename="Terminal"} |
+| (Windows)    | py -m pip install jupyter            |
+|              | ```                                  |
++--------------+--------------------------------------+
+| Conda        | ```{.bash filename="Terminal"}       |
+|              | conda install jupyter                |
+|              | ```                                  |
++--------------+--------------------------------------+
 
 You can verify that Quarto is configured correctly for Jupyter with:
 

--- a/docs/computations/caching.qmd
+++ b/docs/computations/caching.qmd
@@ -14,21 +14,21 @@ Quarto integrates with the [Jupyter Cache](https://jupyter-cache.readthedocs.io/
 
 To use Jupyter Cache you'll want to first install the `jupyter-cache` package:
 
-+-----------+--------------------------------------+
-| Platform  | Command                              |
-+===========+======================================+
-| Windows   | ``` bash                             |
-|           | py -m pip install jupyter-cache      |
-|           | ```                                  |
-+-----------+--------------------------------------+
-| Mac/Linux | ``` bash                             |
-|           | python3 -m pip install jupyter-cache |
-|           | ```                                  |
-+-----------+--------------------------------------+
-| Conda     | ``` bash                             |
-|           | conda install jupyter-cache          |
-|           | ```                                  |
-+-----------+--------------------------------------+
++-----------+---------------------------------------+
+| Platform  | Command                               |
++===========+=======================================+
+| Mac/Linux | ``` {.bash filename="Terminal"}       |
+|           | python3 -m pip install jupyter-cache  |
+|           | ```                                   |
++-----------+---------------------------------------+
+| Windows   | ``` {.powershell filename="Terminal"} |
+|           | py -m pip install jupyter-cache       |
+|           | ```                                   |
++-----------+---------------------------------------+
+| Conda     | ``` {.bash filename="Terminal"}       |
+|           | conda install jupyter-cache           |
+|           | ```                                   |
++-----------+---------------------------------------+
 
 ::: callout-note
 ## Julia Installation

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -181,15 +181,15 @@ To use Jupyter Cache you'll want to first install the `jupyter-cache` package:
 +-----------+--------------------------------------+
 | Platform  | Command                              |
 +===========+======================================+
-| Windows   | ``` bash                             |
-|           | py -m pip install jupyter-cache      |
-|           | ```                                  |
-+-----------+--------------------------------------+
-| Mac/Linux | ``` bash                             |
+| Mac/Linux | ```{.bash filename="Terminal"}       |
 |           | python3 -m pip install jupyter-cache |
 |           | ```                                  |
 +-----------+--------------------------------------+
-| Conda     | ``` bash                             |
+| Windows   | ```{.powershell filename="Terminal"} |
+|           | py -m pip install jupyter-cache      |
+|           | ```                                  |
++-----------+--------------------------------------+
+| Conda     | ```{.bash filename="Terminal"}       |
 |           | conda install jupyter-cache          |
 |           | ```                                  |
 +-----------+--------------------------------------+

--- a/docs/get-started/computations/jupyter.qmd
+++ b/docs/get-started/computations/jupyter.qmd
@@ -26,11 +26,15 @@ The commands you can use for installation and opening Jupyter Lab are given in t
 +-----------+------------------------------------------------------+
 | Platform  | Commands                                             |
 +===========+======================================================+
-| Mac/Linux |     python3 -m pip install jupyter matplotlib plotly |
-|           |     python3 -m jupyter lab computations.ipynb        |
+|           | ```{.bash filename="Terminal"}                       |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly     |
+|           | python3 -m jupyter lab computations.ipynb            |
+|           | ```                                                  |
 +-----------+------------------------------------------------------+
-| Windows   |     py -m pip install jupyter matplotlib plotly      |
-|           |     py -m jupyter lab computations.ipynb             |
+|           | ```{.powershell filename="Terminal"}                 |
+| Windows   | py -m pip install jupyter matplotlib plotly          |
+|           | py -m jupyter lab computations.ipynb                 |
+|           | ```                                                  |
 +-----------+------------------------------------------------------+
 
 The notebook as we start out is shown below.
@@ -299,4 +303,3 @@ This allows our figure display to span out beyond the normal body text column.
 See the documentation on [Article Layout](/docs/authoring/article-layout.qmd) to learn about all of the available layout options.
 
 {{< include _footer.md >}}
-

--- a/docs/get-started/computations/text-editor.qmd
+++ b/docs/get-started/computations/text-editor.qmd
@@ -19,11 +19,11 @@ The commands you can use to install them are given in the table below.
 +-----------+---------------------------------------------------------+
 | Platform  | Commands                                                |
 +===========+=========================================================+
-| Mac/Linux | ```                                                     |
+| Mac/Linux | ```{.bash filename="Terminal"}                          |
 |           | python3 -m pip install jupyter matplotlib plotly pandas |
 |           | ```                                                     |
 +-----------+---------------------------------------------------------+
-| Windows   | ```                                                     |
+| Windows   | ```{.powershell filename="Terminal"}                    |
 |           | py -m pip install jupyter matplotlib plotly pandas      |
 |           | ```                                                     |
 +-----------+---------------------------------------------------------+

--- a/docs/get-started/computations/vscode.qmd
+++ b/docs/get-started/computations/vscode.qmd
@@ -19,11 +19,11 @@ The commands you can use to install them are given in the table below.
 +-----------+--------------------------------------------------+
 | Platform  | Commands                                         |
 +===========+==================================================+
-| Mac/Linux | ```                                              |
+| Mac/Linux | ```{.bash filename="Terminal"}                   |
 |           | python3 -m pip install jupyter matplotlib plotly |
 |           | ```                                              |
 +-----------+--------------------------------------------------+
-| Windows   | ```                                              |
+| Windows   | ```{.powershell filename="Terminal"}             |
 |           | py -m pip install jupyter matplotlib plotly      |
 |           | ```                                              |
 +-----------+--------------------------------------------------+

--- a/docs/get-started/hello/jupyter.qmd
+++ b/docs/get-started/hello/jupyter.qmd
@@ -41,7 +41,7 @@ Next, execute these commands to install JupyterLab along with the packages used 
 +---------------+------------------------------------------------+
 | Platform      | Commands                                       |
 +===============+================================================+
-| Mac/Linux     | ```{.bash filename="Terminal"}           |
+| Mac/Linux     | ```{.bash filename="Terminal"}                 |
 |               | python3 -m pip install jupyter jupyterlab      |
 |               | python3 -m pip install matplotlib plotly       |
 |               | python3 -m jupyter lab hello.ipynb             |

--- a/docs/get-started/hello/jupyter.qmd
+++ b/docs/get-started/hello/jupyter.qmd
@@ -41,13 +41,13 @@ Next, execute these commands to install JupyterLab along with the packages used 
 +---------------+------------------------------------------------+
 | Platform      | Commands                                       |
 +===============+================================================+
-| Mac/Linux     | ```                                            |
+| Mac/Linux     | ```{.bash filename="Terminal"}           |
 |               | python3 -m pip install jupyter jupyterlab      |
 |               | python3 -m pip install matplotlib plotly       |
 |               | python3 -m jupyter lab hello.ipynb             |
 |               | ```                                            |
 +---------------+------------------------------------------------+
-| Windows       | ```                                            |
+| Windows       | ```{.bash filename="Terminal"}                 |
 |               | py -m pip install jupyter jupyterlab           |
 |               | py -m pip install matplotlib plotly            |
 |               | py -m jupyter lab hello.ipynb                  |

--- a/docs/get-started/hello/neovim.qmd
+++ b/docs/get-started/hello/neovim.qmd
@@ -62,9 +62,13 @@ The tutorials will make use of the `matplotlib` and `plotly` Python packages---t
 +-----------+--------------------------------------------------------------+
 | Platform  | Commands                                                     |
 +===========+==============================================================+
-| Mac/Linux |     python3 -m pip install jupyter matplotlib plotly         |
+|           | ```{.bash filename="Terminal"}                               |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
+|           | ```                                                          |
 +-----------+--------------------------------------------------------------+
-| Windows   |     py -m pip install jupyter matplotlib plotly              |
+|           | ```{.powershell filename="Terminal"}                         |
+| Windows   | py -m pip install jupyter matplotlib plotly              |
+|           | ```                                                          |
 +-----------+--------------------------------------------------------------+
 
 ::: callout-note
@@ -223,4 +227,3 @@ You now know the basics of creating and authoring Quarto documents. The followin
 -   [Tutorial: Authoring](../authoring/) --- Learn more about output formats and technical writing features like citations, crossrefs, and advanced layout.
 
 See the article on [Using Neovim with Quarto](/docs/tools/neovim.qmd) to learn more about installing, using, and customizing Neovim for Quarto. 
-

--- a/docs/get-started/hello/neovim.qmd
+++ b/docs/get-started/hello/neovim.qmd
@@ -59,17 +59,17 @@ This is the basic model for Quarto publishing---take a source document and rende
 
 The tutorials will make use of the `matplotlib` and `plotly` Python packages---the commands you can use to install them are given in the table below.
 
-+-----------+--------------------------------------------------------------+
-| Platform  | Commands                                                     |
-+===========+==============================================================+
-|           | ```{.bash filename="Terminal"}                               |
-| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
-|           | ```{.powershell filename="Terminal"}                         |
-| Windows   | py -m pip install jupyter matplotlib plotly              |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
++-----------+-----------------------------------------------------+
+| Platform  | Commands                                            |
++===========+=====================================================+
+|           | ```{.bash filename="Terminal"}                      |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly    |
+|           | ```                                                 |
++-----------+-----------------------------------------------------+
+|           | ```{.powershell filename="Terminal"}                |
+| Windows   | py -m pip install jupyter matplotlib plotly         |
+|           | ```                                                 |
++-----------+-----------------------------------------------------+
 
 ::: callout-note
 Note that while this tutorial uses Python, using Julia (via the [IJulia](https://julialang.github.io/IJulia.jl/stable/) kernel) or using R (via the [knitr package](https://github.com/yihui/knitr)), are also well supported.

--- a/docs/get-started/hello/text-editor.qmd
+++ b/docs/get-started/hello/text-editor.qmd
@@ -23,17 +23,17 @@ This is the basic model for Quarto publishing---take a source document (in this 
 
 The tutorials will make use of the `matplotlib` and `plotly` Python packages---the commands you can use to install them are given in the table below.
 
-+-----------+--------------------------------------------------------------+
-| Platform  | Commands                                                     |
-+===========+==============================================================+
-|           | ```{.bash filename="Terminal"}                               |
-| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
-|           | ```{.powershell filename="Terminal"}                         |
-| Windows   | py -m pip install jupyter matplotlib plotly              |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
++-----------+---------------------------------------------------+
+| Platform  | Commands                                          |
++===========+===================================================+
+|           | ```{.bash filename="Terminal"}                    |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly  |
+|           | ```                                               |
++-----------+---------------------------------------------------+
+|           | ```{.powershell filename="Terminal"}              |
+| Windows   | py -m pip install jupyter matplotlib plotly       |
+|           | ```                                               |
++-----------+---------------------------------------------------+
 
 ::: callout-note
 Note that while this tutorial uses Python, using Julia (via the [IJulia](https://julialang.github.io/IJulia.jl/stable/) kernel) is also well supported.

--- a/docs/get-started/hello/text-editor.qmd
+++ b/docs/get-started/hello/text-editor.qmd
@@ -26,9 +26,13 @@ The tutorials will make use of the `matplotlib` and `plotly` Python packages---t
 +-----------+--------------------------------------------------------------+
 | Platform  | Commands                                                     |
 +===========+==============================================================+
-| Mac/Linux |     python3 -m pip install jupyter matplotlib plotly         |
+|           | ```{.bash filename="Terminal"}                               |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
+|           | ```                                                          |
 +-----------+--------------------------------------------------------------+
-| Windows   |     py -m pip install jupyter matplotlib plotly              |
+|           | ```{.powershell filename="Terminal"}                         |
+| Windows   | py -m pip install jupyter matplotlib plotly              |
+|           | ```                                                          |
 +-----------+--------------------------------------------------------------+
 
 ::: callout-note
@@ -214,4 +218,3 @@ See Amy Cesal's article on [Writing Alt Text for Data Visualization](https://med
 :::
 
 {{< include _footer.md >}}
-

--- a/docs/get-started/hello/vscode.qmd
+++ b/docs/get-started/hello/vscode.qmd
@@ -38,17 +38,17 @@ This is the basic model for Quarto publishing---take a source document and rende
 
 The tutorials will make use of the `matplotlib` and `plotly` Python packages---the commands you can use to install them are given in the table below.
 
-+-----------+--------------------------------------------------------------+
-| Platform  | Commands                                                     |
-+===========+==============================================================+
-|           | ```{.bash filename="Terminal"}                               |
-| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
-|           | ```{.powershell filename="Terminal"}                         |
-| Windows   | py -m pip install jupyter matplotlib plotly              |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
++-----------+---------------------------------------------------+
+| Platform  | Commands                                          |
++===========+===================================================+
+|           | ```{.bash filename="Terminal"}                    |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly  |
+|           | ```                                               |
++-----------+---------------------------------------------------+
+|           | ```{.powershell filename="Terminal"}              |
+| Windows   | py -m pip install jupyter matplotlib plotly       |
+|           | ```                                               |
++-----------+---------------------------------------------------+
 
 ::: callout-note
 Note that while this tutorial uses Python, using Julia (via the [IJulia](https://julialang.github.io/IJulia.jl/stable/) kernel) is also well supported.
@@ -92,17 +92,17 @@ plt.show()
 
 Note that if you are following along be sure to install the required dependencies if you haven't already:
 
-+-----------+--------------------------------------------------------------+
-| Platform  | Commands                                                     |
-+===========+==============================================================+
-|           | ```{.bash filename="Terminal"}                               |
-| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
-|           | ```{.powershell filename="Terminal"}                         |
-| Windows   | py -m pip install jupyter matplotlib plotly              |
-|           | ```                                                          |
-+-----------+--------------------------------------------------------------+
++-----------+----------------------------------------------------+
+| Platform  | Commands                                           |
++===========+====================================================+
+|           | ```{.bash filename="Terminal"}                     |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly   |
+|           | ```                                                |
++-----------+----------------------------------------------------+
+|           | ```{.powershell filename="Terminal"}               |
+| Windows   | py -m pip install jupyter matplotlib plotly        |
+|           | ```                                                |
++-----------+----------------------------------------------------+
 
 To render and preview, execute the **Quarto: Render** command.
 You can alternatively use the <kbd>Ctrl+Shift+K</kbd> keyboard shortcut, or the **Render** button at the top right of the editor:

--- a/docs/get-started/hello/vscode.qmd
+++ b/docs/get-started/hello/vscode.qmd
@@ -41,9 +41,13 @@ The tutorials will make use of the `matplotlib` and `plotly` Python packages---t
 +-----------+--------------------------------------------------------------+
 | Platform  | Commands                                                     |
 +===========+==============================================================+
-| Mac/Linux |     python3 -m pip install jupyter matplotlib plotly         |
+|           | ```{.bash filename="Terminal"}                               |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
+|           | ```                                                          |
 +-----------+--------------------------------------------------------------+
-| Windows   |     py -m pip install jupyter matplotlib plotly              |
+|           | ```{.powershell filename="Terminal"}                         |
+| Windows   | py -m pip install jupyter matplotlib plotly              |
+|           | ```                                                          |
 +-----------+--------------------------------------------------------------+
 
 ::: callout-note
@@ -88,13 +92,17 @@ plt.show()
 
 Note that if you are following along be sure to install the required dependencies if you haven't already:
 
-+-----------+------------------------------------------------------+
-| Platform  | Commands                                             |
-+===========+======================================================+
-| Mac/Linux |     python3 -m pip install jupyter matplotlib plotly |
-+-----------+------------------------------------------------------+
-| Windows   |     py -m pip install jupyter matplotlib plotly      |
-+-----------+------------------------------------------------------+
++-----------+--------------------------------------------------------------+
+| Platform  | Commands                                                     |
++===========+==============================================================+
+|           | ```{.bash filename="Terminal"}                               |
+| Mac/Linux | python3 -m pip install jupyter matplotlib plotly         |
+|           | ```                                                          |
++-----------+--------------------------------------------------------------+
+|           | ```{.powershell filename="Terminal"}                         |
+| Windows   | py -m pip install jupyter matplotlib plotly              |
+|           | ```                                                          |
++-----------+--------------------------------------------------------------+
 
 To render and preview, execute the **Quarto: Render** command.
 You can alternatively use the <kbd>Ctrl+Shift+K</kbd> keyboard shortcut, or the **Render** button at the top right of the editor:

--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -37,21 +37,21 @@ To create a new Python 3 virtual environment in the directory `env`:
 
 To use the environment you need to activate it. This differs slightly depending on which platform / shell you are using:
 
-+---------------+-----------------------------------------------------+
-| Shell         | Command                                             |
-+===============+=====================================================+
-| Mac/Linux     | ```{.bash filename="Terminal"}                      |
-|               | source env/bin/activate                             |
-|               | ```                                                 |
-+---------------+-----------------------------------------------------+
-| Windows\      | ```{.powershell filename="Terminal"}                |
-| (Command)     | env\Scripts\activate.bat                            |
-|               | ```                                                 |
-+---------------+-----------------------------------------------------+
-| Windows\      | ```{.powershell filename="Terminal"}                |
-| (PowerShell)  | env\Scripts\Activate.ps1                            |
-|               | ```                                                 |
-+---------------+-----------------------------------------------------+
++---------------+-----------------------------------------+
+| Shell         | Command                                 |
++===============+=========================================+
+| Mac/Linux     | ```{.bash filename="Terminal"}          |
+|               | source env/bin/activate                 |
+|               | ```                                     |
++---------------+-----------------------------------------+
+| Windows\      | ```{.powershell filename="Terminal"}    |
+| (Command)     | env\Scripts\activate.bat                |
+|               | ```                                     |
++---------------+-----------------------------------------+
+| Windows\      | ```{.powershell filename="Terminal"}    |
+| (PowerShell)  | env\Scripts\Activate.ps1                |
+|               | ```                                     |
++---------------+-----------------------------------------+
 
 ::: callout-note
 #### PowerShell Note
@@ -270,8 +270,8 @@ To use Jupyter or JupyterLab within a Python virtual environment you just need t
 |                      | ```                                  |
 +----------------------+--------------------------------------+
 |                      | ```{.powershell filename="Terminal"} |
-| Windows (PowerShell) | env\Scripts\Activate.ps1             |
-|                      | py -m jupyter lab                    |
+| Windows\             | env\Scripts\Activate.ps1             |
+| (PowerShell)         | py -m jupyter lab                    |
 |                      | ```                                  |
 +----------------------+--------------------------------------+
 

--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -26,9 +26,13 @@ To create a new Python 3 virtual environment in the directory `env`:
 +--------------+-------------------------+
 | Platform     | Command                 |
 +==============+=========================+
-| Windows      |     py -m venv env      |
+| Windows      | ```powershell           |
+|              | py -m venv env          |
+|              | ```                     |
 +--------------+-------------------------+
-| Mac/Linux    |     python3 -m venv env |
+| Mac/Linux    | ```bash                 |
+|              | python3 -m venv env     |
+|              | ```                     |
 +--------------+-------------------------+
 
 To use the environment you need to activate it. This differs slightly depending on which platform / shell you are using:
@@ -36,13 +40,17 @@ To use the environment you need to activate it. This differs slightly depending 
 +---------------+------------------------------+
 | Shell         | Command                      |
 +===============+==============================+
-| Windows\      |     env\Scripts\activate.bat |
-| (Command)     |                              |
+| Windows\      | ```powershell                |
+| (Command)     | env\Scripts\activate.bat     |
+|               | ```                          |
 +---------------+------------------------------+
-| Windows\      |     env\Scripts\Activate.ps1 |
-| (PowerShell)  |                              |
+| Windows\      | ```powershell                |
+| (PowerShell)  | env\Scripts\Activate.ps1     |
+|               | ```                          |
 +---------------+------------------------------+
-| Mac/Linux     |     source env/bin/activate  |
+| Mac/Linux     | ```bash                      |
+|               | source env/bin/activate      |
+|               | ```                          |
 +---------------+------------------------------+
 
 ::: callout-note
@@ -60,9 +68,13 @@ Once you've activated the environment, you need to ensure that you have the pack
 +--------------+------------------------------------------------------+
 | Platform     | Command                                              |
 +==============+======================================================+
-| Windows      |     py -m pip install jupyter matplotlib pandas      |
+| Windows      | ```powershell                                        |
+|              | py -m pip install jupyter matplotlib pandas          |
+|              | ```                                                  |
 +--------------+------------------------------------------------------+
-| Mac/Linux    |     python3 -m pip install jupyter matplotlib pandas |
+| Mac/Linux    | ```bash                                              |
+|              | python3 -m pip install jupyter matplotlib pandas     |
+|              | ```                                                  |
 +--------------+------------------------------------------------------+
 
 Assuming you installed all of the required packages (likely more than just `pandas` and `matplotlib`) you should now be able to `quarto render` documents within the directory.
@@ -80,9 +92,13 @@ To make your environment reproducible, you need to create a `requirements.txt` f
 +--------------+----------------------------------------------+
 | Platform     | Command                                      |
 +==============+==============================================+
-| Windows      |     py -m pip freeze > requirements.txt      |
+| Windows      | ```powershell                                |
+|              | py -m pip freeze > requirements.txt          |
+|              | ```                                          |
 +--------------+----------------------------------------------+
-| Mac/Linux    |     python3 -m pip freeze > requirements.txt |
+| Mac/Linux    | ```bash                                      |
+|              | python3 -m pip freeze > requirements.txt     |
+|              | ```                                          |
 +--------------+----------------------------------------------+
 
 You should generally check the `requirements.txt` file into version control.
@@ -98,9 +114,13 @@ Then, install packages from `requirements.txt`:
 +--------------+------------------------------------------------+
 | Platform     | Command                                        |
 +==============+================================================+
-| Windows      |     py -m pip install -r requirements.txt      |
+| Windows      | ```bash                                        |
+|              | py -m pip install -r requirements.txt          |
+|              | ```                                            |
 +--------------+------------------------------------------------+
-| Mac/Linux    |     python3 -m pip install -r requirements.txt |
+| Mac/Linux    | ```bash                                        |
+|              | python3 -m pip install -r requirements.txt     |
+|              | ```                                            |
 +--------------+------------------------------------------------+
 
 ## Using conda {.platform-table}
@@ -118,17 +138,21 @@ If this is the first time you've used conda in your shell, you may need to execu
 +--------------------+---------------------------+
 | Shell              | Command                   |
 +====================+===========================+
-| Windows\           |     conda init cmd.exe    |
-| (Command)          |                           |
+| Windows\           | ```powershell             |
+| (Command)          | conda init cmd.exe        |
+|                    | ```                       |
 +--------------------+---------------------------+
-| Windows\           |     conda init powershell |
-| (PowerShell)       |                           |
+| Windows\           | ```powershell             |
+| (PowerShell)       | conda init powershell     |
+|                    | ```                       |
 +--------------------+---------------------------+
-| Linux / Older Mac\ |     conda init bash       |
-| (Bash)             |                           |
+| Linux / Older Mac\ | ```bash                   |
+| (Bash)             | conda init bash           |
+|                    | ```                       |
 +--------------------+---------------------------+
-| Newer Mac\         |     conda init zsh        |
-| (Zsh)              |                           |
+| Newer Mac\         | ```bash                   |
+| (Zsh)              | conda init zsh            |
+|                    | ```                       |
 +--------------------+---------------------------+
 
 You will likely need to exit and restart your terminal for `conda init` to be reflected in your session.
@@ -138,9 +162,13 @@ To use the environment you need to activate it, which you do as follows:
 +--------------+--------------------------+
 | Platform     | Command                  |
 +==============+==========================+
-| Windows      |     conda activate .\env |
+| Windows      | ```powershell            |
+|              | conda activate .\env     |
+|              | ```                      |
 +--------------+--------------------------+
-| Mac/Linux    |     conda activate ./env |
+| Mac/Linux    | ```bash                  |
+|              | conda activate ./env     |
+|              | ```                      |
 +--------------+--------------------------+
 
 Once you've activated the environment, you need to ensure that you have the packages required to render your documents. This will typically encompass `jupyter` / `jupyterlab` plus whatever other packages are used in your Python code. Use `conda install` to install packages into your environment. For example:
@@ -231,14 +259,20 @@ To use Jupyter or JupyterLab within a Python virtual environment you just need t
 +----------------------+------------------------------+
 | Shell                | Command                      |
 +======================+==============================+
-| Windows\             |     env\Scripts\activate.bat |
-| (Command)            |     py -m jupyter lab        |
+|                      | ```powershell                |
+| Windows\             | env\Scripts\activate.bat     |
+| (Command)            | py -m jupyter lab            |
+|                      | ```                          |
 +----------------------+------------------------------+
-| Windows (PowerShell) |     env\Scripts\Activate.ps1 |
-|                      |     py -m jupyter lab        |
+|                      | ```powershell                |
+| Windows (PowerShell) | env\Scripts\Activate.ps1     |
+|                      | py -m jupyter lab            |
+|                      | ```                          |
 +----------------------+------------------------------+
-| Mac/Linux            |     source env/bin/activate  |
-|                      |     python3 -m jupyter lab   |
+|                      | ```bash                      |
+| Mac/Linux            | source env/bin/activate      |
+|                      | python3 -m jupyter lab       |
+|                      | ```                          |
 +----------------------+------------------------------+
 
 All of the Python packages installed within the `env` will be available in your Jupyter notebook session. The workflow is similar if you are using conda environments.

--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -23,35 +23,35 @@ Here we'll provide a brief run through of creating a venv for a Quarto project. 
 
 To create a new Python 3 virtual environment in the directory `env`:
 
-+--------------+-------------------------+
-| Platform     | Command                 |
-+==============+=========================+
-| Windows      | ```powershell           |
-|              | py -m venv env          |
-|              | ```                     |
-+--------------+-------------------------+
-| Mac/Linux    | ```bash                 |
-|              | python3 -m venv env     |
-|              | ```                     |
-+--------------+-------------------------+
++--------------+------------------------------------------------+
+| Platform     | Command                                        |
++==============+================================================+
+| Windows      | ```{.powershell filename="Terminal"}           |
+|              | py -m venv env                                 |
+|              | ```                                            |
++--------------+------------------------------------------------+
+| Mac/Linux    | ```{.bash filename="Terminal"}                 |
+|              | python3 -m venv env                            |
+|              | ```                                            |
++--------------+------------------------------------------------+
 
 To use the environment you need to activate it. This differs slightly depending on which platform / shell you are using:
 
-+---------------+------------------------------+
-| Shell         | Command                      |
-+===============+==============================+
-| Windows\      | ```powershell                |
-| (Command)     | env\Scripts\activate.bat     |
-|               | ```                          |
-+---------------+------------------------------+
-| Windows\      | ```powershell                |
-| (PowerShell)  | env\Scripts\Activate.ps1     |
-|               | ```                          |
-+---------------+------------------------------+
-| Mac/Linux     | ```bash                      |
-|               | source env/bin/activate      |
-|               | ```                          |
-+---------------+------------------------------+
++---------------+-----------------------------------------------------+
+| Shell         | Command                                             |
++===============+=====================================================+
+| Windows\      | ```{.powershell filename="Terminal"}                |
+| (Command)     | env\Scripts\activate.bat                            |
+|               | ```                                                 |
++---------------+-----------------------------------------------------+
+| Windows\      | ```{.powershell filename="Terminal"}                |
+| (PowerShell)  | env\Scripts\Activate.ps1                            |
+|               | ```                                                 |
++---------------+-----------------------------------------------------+
+| Mac/Linux     | ```{.bash filename="Terminal"}                      |
+|               | source env/bin/activate                             |
+|               | ```                                                 |
++---------------+-----------------------------------------------------+
 
 ::: callout-note
 #### PowerShell Note
@@ -68,11 +68,11 @@ Once you've activated the environment, you need to ensure that you have the pack
 +--------------+------------------------------------------------------+
 | Platform     | Command                                              |
 +==============+======================================================+
-| Windows      | ```powershell                                        |
+| Windows      | ```{.powershell filename="Terminal"}                 |
 |              | py -m pip install jupyter matplotlib pandas          |
 |              | ```                                                  |
 +--------------+------------------------------------------------------+
-| Mac/Linux    | ```bash                                              |
+| Mac/Linux    | ```{.bash filename="Terminal"}                       |
 |              | python3 -m pip install jupyter matplotlib pandas     |
 |              | ```                                                  |
 +--------------+------------------------------------------------------+
@@ -92,11 +92,11 @@ To make your environment reproducible, you need to create a `requirements.txt` f
 +--------------+----------------------------------------------+
 | Platform     | Command                                      |
 +==============+==============================================+
-| Windows      | ```powershell                                |
+| Windows      | ```{.powershell filename="Terminal"}         |
 |              | py -m pip freeze > requirements.txt          |
 |              | ```                                          |
 +--------------+----------------------------------------------+
-| Mac/Linux    | ```bash                                      |
+| Mac/Linux    | ```{.bash filename="Terminal"}               |
 |              | python3 -m pip freeze > requirements.txt     |
 |              | ```                                          |
 +--------------+----------------------------------------------+
@@ -114,11 +114,11 @@ Then, install packages from `requirements.txt`:
 +--------------+------------------------------------------------+
 | Platform     | Command                                        |
 +==============+================================================+
-| Windows      | ```bash                                        |
+| Windows      | ```{.bash filename="Terminal"}                 |
 |              | py -m pip install -r requirements.txt          |
 |              | ```                                            |
 +--------------+------------------------------------------------+
-| Mac/Linux    | ```bash                                        |
+| Mac/Linux    | ```{.bash filename="Terminal"}                 |
 |              | python3 -m pip install -r requirements.txt     |
 |              | ```                                            |
 +--------------+------------------------------------------------+
@@ -135,41 +135,41 @@ conda create --prefix env python
 
 If this is the first time you've used conda in your shell, you may need to execute one of the following commands before using other conda tools:
 
-+--------------------+---------------------------+
-| Shell              | Command                   |
-+====================+===========================+
-| Windows\           | ```powershell             |
-| (Command)          | conda init cmd.exe        |
-|                    | ```                       |
-+--------------------+---------------------------+
-| Windows\           | ```powershell             |
-| (PowerShell)       | conda init powershell     |
-|                    | ```                       |
-+--------------------+---------------------------+
-| Linux / Older Mac\ | ```bash                   |
-| (Bash)             | conda init bash           |
-|                    | ```                       |
-+--------------------+---------------------------+
-| Newer Mac\         | ```bash                   |
-| (Zsh)              | conda init zsh            |
-|                    | ```                       |
-+--------------------+---------------------------+
++--------------------+---------------------------------------+
+| Shell              | Command                               |
++====================+=======================================+
+| Windows\           | ```{.powershell filename="Terminal"}  |
+| (Command)          | conda init cmd.exe                    |
+|                    | ```                                   |
++--------------------+---------------------------------------+
+| Windows\           | ```{.powershell filename="Terminal"}  |
+| (PowerShell)       | conda init powershell                 |
+|                    | ```                                   |
++--------------------+---------------------------------------+
+| Linux / Older Mac\ | ```{.bash filename="Terminal"}        |
+| (Bash)             | conda init bash                       |
+|                    | ```                                   |
++--------------------+---------------------------------------+
+| Newer Mac\         | ```{.bash filename="Terminal"}        |
+| (Zsh)              | conda init zsh                        |
+|                    | ```                                   |
++--------------------+---------------------------------------+
 
 You will likely need to exit and restart your terminal for `conda init` to be reflected in your session.
 
 To use the environment you need to activate it, which you do as follows:
 
-+--------------+--------------------------+
-| Platform     | Command                  |
-+==============+==========================+
-| Windows      | ```powershell            |
-|              | conda activate .\env     |
-|              | ```                      |
-+--------------+--------------------------+
-| Mac/Linux    | ```bash                  |
-|              | conda activate ./env     |
-|              | ```                      |
-+--------------+--------------------------+
++--------------+--------------------------------------+
+| Platform     | Command                              |
++==============+======================================+
+| Windows      | ```{.powershell filename="Terminal"} |
+|              | conda activate .\env                 |
+|              | ```                                  |
++--------------+--------------------------------------+
+| Mac/Linux    | ```{.bash filename="Terminal"}       |
+|              | conda activate ./env                 |
+|              | ```                                  |
++--------------+--------------------------------------+
 
 Once you've activated the environment, you need to ensure that you have the packages required to render your documents. This will typically encompass `jupyter` / `jupyterlab` plus whatever other packages are used in your Python code. Use `conda install` to install packages into your environment. For example:
 
@@ -256,24 +256,24 @@ renv::restore()
 
 To use Jupyter or JupyterLab within a Python virtual environment you just need to activate the environment and then launch the Jupyter front end. For example:
 
-+----------------------+------------------------------+
-| Shell                | Command                      |
-+======================+==============================+
-|                      | ```powershell                |
-| Windows\             | env\Scripts\activate.bat     |
-| (Command)            | py -m jupyter lab            |
-|                      | ```                          |
-+----------------------+------------------------------+
-|                      | ```powershell                |
-| Windows (PowerShell) | env\Scripts\Activate.ps1     |
-|                      | py -m jupyter lab            |
-|                      | ```                          |
-+----------------------+------------------------------+
-|                      | ```bash                      |
-| Mac/Linux            | source env/bin/activate      |
-|                      | python3 -m jupyter lab       |
-|                      | ```                          |
-+----------------------+------------------------------+
++----------------------+--------------------------------------+
+| Shell                | Command                              |
++======================+======================================+
+|                      | ```{.powershell filename="Terminal"} |
+| Windows\             | env\Scripts\activate.bat             |
+| (Command)            | py -m jupyter lab                    |
+|                      | ```                                  |
++----------------------+--------------------------------------+
+|                      | ```{.powershell filename="Terminal"} |
+| Windows (PowerShell) | env\Scripts\Activate.ps1             |
+|                      | py -m jupyter lab                    |
+|                      | ```                                  |
++----------------------+--------------------------------------+
+|                      | ```{.bash filename="Terminal"}       |
+| Mac/Linux            | source env/bin/activate              |
+|                      | python3 -m jupyter lab               |
+|                      | ```                                  |
++----------------------+--------------------------------------+
 
 All of the Python packages installed within the `env` will be available in your Jupyter notebook session. The workflow is similar if you are using conda environments.
 

--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -26,12 +26,12 @@ To create a new Python 3 virtual environment in the directory `env`:
 +--------------+------------------------------------------------+
 | Platform     | Command                                        |
 +==============+================================================+
-| Windows      | ```{.powershell filename="Terminal"}           |
-|              | py -m venv env                                 |
-|              | ```                                            |
-+--------------+------------------------------------------------+
 | Mac/Linux    | ```{.bash filename="Terminal"}                 |
 |              | python3 -m venv env                            |
+|              | ```                                            |
++--------------+------------------------------------------------+
+| Windows      | ```{.powershell filename="Terminal"}           |
+|              | py -m venv env                                 |
 |              | ```                                            |
 +--------------+------------------------------------------------+
 
@@ -40,16 +40,16 @@ To use the environment you need to activate it. This differs slightly depending 
 +---------------+-----------------------------------------------------+
 | Shell         | Command                                             |
 +===============+=====================================================+
+| Mac/Linux     | ```{.bash filename="Terminal"}                      |
+|               | source env/bin/activate                             |
+|               | ```                                                 |
++---------------+-----------------------------------------------------+
 | Windows\      | ```{.powershell filename="Terminal"}                |
 | (Command)     | env\Scripts\activate.bat                            |
 |               | ```                                                 |
 +---------------+-----------------------------------------------------+
 | Windows\      | ```{.powershell filename="Terminal"}                |
 | (PowerShell)  | env\Scripts\Activate.ps1                            |
-|               | ```                                                 |
-+---------------+-----------------------------------------------------+
-| Mac/Linux     | ```{.bash filename="Terminal"}                      |
-|               | source env/bin/activate                             |
 |               | ```                                                 |
 +---------------+-----------------------------------------------------+
 
@@ -68,12 +68,12 @@ Once you've activated the environment, you need to ensure that you have the pack
 +--------------+------------------------------------------------------+
 | Platform     | Command                                              |
 +==============+======================================================+
-| Windows      | ```{.powershell filename="Terminal"}                 |
-|              | py -m pip install jupyter matplotlib pandas          |
-|              | ```                                                  |
-+--------------+------------------------------------------------------+
 | Mac/Linux    | ```{.bash filename="Terminal"}                       |
 |              | python3 -m pip install jupyter matplotlib pandas     |
+|              | ```                                                  |
++--------------+------------------------------------------------------+
+| Windows      | ```{.powershell filename="Terminal"}                 |
+|              | py -m pip install jupyter matplotlib pandas          |
 |              | ```                                                  |
 +--------------+------------------------------------------------------+
 
@@ -92,12 +92,12 @@ To make your environment reproducible, you need to create a `requirements.txt` f
 +--------------+----------------------------------------------+
 | Platform     | Command                                      |
 +==============+==============================================+
-| Windows      | ```{.powershell filename="Terminal"}         |
-|              | py -m pip freeze > requirements.txt          |
-|              | ```                                          |
-+--------------+----------------------------------------------+
 | Mac/Linux    | ```{.bash filename="Terminal"}               |
 |              | python3 -m pip freeze > requirements.txt     |
+|              | ```                                          |
++--------------+----------------------------------------------+
+| Windows      | ```{.powershell filename="Terminal"}         |
+|              | py -m pip freeze > requirements.txt          |
 |              | ```                                          |
 +--------------+----------------------------------------------+
 
@@ -114,12 +114,12 @@ Then, install packages from `requirements.txt`:
 +--------------+------------------------------------------------+
 | Platform     | Command                                        |
 +==============+================================================+
-| Windows      | ```{.bash filename="Terminal"}                 |
-|              | py -m pip install -r requirements.txt          |
-|              | ```                                            |
-+--------------+------------------------------------------------+
 | Mac/Linux    | ```{.bash filename="Terminal"}                 |
 |              | python3 -m pip install -r requirements.txt     |
+|              | ```                                            |
++--------------+------------------------------------------------+
+| Windows      | ```{.bash filename="Terminal"}                 |
+|              | py -m pip install -r requirements.txt          |
 |              | ```                                            |
 +--------------+------------------------------------------------+
 
@@ -138,20 +138,20 @@ If this is the first time you've used conda in your shell, you may need to execu
 +--------------------+---------------------------------------+
 | Shell              | Command                               |
 +====================+=======================================+
-| Windows\           | ```{.powershell filename="Terminal"}  |
-| (Command)          | conda init cmd.exe                    |
-|                    | ```                                   |
-+--------------------+---------------------------------------+
-| Windows\           | ```{.powershell filename="Terminal"}  |
-| (PowerShell)       | conda init powershell                 |
+| Newer Mac\         | ```{.bash filename="Terminal"}        |
+| (Zsh)              | conda init zsh                        |
 |                    | ```                                   |
 +--------------------+---------------------------------------+
 | Linux / Older Mac\ | ```{.bash filename="Terminal"}        |
 | (Bash)             | conda init bash                       |
 |                    | ```                                   |
 +--------------------+---------------------------------------+
-| Newer Mac\         | ```{.bash filename="Terminal"}        |
-| (Zsh)              | conda init zsh                        |
+| Windows\           | ```{.powershell filename="Terminal"}  |
+| (Command)          | conda init cmd.exe                    |
+|                    | ```                                   |
++--------------------+---------------------------------------+
+| Windows\           | ```{.powershell filename="Terminal"}  |
+| (PowerShell)       | conda init powershell                 |
 |                    | ```                                   |
 +--------------------+---------------------------------------+
 
@@ -162,12 +162,12 @@ To use the environment you need to activate it, which you do as follows:
 +--------------+--------------------------------------+
 | Platform     | Command                              |
 +==============+======================================+
-| Windows      | ```{.powershell filename="Terminal"} |
-|              | conda activate .\env                 |
-|              | ```                                  |
-+--------------+--------------------------------------+
 | Mac/Linux    | ```{.bash filename="Terminal"}       |
 |              | conda activate ./env                 |
+|              | ```                                  |
++--------------+--------------------------------------+
+| Windows      | ```{.powershell filename="Terminal"} |
+|              | conda activate .\env                 |
 |              | ```                                  |
 +--------------+--------------------------------------+
 
@@ -259,6 +259,11 @@ To use Jupyter or JupyterLab within a Python virtual environment you just need t
 +----------------------+--------------------------------------+
 | Shell                | Command                              |
 +======================+======================================+
+|                      | ```{.bash filename="Terminal"}       |
+| Mac/Linux            | source env/bin/activate              |
+|                      | python3 -m jupyter lab               |
+|                      | ```                                  |
++----------------------+--------------------------------------+
 |                      | ```{.powershell filename="Terminal"} |
 | Windows\             | env\Scripts\activate.bat             |
 | (Command)            | py -m jupyter lab                    |
@@ -267,11 +272,6 @@ To use Jupyter or JupyterLab within a Python virtual environment you just need t
 |                      | ```{.powershell filename="Terminal"} |
 | Windows (PowerShell) | env\Scripts\Activate.ps1             |
 |                      | py -m jupyter lab                    |
-|                      | ```                                  |
-+----------------------+--------------------------------------+
-|                      | ```{.bash filename="Terminal"}       |
-| Mac/Linux            | source env/bin/activate              |
-|                      | python3 -m jupyter lab               |
 |                      | ```                                  |
 +----------------------+--------------------------------------+
 

--- a/docs/tools/jupyter-lab-extension.qmd
+++ b/docs/tools/jupyter-lab-extension.qmd
@@ -20,7 +20,7 @@ You can install the Quarto JupyterLab extension one of two ways:
     +----------------+------------------------------------------------+
     | Platform       | Commands                                       |
     +================+================================================+
-    | Mac/Linux      | ```{.bash filename="Terminal"}           |
+    | Mac/Linux      | ```{.bash filename="Terminal"}                 |
     |                | python3 -m pip install jupyterlab-quarto       |
     |                | ```                                            |
     +----------------+------------------------------------------------+

--- a/docs/tools/jupyter-lab-extension.qmd
+++ b/docs/tools/jupyter-lab-extension.qmd
@@ -20,11 +20,11 @@ You can install the Quarto JupyterLab extension one of two ways:
     +----------------+------------------------------------------------+
     | Platform       | Commands                                       |
     +================+================================================+
-    | Mac/Linux      | ```                                            |
+    | Mac/Linux      | ```{.bash filename="Terminal"}           |
     |                | python3 -m pip install jupyterlab-quarto       |
     |                | ```                                            |
     +----------------+------------------------------------------------+
-    | Windows        | ```                                            |
+    | Windows        | ```{.powershell filename="Terminal"}           |
     |                | py -m pip install jupyterlab-quarto            |
     |                | ```                                            |
     +----------------+------------------------------------------------+
@@ -50,11 +50,11 @@ The Quarto contents shown in your Notebooks will not match the rendered output p
     +---------------+-----------------------------------------------------------+
     | Platform      | Commands                                                  |
     +===============+===========================================================+
-    | Mac/Linux     | ```                                                       |
+    | Mac/Linux     | ```{.bash filename="Terminal"}                            |
     |               | python3 -m jupyter labextension disable jupyterlab-quarto |
     |               | ```                                                       |
     +---------------+-----------------------------------------------------------+
-    | Windows       | ```                                                       |
+    | Windows       | ```{.powershell filename="Terminal"}                      |
     |               | py -m jupyter labextension disable jupyterlab-quarto      |
     |               | ```                                                       |
     +---------------+-----------------------------------------------------------+
@@ -64,11 +64,11 @@ The Quarto contents shown in your Notebooks will not match the rendered output p
     +----------------+----------------------------------------------------------+
     | Platform       | Commands                                                 |
     +================+==========================================================+
-    | Mac/Linux      | ```                                                      |
+    | Mac/Linux      | ```{.bash filename="Terminal"}                           |
     |                | python3 -m jupyter labextension enable jupyterlab-quarto |
     |                | ```                                                      |
     +----------------+----------------------------------------------------------+
-    | Windows        | ```                                                      |
+    | Windows        | ```{.powershell filename="Terminal"}                     |
     |                | py -m jupyter labextension enable jupyterlab-quarto      |
     |                | ```                                                      |
     +----------------+----------------------------------------------------------+
@@ -82,11 +82,11 @@ The Quarto contents shown in your Notebooks will not match the rendered output p
     +----------------+------------------------------------------------+
     | Platform       | Commands                                       |
     +================+================================================+
-    | Mac/Linux      | ```                                            |
+    | Mac/Linux      | ```{.bash filename="Terminal"}                 |
     |                | python3 -m pip uninstall jupyterlab-quarto     |
     |                | ```                                            |
     +----------------+------------------------------------------------+
-    | Windows        | ```                                            |
+    | Windows        | ```{.powershell filename="Terminal"}           |
     |                | py -m pip uninstall jupyterlab-quarto          |
     |                | ```                                            |
     +----------------+------------------------------------------------+

--- a/docs/tools/jupyter-lab.qmd
+++ b/docs/tools/jupyter-lab.qmd
@@ -43,17 +43,17 @@ Note that if you are authoring a book or website you can also use [`quarto previ
 
 To run JupyterLab, invoke the `jupyter` module from within the shell where you are using Quarto:
 
-+--------------+------------------------+
-| Platform     | Command                |
-+==============+========================+
-| Windows      | ``` bash               |
-|              | py -m jupyter lab      |
-|              | ```                    |
-+--------------+------------------------+
-| Mac/Linux    | ``` bash               |
-|              | python3 -m jupyter lab |
-|              | ```                    |
-+--------------+------------------------+
++--------------+--------------------------------------+
+| Platform     | Command                              |
++==============+======================================+
+| Mac/Linux    | ```{.bash filename="Terminal"}       |
+|              | python3 -m jupyter lab               |
+|              | ```                                  |
++--------------+--------------------------------------+
+| Windows      | ```{.powershell filename="Terminal"} |
+|              | py -m jupyter lab                    |
+|              | ```                                  |
++--------------+--------------------------------------+
 
 #### Render without Preview
 


### PR DESCRIPTION
This PR tweaks the code blocks in tables to allow the copy button which make it easier to use the code showed.
It also makes the OS order consistent across the website.

| Before | After |
|--------|-------|
| <img width="877" alt="image" src="https://github.com/quarto-dev/quarto-web/assets/8896044/beed0219-f707-4a41-a0b0-cc36dc81ba9a"> | <img width="877" alt="image" src="https://github.com/quarto-dev/quarto-web/assets/8896044/1e52168b-4ff3-48a8-8f3a-ea3a26e9841d"> |
