### PR TITLE
fix: extension embedding example

### DIFF
--- a/docs/extensions/_formats-common.qmd
+++ b/docs/extensions/_formats-common.qmd
@@ -58,6 +58,7 @@ In some cases format extensions will want to make use of other extensions. This 
 
 ``` {.bash filename="Terminal"}
 quarto create extension format:pdf myformat
+cd myformat
 quarto add quarto-ext/fancy-text --embed myformat
 ```
 

--- a/docs/extensions/_formats-common.qmd
+++ b/docs/extensions/_formats-common.qmd
@@ -56,12 +56,29 @@ contributes:
 
 In some cases format extensions will want to make use of other extensions. This is permitted, but adding extensions for use within a custom format must be done with a special command line flag to ensure they are embedded correctly.
 
+``` {.bash filename="Terminal"}
+quarto create extension format:pdf myformat
+quarto add quarto-ext/fancy-text --embed myformat
+```
+
 For example, here we want to make the [fancy-text](https://github.com/quarto-ext/fancy-text) extension (which provides special formatting for the words {{< latex >}} and {{< bibtex >}}) available for users of the [jss](https://github.com/quarto-journals/jss) custom format:
 
 ``` {.bash filename="Terminal"}
-quarto add quarto-ext/fancy-text --embed quarto-journals/jss
+quarto add quarto-ext/fancy-text --embed jss
 ```
 
-This will add the `quarto-ext/fancy-text` extension into the `quarto-journals/jss` extension in the `_extensions` folder. By embedding an extension you make it available without creating the potential for conflict with other versions of the extension that uses might already have installed.
+This will produce the following output:
+
+``` {.bash filename="Output"}
+quarto-journals/jss
+└── _extensions
+    └── jss
+        ├── _extensions
+        │   └── quarto-ext
+        │       └── fancy-text
+        └── partials
+```
+
+This will add the `quarto-ext/fancy-text` extension into the `jss` extension in the `_extensions` folder. By embedding an extension you make it available without creating the potential for conflict with other versions of the extension that uses might already have installed.
 
 [^_formats-common-1]: This is most common in the the case of PDF based formats which have a secondary step of converting the LaTeX produced by Pandoc into a PDF. If there are files that are referenced indirectly by the LaTeX, they will need to be discoverable and should typically be copied into the same directory that contains the LaTeX input.


### PR DESCRIPTION
This PRs fixes and improves the documentation for extension embedding.

The example was to embed extension in an installed extension, which actually should never happen in user, but instead you want to embed extension when developping one.

In addition, the `jss` / `fancy-text` example now got adirectory tree to clearly show that embedding means adding an extension within an extension.

This is related to quarto-dev/quarto-cli#6291