### PR TITLE
Update `r-stretch` Documentation

### DIFF
--- a/docs/presentations/revealjs/advanced.qmd
+++ b/docs/presentations/revealjs/advanced.qmd
@@ -224,7 +224,7 @@ You can also disable auto-stretch for an individual slide by adding the `.nostre
 ## Slide Title {.nostretch}
 ```
 
-`auto-stretch` will only apply on non-nested image, which means an image in a feature blocks (e.g fragments, layout panel, columns, ... ) or a custom Divs will be ignored. For custom Divs, you can opt-in `auto-stretch` behavior by adding the class `.r-stretch` to the outer divs. In that the image within the blocks will be unwrapped below.
+`auto-stretch` will not apply to images with a specified `height` yet will apply if only `width` is specified. `auto-stretch` will only apply on non-nested image, which means an image in a feature blocks (e.g fragments, layout panel, columns, ... ) or a custom Divs will be ignored. For custom Divs, you can opt-in `auto-stretch` behavior by adding the class `.r-stretch` to the outer divs. In that the image within the blocks will be unwrapped below.
 
 ## Auto Animate
 


### PR DESCRIPTION
Added a comment about `r-stretch` no applied on images with a specified `height`.

Reflecting comments by @cderv  on https://github.com/quarto-dev/quarto-cli/discussions/7128.