### PR TITLE
fix gallery link to secure

### DIFF
--- a/docs/gallery/gallery.yml
+++ b/docs/gallery/gallery.yml
@@ -114,7 +114,7 @@
       thumbnail: websites/websites-julia-workshop.png
     - title: "devito"
       subtitle: devito documentation
-      href: https://devitoproject.org
+      href: https://www.devitoproject.org
       thumbnail: websites/websites-devito.png
     - title: Beatriz Milz
       subtitle: personal website + blog


### PR DESCRIPTION
Looks like the certificate only works with `www`, fixed here