### PR TITLE
chore: update checkout action to v4

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -152,7 +152,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -190,7 +190,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -230,7 +230,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/quarto-pub.qmd
+++ b/docs/publishing/quarto-pub.qmd
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -208,7 +208,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -342,7 +342,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v4 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
This PR updates the documentation to use the checkout GitHub Actions v4.

See <https://github.com/quarto-dev/quarto-actions/pull/86> for action repository already updated.

Checkout action release: https://github.com/actions/checkout/releases/tag/v4.0.0