### PR TITLE
fix: typo in jupyterlab-quarto version

### DIFF
--- a/docs/tools/_jupyter-lab-extension-install.qmd
+++ b/docs/tools/_jupyter-lab-extension-install.qmd
@@ -33,11 +33,11 @@ You can install the Quarto JupyterLab extension one of two ways:
     | Platform       | Commands                                          |
     +================+===================================================+
     | Mac/Linux      | ``` {.bash filename="Terminal"}                   |
-    |                | python3 -m pip install jupyterlab-quarto==0.1.45 |
+    |                | python3 -m pip install jupyterlab-quarto==0.1.45  |
     |                | ```                                               |
     +----------------+---------------------------------------------------+
     | Windows        | ``` {.powershell filename="Terminal"}             |
-    |                | py -m pip install jupyterlab-quarto==0.1.45      |
+    |                | py -m pip install jupyterlab-quarto==0.1.45       |
     |                | ```                                               |
     +----------------+---------------------------------------------------+
 

--- a/docs/tools/_jupyter-lab-extension-install.qmd
+++ b/docs/tools/_jupyter-lab-extension-install.qmd
@@ -33,11 +33,11 @@ You can install the Quarto JupyterLab extension one of two ways:
     | Platform       | Commands                                          |
     +================+===================================================+
     | Mac/Linux      | ``` {.bash filename="Terminal"}                   |
-    |                | python3 -m pip install jupyterlab-quarto==0.1.4.5 |
+    |                | python3 -m pip install jupyterlab-quarto==0.1.45 |
     |                | ```                                               |
     +----------------+---------------------------------------------------+
     | Windows        | ``` {.powershell filename="Terminal"}             |
-    |                | py -m pip install jupyterlab-quarto==0.1.4.5      |
+    |                | py -m pip install jupyterlab-quarto==0.1.45      |
     |                | ```                                               |
     +----------------+---------------------------------------------------+
 


### PR DESCRIPTION
This PR fixes a typo in the version number of jupyterlab (*i.e.*, an extra dot).