### PR TITLE
docs: add a note to show how to upgrade ojs core library

### DIFF
--- a/docs/interactive/ojs/libraries.qmd
+++ b/docs/interactive/ojs/libraries.qmd
@@ -70,6 +70,17 @@ Plot.plot({
 
 You can find complete documentation for Observable plot <https://github.com/observablehq/plot>.
 
+::: {.callout-note}
+Quarto does not dynamically embed Observable, thus the version embedded by Quarto may be a little out of date.
+If you need to use the latest version of Plot (or any other core libraries), you can use the `import` function to import the latest version. 
+
+```ojs
+Plot = import("https://esm.sh/@observablehq/plot")
+```
+
+It's also possible to install Plot locally using NPM and then import it from your local node_modules directory, see <https://observablehq.com/plot/getting-started#installing-from-npm> for details.
+:::
+
 ## D3 {#d3}
 
 [D3.js](https://d3js.org/) is a JavaScript library for manipulating documents based on data. D3 is capable of creating just about any interactive graphic you can imagine!


### PR DESCRIPTION
This PR adds a note on how to upgrade an Observable core library such as Plot.

This is because of recurring questions on this aspect:
- https://github.com/quarto-dev/quarto-cli/discussions/3677
- https://github.com/quarto-dev/quarto-cli/discussions/6410