### PR TITLE
tweak overview language

### DIFF
--- a/docs/manuscripts/index.qmd
+++ b/docs/manuscripts/index.qmd
@@ -16,13 +16,13 @@ format:
 
 ## Overview
 
-Quarto provides a framework for writing and publishing your scholarly articles. A Quarto manuscript lets you:
+Quarto manuscript projects provide a framework for writing and publishing scholarly articles. A Quarto manuscript lets you:
 
-* Link your computations to your narrative, allowing your readers to dive into your code
-* Produce manuscripts in multiple formats, and give readers easy access through a manuscript website 
-* Get a submission ready archive of your manuscript, including your computational notebooks
+* Use one or more notebooks or `.qmd` documents as the source of content and computations, and then publish these computations alongside the manuscript, allowing readers to dive into your code.
 
-The output of a Quarto manuscript is a webpage ([live example](https://cwickham.github.io/manuscript-template-jupyter/)). The article itself appears as the content of the webpage, and can include all the elements common to scholarly writing like figures, tables, equations, cross references and citations. 
+* Produce manuscripts in multiple formats (including the native LaTeX or MS Word format supported by journals), and give readers easy access to all of the formats through a manuscript website.
+
+The output of a Quarto manuscript is a website ([live example](https://cwickham.github.io/manuscript-template-jupyter/)). The article itself appears as the content of the website, and can include all the elements common to scholarly writing like figures, tables, equations, cross references and citations. The website also makes available other formats (e.g. PDF, Docx) as well as links to all of the computations used to create the article.
 
 ::: {layout="[[3,1]]"}
 


### PR DESCRIPTION
Here's a proposed tweak to the overview language. The main thing I did was:

(1) Try to distinguish manuscripts from normal notebooks or qmds by mentioning that you can use "one or more" of them (to me just saying "Link your computations to your narrative, allowing your readers to dive into your code" isn't quite enough to see why this is something new).

(2) Punch up the emphasis of "multiple formats" available through the website (again to distinguish from a normal article you might publish)

(3) Eliminate the reference to MECA bundles in the intro (too much to try to communicate/understand, and in the early days this will only be interesting to users that have been pointed to us from a journal that is prepared to accept MECA submissions.