### PR TITLE
Fix formatting of `output-location` description

### DIFF
--- a/docs/reference/formats/presentations/revealjs.json
+++ b/docs/reference/formats/presentations/revealjs.json
@@ -167,7 +167,7 @@
       },
       {
         "name": "output-location",
-        "description": "Location of output relative to the code that generated it. The possible values are as follows:\n\n- `default`: Normal flow of the slide after the code\n- `fragment`: In a fragment (not visible until you advance)\n- `slide`: On a new slide after the curent one\n- 'column': In an adjacent column \n- `column-fragment`:   In an adjacent column (not visible until you advance)\n\nNote that this option is supported only for the `revealjs` format.\n"
+        "description": "Location of output relative to the code that generated it. The possible values are as follows:\n\n- `default`: Normal flow of the slide after the code\n- `fragment`: In a fragment (not visible until you advance)\n- `slide`: On a new slide after the curent one\n- `column`: In an adjacent column \n- `column-fragment`:   In an adjacent column (not visible until you advance)\n\nNote that this option is supported only for the `revealjs` format.\n"
       }
     ]
   },


### PR DESCRIPTION
the `column` option uses the wrong quotes. This PR fixes that

<img width="955" alt="Screenshot 2023-09-27 at 5 41 49 PM" src="https://github.com/quarto-dev/quarto-web/assets/14034784/d2713c18-cf0b-46d4-b422-988a2b677db2">
