### PR TITLE
Added a note about engine specification for inline R code

### DIFF
--- a/docs/computations/execution-options.qmd
+++ b/docs/computations/execution-options.qmd
@@ -178,6 +178,13 @@ To include executable expressions within markdown for Knitr, enclose the express
 The radius of the circle is `r radius`.
 ```
 
+::: {.callout-note}
+Starting from version 1.3.433, if you only use R for inline code in Quarto, you need to explicitly specify the "knitr" engine. You can do this by adding `engine: knitr` in your YAML header.
+
+However, if you use at least one code chunk that uses R, this step is not necessary.
+:::
+
+
 ### OJS
 
 To include reactive OJS expressions within markdown, use the syntax `${expr}`. For example, if we have a reactive called `radius` we can use it within markdown as follows:


### PR DESCRIPTION
Since 1.3.433 it is necessary to specify the engine (knitr) if no code chunk uses R. 
This was not documented anywhere else. So I added a callout-note in lines 181-187.

The second amendment in the file was created by GitHub. I did not actively edit line 415. Maybe the GitHubs Code editor added a CR-LF at the end?
I hope this is not a problem 