### PR TITLE
Add  quarto-ieee template for IEEE transaction/journal

### DIFF
--- a/docs/extensions/listings/journal-articles.yml
+++ b/docs/extensions/listings/journal-articles.yml
@@ -81,3 +81,10 @@
   author: "[christopherkenny](https://github.com/christopherkenny)"
   description: |
     American Political Science Review (APSR)
+    
+- name: ieee
+  path: https://github.com/dfolio/quarto-ieee
+  author: "[dfolio](https://github.com/dfolio)"
+  description: |
+    Institute of Electrical and Electronics Engineers (IEEE)
+


### PR DESCRIPTION
IEEE is one of the most famous scientific associations in the fields of engineering. It is the publisher of hundreds of peer-reviewed transactions, journals and magazines in various fields (e.g. electronics, computer engineering, control, biomedical, etc.).
This adds the [quarto-ieee] template, which supports the [`IEEEtran`](https://ctan.org/pkg/ieeetran)  LaTeX document class for PDF output. In addition, the HTML output is supported, and attempts to mimic as closely as possible the paper layout seen on [IEEEXplore<sup>®</sup>](https://ieeexplore.ieee.org/).

The [quarto-ieee] template is hosted on Github, includes a [`README.md`](https://github.com/dfolio/quarto-ieee#readme), and is licensed under the MIT.

[quarto-ieee]: <https://github.com/dfolio/quarto-ieee>