### PR TITLE
docs(dashboards): Fix link to Pages in dashboard components

### DIFF
--- a/docs/dashboards/reference.qmd
+++ b/docs/dashboards/reference.qmd
@@ -35,7 +35,7 @@ format:
 
 ## Pages
 
-[Pages](http://localhost:6978/docs/dashboards/components.html#pages) can specify a custom orientation that is distinct from the global orientation.
+[Pages](components.qmd#pages) can specify a custom orientation that is distinct from the global orientation.
 
 | Option        | Description                                         |
 |---------------|-----------------------------------------------------|


### PR DESCRIPTION
From a `localhost` link to `components.qmd#pages`