### PR TITLE
docs: explicit reference to filetype for .mmd File Includes

### DIFF
--- a/docs/authoring/diagrams.qmd
+++ b/docs/authoring/diagrams.qmd
@@ -134,7 +134,7 @@ graph G {
 
 ## File Include
 
-You might find it more convenient to edit your diagram in a standalone file and then reference it from within your `.qmd` document. You can do this by adding the `file` option to a Mermaid or Graphviz cell.
+You might find it more convenient to edit your diagram in a standalone `.dot` or `.mmd` file and then reference it from within your `.qmd` document. You can do this by adding the `file` option to a Mermaid or Graphviz cell.
 
 For example, here we include a very complex diagram whose definition would be too unwieldy to provide inline:
 


### PR DESCRIPTION
Makes more explicit that an .mmd file can be used as an external source when including a Mermaid diagram in a .qmd document, as this is made more explicit for .dot files in the current version of the docs.

Mermaid and Graphviz diagrams can be included in `.qmd` documents from external files.

In the docs an example is given for how to achieve this
using a Graphviz diagram defined in a `.dot` file.

This minor change makes it more explicit that an appropriate filetype
that would achieve the same for a Mermaid diagram is `.mmd`.

The `.mmd` filetype is mentioned two sections previous
in the context of specific editors (RStudio, VS Code).
Readers of the docs are likely to benefit from seeing
the relevant filetypes close to their implementation in the File Include section of the docs,
especially if they are not users of RStudio or VS Code and
may miss those previous sections.