### PR TITLE
Delete docs/presentations/revealjs/_learning-more.md

### DIFF
--- a/docs/presentations/revealjs/_learning-more.md
+++ b/docs/presentations/revealjs/_learning-more.md
@@ -1,3 +1,0 @@
--   [Presenting Slides](presenting.qmd) describes slide navigation, printing to PDF, drawing on slides using a chalkboard, and creating multiplex presentations.
--   [Advanced Reveal](advanced.qmd) delves into transitions, animations, advanced layout and positioning, and other options available for customizing presentations.
--   [Reveal Themes](themes.qmd) talks about using and customizing existing themes as well as creating brand new themes.


### PR DESCRIPTION
The doc doesn't seem to be used anywhere (`index.qmd`, `presenting.qmd`, `theme.qmd` and `advanced.qmd` have their own specific "Learning more" content).