### PR TITLE
Document conditional spans and code blocks

### DIFF
--- a/docs/authoring/conditional.qmd
+++ b/docs/authoring/conditional.qmd
@@ -2,11 +2,11 @@
 title: "Conditional Content"
 ---
 
-In some cases you may want to create content that only displays for a given output format (or only displays when *not* rendering to a format). You can accomplish this by creating divs with the `.content-visible` and `.content-hidden` classes.
+In some cases you may want to create content that only displays for a given output format (or only displays when *not* rendering to a format). You can accomplish this by creating divs, spans and code blocks with the `.content-visible` and `.content-hidden` classes.
 
 ## .content-visible
 
-To make content visible only for a given format, create a div (`:::`) with the `.content-visible` class. For example, here we mark content as only visible in HTML:
+To make content visible only for a given format, you can create a div (`:::`) with the `.content-visible` class. For example, here we mark content as only visible in HTML:
 
 ``` markdown
 ::: {.content-visible when-format="html"}
@@ -14,6 +14,23 @@ To make content visible only for a given format, create a div (`:::`) with the `
 Will only appear in HTML.
 
 :::
+```
+
+You can also set conditions on non-executable code blocks:
+
+```` markdown
+```{.python .content-visible when-format="html"}
+# code shown only in HTML
+2+2
+```
+````
+
+To apply a condition only to a part of a paragraph, use a span (`[]{}`):
+
+``` markdown
+Some text
+[in HTML.]{.content-visible when-format="html"}
+[in PDF.]{.content-visible when-format="pdf"}
 ```
 
 You can also mark content as visible for all formats *except* a specified format. For example:
@@ -30,7 +47,7 @@ Then `when-format` and `unless-format` attributes match the current Pandoc outpu
 
 ## .content-hidden
 
-To prevent content from being displayed when rendering to a given format, create a div (`:::`) with the `.content-hidden` class. For example, here we mark content as hidden in HTML:
+To prevent content from being displayed when rendering to a given format, use the `.content-hidden` class. For example, here we mark content as hidden in HTML:
 
 ``` markdown
 ::: {.content-hidden when-format="html"}


### PR DESCRIPTION
This documents that conditional spans are supported (following https://github.com/quarto-dev/quarto-cli/pull/7083).

It also documents conditions on non-executable code blocks, though I wonder now if it's worth documenting as long as the feature is not working for executable blocks.

Should I make a PR on quarto-cli to update the changelog? (sorry I didn't add it previously, I thought things might change before getting merged).