### PR TITLE
Add missing column specifiers -- page-inset-left/right

### DIFF
--- a/docs/authoring/article-layout.qmd
+++ b/docs/authoring/article-layout.qmd
@@ -409,29 +409,44 @@ This content will appear in the margin!
 Here are all of the available column specifiers:
 
 ::: column-page-right
-+--------------+---------------------------------+---------------------------------+
-| Column       | Code Cell `column`              | Class Name                      |
-+==============+=================================+=================================+
-| Body         |     column: body                |     .column-body                |
-|              |     column: body-outset         |     .column-body-outset         |
-|              |     column: body-outset-left    |     .column-body-outset-left    |
-|              |     column: body-outset-right   |     .column-body-outset-right   |
-+--------------+---------------------------------+---------------------------------+
-| Page         |     column: page                |     .column-page                |
-|              |     column: page-left           |     .column-page-left           |
-|              |     column: page-right          |     .column-page-right          |
-+--------------+---------------------------------+---------------------------------+
-| Screen Inset |     column: screen-inset        |     .column-screen-inset        |
-|              |     column: screen-inset-shaded |     .column-screen-inset-shaded |
-|              |     column: screen-inset-left   |     .column-screen-inset-left   |
-|              |     column: screen-inset-right  |     .column-screen-inset-right  |
-+--------------+---------------------------------+---------------------------------+
-| Screen       |     column: screen              |     .column-screen              |
-|              |     column: screen-left         |     .column-screen-left         |
-|              |     column: screen-right        |     .column-screen-right        |
-+--------------+---------------------------------+---------------------------------+
-| Margin       |     column: margin              |     .column-margin              |
-+--------------+---------------------------------+---------------------------------+
++--------------+-----------------------------+-----------------------------+
+| Column       | Code Cell `column`          | Class Name                  |
++==============+=============================+=============================+
+| Body         | ```                         | ```                         |
+|              | column: body                | .column-body                |
+|              | column: body-outset         | .column-body-outset         |
+|              | column: body-outset-left    | .column-body-outset-left    |
+|              | column: body-outset-right   | .column-body-outset-right   |
+|              | ```                         | ```                         |
++--------------+-----------------------------+-----------------------------+
+| Page Inset   | ```                         | ```                         |
+|              | column: page-inset-left     | .column-page-inset-left     |
+|              | column: page-inset-right    | .column-page-inset-right    |
+|              | ```                         | ```                         |
++--------------+-----------------------------+-----------------------------+
+| Page         | ```                         | ```                         |
+|              | column: page                | .column-page                |
+|              | column: page-left           | .column-page-left           |
+|              | column: page-right          | .column-page-right          |
+|              | ```                         | ```                         |
++--------------+-----------------------------+-----------------------------+
+| Screen Inset | ```                         | ```                         |
+|              | column: screen-inset        | .column-screen-inset        |
+|              | column: screen-inset-shaded | .column-screen-inset-shaded |
+|              | column: screen-inset-left   | .column-screen-inset-left   |
+|              | column: screen-inset-right  | .column-screen-inset-right  |
+|              | ```                         | ```                         |
++--------------+-----------------------------+-----------------------------+
+| Screen       | ```                         | ```                         |
+|              | column: screen              | .column-screen              |
+|              | column: screen-left         | .column-screen-left         |
+|              | column: screen-right        | .column-screen-right        |
+|              | ```                         | ```                         |
++--------------+-----------------------------+-----------------------------+
+| Margin       | ```                         | ```                         |
+|              | column: margin              | .column-margin              |
+|              | ```                         | ```                         |
++--------------+-----------------------------+-----------------------------+
 :::
 
 ## PDF/LaTeX Layout {data-link="PDF/LaTeX Layout"}


### PR DESCRIPTION
The table of available column specifiers was missing `page-inset-left` and `page-inset-right`, so I added them to the table.