### PR TITLE
Add a landing page for Reference > Code Cells

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -462,6 +462,7 @@ website:
                   - text: "FictionBook"
                     href: docs/reference/formats/fb2.qmd
           - section: "Code Cells"
+            href: docs/reference/cells/index.qmd
             contents:
               - text: "Jupyter"
                 href: docs/reference/cells/cells-jupyter.qmd

--- a/docs/reference/cells/index.qmd
+++ b/docs/reference/cells/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Code Cells
+toc: false
+anchor-sections: false
+listing:
+  id: reference-links
+  template: ../../../ejs/links.ejs
+  contents: ./reference.yml
+---
+
+The options available in an executable code cell depend on the engine used to process them. The engine is chosen automatically, as outlined in the [Guide](https://quarto.org/docs/computations/execution-options.html#engine-binding).
+
+::: {#reference-links .column-screen-inset-right style="max-width: 850px;"}
+:::

--- a/docs/reference/cells/reference.yml
+++ b/docs/reference/cells/reference.yml
@@ -1,0 +1,8 @@
+- title: "Code Cells"
+  links:
+    - text: Jupyter
+      href: cells-jupyter.qmd
+    - text: Knitr
+      href: cells-knitr.qmd
+    - text: Observable JS
+      href: cells-ojs.qmd

--- a/docs/reference/index.qmd
+++ b/docs/reference/index.qmd
@@ -7,7 +7,7 @@ anchor-sections: false
 listing:
   id: reference-links
   template: ../../ejs/links.ejs
-  contents: reference.yml
+  contents: ./reference.yml
 image: /images/hero_right.png  
 ---
 


### PR DESCRIPTION
I'd like to provide a link on the cheatsheet for where people can learn about other code cell options. Currently, I'd need to list both a knitr and jupyter link because there is no common landing page (except the top-level Reference page).

I'm not sure if there is a less duplicative approach than what I did here (copying part of the top-level `reference.yml`)...

Also open to what text might be on this landing page.