### PR TITLE
Update rstudio.qmd

### DIFF
--- a/docs/get-started/computations/rstudio.qmd
+++ b/docs/get-started/computations/rstudio.qmd
@@ -282,6 +282,8 @@ Save your document and inspect the rendered output.
 The average city mileage of the cars in our data is 16.86 and the average highway mileage is 23.44.
 :::
 
+Note: If you have no R-code chunk in your document, make sure to set your engine in the YAML Header (engine: knitr).
+
 ## Caching
 
 If your document includes code chunks that take too long to compute, you might want to cache the results of those chunks.


### PR DESCRIPTION
added a note for inline R Code evaluation.

The note explains the changes that require an explicit rendering engine definition if no code chunks are available.