### PR TITLE
use python f-strings in script.qmd

### DIFF
--- a/docs/prerelease/1.4/script.qmd
+++ b/docs/prerelease/1.4/script.qmd
@@ -73,8 +73,7 @@ Jupyter scripts are especially convenient when most of your document consists of
 #| echo: false
 radius = 10
 from IPython.display import display, Markdown
-display(Markdown("The _radius_ of the circle is **{radius}**."
-    .format(radius = radius)))
+display(Markdown(f"The _radius_ of the circle is **{radius}**."))
 ```
 
 Note that dynamically generated markdown will still be enclosed in the standard Quarto output divs. If you want to remove all of Quarto's default output enclosures use the `output: asis` option. For example:
@@ -85,8 +84,7 @@ Note that dynamically generated markdown will still be enclosed in the standard 
 #| output: asis
 radius = 10
 from IPython.display import display, Markdown
-display(Markdown("The _radius_ of the circle is **{radius}**."
-    .format(radius = radius)))
+display(Markdown(f"The _radius_ of the circle is **{radius}**."))
 ```
 
 


### PR DESCRIPTION
update docs to use python f-strings instead of `.format()` notation