### PR TITLE
docs: makes it clear zip an tar.gz are supported

### DIFF
--- a/docs/extensions/managing.qmd
+++ b/docs/extensions/managing.qmd
@@ -33,7 +33,7 @@ quarto add cooltools/lightbox
 quarto add bigstateu/fancytweet
 ```
 
-While it's convenient to distribute extensions using GitHub, you can also distribute them as an ordinary gzip archive using a URL or a local file. See the article on [Distributing Extensions](distributing.qmd) for additional details.
+While it's convenient to distribute extensions using GitHub, you can also bundle them into a `.zip` or `.tar.gz` archive and distribute them using a URL or a local file. See the article on [Distributing Extensions](distributing.qmd) for additional details.
 
 ## Updating
 


### PR DESCRIPTION
Originally discussed in https://github.com/quarto-dev/quarto-cli/issues/5827#issuecomment-1578271647

This PR intends to make it explicit that extensions can be bundle as `.zip` or `.tar.gz` archive (as explicilty stated in other pages but `/Users/mcanouil/Projects/quarto/quarto-web/docs/extensions/managing.qmd`).