### PR TITLE
Add journal article template for the APSR to listing

### DIFF
--- a/docs/extensions/listings/journal-articles.yml
+++ b/docs/extensions/listings/journal-articles.yml
@@ -75,3 +75,9 @@
   author: "[kelly-sovacool](https://github.com/kelly-sovacool)"
   description:
     Quarto template for ASM mSystems.
+
+- name: apsr
+  path: https://github.com/christopherkenny/apsr
+  author: "[christopherkenny](https://github.com/christopherkenny)"
+  description: |
+    American Political Science Review (APSR)


### PR DESCRIPTION
The American Political Science Review is one of the primary journals in political science. This adds a Quarto template for the APSR to listing page.

The template is on GitHub, has a[ `readme.md`](https://github.com/christopherkenny/apsr/blob/main/README.md) file, and is licensed under MIT (for the Quarto part) and CC BY 4.0 (for the underlying LaTeX template). 