### PR TITLE
Add an entry for the quarto-d2 filter

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -283,3 +283,9 @@
   author: "[clearmatics](https://github.com/clearmatics/)"
   description: |
     Run standalone React components in your project!
+
+- name: d2
+  path: https://github.com/data-intuitive/quarto-d2
+  author: "[Data Intuitive](https://github.com/data-intuitive/)"
+  description: |
+    Render [D2 diagrams](https://d2lang.com) directly in your documents.


### PR DESCRIPTION
This extension adds a lua extension to render D2 diagrams in a quarto document.

Example:

````markdown
---
title: "D2 Example"
filters:
  - d2
---

```{.d2}
logs: {
  shape: page
  style.multiple: true
}
user: User {shape: person}
network: Network {
  tower: Cell Tower {
    satellites: {
      shape: stored_data
      style.multiple: true
    }

    satellites -> transmitter
    satellites -> transmitter
    satellites -> transmitter
    transmitter
  }
  processor: Data Processor {
    storage: Storage {
      shape: cylinder
      style.multiple: true
    }
  }
  portal: Online Portal {
    UI
  }

  tower.transmitter -> processor: phone logs
}
server: API Server

user -> network.tower: Make call
network.processor -> server
network.processor -> server
network.processor -> server

server -> logs
server -> logs
server -> logs: persist

server -> network.portal.UI: display
user -> network.portal.UI: access {
  style.stroke-dash: 3
}
```

````

---

Result:

![](https://github.com/data-intuitive/quarto-d2/raw/main/images/diagram-1.svg)