### PR TITLE
Code listings: render the callout

### DIFF
--- a/docs/authoring/cross-references.qmd
+++ b/docs/authoring/cross-references.qmd
@@ -267,6 +267,7 @@ SELECT * FROM Customers
 ```
 
 Then we query the customers database (@lst-customers).
+````
 
 ::: {.callout-note}
 
@@ -274,7 +275,7 @@ Note that code listings currently only work with _display code blocks_ (as oppos
 
 :::
 
-````
+
 
 ## Theorems and Proofs
 


### PR DESCRIPTION
The callout-note was showing up as part of the code example, which I don't think was what was intended.