### PR TITLE
fix(prelease/inline.qmd): missing "e" for "Note that"

### DIFF
--- a/docs/prerelease/1.4/inline.qmd
+++ b/docs/prerelease/1.4/inline.qmd
@@ -46,7 +46,7 @@ execute:
 
 ## Markdown Output
 
-Not that by default, the output of inline expressions is treated as ordinary text (i.e. markdown within it is not rendered). Any markdown like syntax within the output of inline expressions will be automatically escaped. For example, the following inline expression:
+Note that by default, the output of inline expressions is treated as ordinary text (i.e. markdown within it is not rendered). Any markdown like syntax within the output of inline expressions will be automatically escaped. For example, the following inline expression:
 
 `` `{{python}} '**not bold**'` ``
 


### PR DESCRIPTION
This PR fixes a typo noticed in <https://github.com/quarto-dev/quarto-cli/discussions/6486?notification_referrer_id=NT_kwDOAIe-LLI3MzQ2OTY4NjU2Ojg4OTYwNDQ#discussioncomment-6696774>.