### PR TITLE
Fix typo in vscode-notebook.qmd

### DIFF
--- a/docs/tools/vscode-notebook.qmd
+++ b/docs/tools/vscode-notebook.qmd
@@ -37,7 +37,7 @@ Quarto uses leading comments with a special prefix (`#|`) to denote cell options
 
 Note that options must appear at the very beginning of the cell. As with document front-matter, option names/values use YAML syntax.
 
-There are many output options available, including options to optionally hide code, warnings, and/or output. See the documentation on [Output Outputs](../computations/execution-options.qmd#output-options) for additional details.
+There are many output options available, including options to optionally hide code, warnings, and/or output. See the documentation on [Output Options](../computations/execution-options.qmd#output-options) for additional details.
 
 ## Cell Execution
 


### PR DESCRIPTION
Fixed small typo: changed "Output Outputs" to "Output Options"