### PR TITLE
fix: use default base url for jsdelivr

### DIFF
--- a/docs/interactive/ojs/libraries.qmd
+++ b/docs/interactive/ojs/libraries.qmd
@@ -249,7 +249,7 @@ Modules can optionally include an `@` sign with a version. For example:
 d3 = require("d3@7")
 ```
 
-See the [jsDelivr documentation](https://www.jsdelivr.com/features#npm) for additional details. Note that the require function automatically prepends the prefix `https://cdn.jsdelivr.net/npm/` when resolving imports, so where the jsDeliver documentation says to use this URL:
+See the [jsDelivr documentation](https://www.jsdelivr.com) for additional details. Note that the require function automatically prepends the prefix `https://cdn.jsdelivr.net/npm/` when resolving imports, so where the jsDeliver documentation says to use this URL:
 
     https://cdn.jsdelivr.net/npm/package@version/file
 


### PR DESCRIPTION
The URL has changed, so use the apex url now.

Fixes quarto-dev/quarto-cli#6862