### PR TITLE
update terminal comment to not use an apostrophe

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -72,7 +72,7 @@ If you do not already have a `gh-pages` branch, you can create one as follows. F
 
 ``` {.bash filename="Terminal"}
 git checkout --orphan gh-pages
-git reset --hard # make sure you've committed changes before running this!
+git reset --hard # make all changes are committed before running this!
 git commit --allow-empty -m "Initialising gh-pages branch"
 git push origin gh-pages
 ```

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -72,7 +72,7 @@ If you do not already have a `gh-pages` branch, you can create one as follows. F
 
 ``` {.bash filename="Terminal"}
 git checkout --orphan gh-pages
-git reset --hard # make all changes are committed before running this!
+git reset --hard # make sure all changes are committed before running this!
 git commit --allow-empty -m "Initialising gh-pages branch"
 git push origin gh-pages
 ```


### PR DESCRIPTION
the apostrophe in

```sh
git reset --hard # make sure you've committed changes before running this!
```

was causing vscode to look for the matching apostrophe and was not running the code in the block and returning a `quote>` prompt