### PR TITLE
fix: href does not exist, correct is path

### DIFF
--- a/docs/websites/website-listings.qmd
+++ b/docs/websites/website-listings.qmd
@@ -528,7 +528,7 @@ will include all the documents in the `posts` directory, but will also merge in 
 - title: "Archived Item 1"
   author: Norah Jones
   date: 2020-01-01
-  href: "archived/archived-item-.html"
+  path: "archived/archived-item-.html"
   categories: [archived, technology]
 ```
 


### PR DESCRIPTION
This PR fixes the documentation which states the option to add file or external links is `href` when it is `path` (or at least the latter works as most users expect it to work).

This is from at least two feedback this week:
- https://github.com/quarto-dev/quarto-cli/issues/4903#issuecomment-1736357397
- https://github.com/quarto-dev/quarto-cli/discussions/6338
- https://github.com/quarto-dev/quarto-cli/discussions/6309

CC @dragonstyle 