### PR TITLE
Prerelease notes/howto for Connect email feature

### DIFF
--- a/docs/prerelease/1.4/_highlights.qmd
+++ b/docs/prerelease/1.4/_highlights.qmd
@@ -14,6 +14,8 @@ Quarto 1.4 includes the following new features:
 
 -   [Easy Binder Configuration for Quarto Projects](/docs/prerelease/1.4/binder.qmd)---Support for generating files required to deploy a Quarto project using Binder.
 
+-   [Connect Email Generation](/docs/prerelease/1.4/email.qmd)---Extends the `html` output format so that HTML/text emails can be created and selectively delivered through Posit Connect.
+
 -   [Lightbox Treatment for Images and Figures](/docs/prerelease//1.4/lightbox.qmd)---Support for zooming into images and figures using a `lightbox`. Includes support for grouping multiple images into a gallery.
 
 -   [Lua changes](/docs/prerelease/1.4/lua_changes.qmd)---Quarto v1.4 adds new features to writers of Lua filters.

--- a/docs/prerelease/1.4/email.qmd
+++ b/docs/prerelease/1.4/email.qmd
@@ -1,0 +1,134 @@
+---
+title: "Connect Email Generation"
+---
+
+{{< include _pre-release-feature.qmd >}}
+
+## Overview
+
+Quarto v1.4 has an email generation feature can be used for HTML documents published in Posit Connect (https://posit.co/products/enterprise/connect/). This feature contributes to the HTML output format and enables users to generate HTML and/or text emails that can be selectively delivered on document render in Connect.
+
+### How to author an HTML document with a Connect email
+
+Using this feature is fairly straightforward, and the first thing you need to know is that the email message must belong to a single region of content using a div (`:::`) with the class `.email`. Secondly, a subject line is required, and that belongs in its own div with the class `.subject`. The `.subject` div should be inside of the `.email` div and it needs to consist of only text. Optionally, you could include a `.email-text` div with a text-only version of the email. If this is included, it will serve as a fallback should an email client not be able to display HTML email.
+
+A typical HTML document with an associated Connect email might look something like this:
+
+```
+---
+format: email
+---
+
+The report content. Anything that is here is not part of the email message.
+
+::: {.email}
+
+::: {.subject}
+The subject line.
+:::
+
+::: {.email-text}
+An optional text-only version of the email message..
+:::
+
+The HTML email content. Here you can add code cells and write accompanying text.
+This content is not seen when viewing the rendered document on Connect (it's only
+seen when sending an email from the Connect document page). Emails from Connect
+can be sent manually, and, they can also be scheduled.
+
+:::
+
+Any additional report content.
+
+```
+
+The email div can appear anywhere in the HTML document so long as it only appears once. Any images generated in the email portion of the document (for example, static plots) will be embedded in the email message as Base64 images. This essentially means that all content, even images, will be self-contained and doesn't need to be stored elsewhere and retrieved. With email messages, we have to keep things simple by necessity and this means that interactive or otherwise complex outputs cannot be used (since they cannot be understood by email clients).
+
+If your reporting creates data files (like CSVs or Excel files), these can attached to the email message. We can make this happen by declaring the file names in the YAML header. Say, for instance, the files `"raw_data.csv"` and `"summary.csv"` were written to the working directory through a render of the document. We could make these available as email attachments by using the `email-attachments` option in the YAML, like this:
+
+```
+---
+format: email
+email-attachments:
+  - raw_data.csv
+  - summary.csv
+---
+```
+
+It doesn't matter where in the document those files were generated (e.g., inside or outside of the `.email` div), the key thing is that those files _were_ generated through a document render.
+
+### Suppressing scheduled Connect email messages
+
+Emails on Connect can be set up to be regularly sent upon render. We could suppress that behavior though and ask that an email associated with the main document _not_ be sent upon rendering at the scheduled time (this is known in Connect as suppressing a scheduled email). Put another way we could _allow_ the regular sending of an email message should a .qmd have email components and there is a schedule in place. We can have control over this with by using a div with the `.email-scheduled` class. Running code inside of that should result in a `TRUE`, `True`, or `"yes"` (something _truthy_) if we want emails to be sent unimpeded. If we want to suppress the sending of email at the next scheduled Connect render, the code within that div should return `FALSE`, `False`, or `"no"` (which is _falsy_). Here is an example where the associated email is _only_ sent when a certain condition is true. It's set up using R but could also be equivalently done with Python or other types of computation engines available in Quarto.
+
+````
+---
+format: email
+---
+
+```{r}
+#| echo: false
+
+library(profitcalcs)
+
+profit <- determine_profit()
+
+if (profit < 0) {
+
+  # Send email since we have a reason for it
+
+  subject <- "We have a problem here"
+  send_email <- TRUE
+
+} else {
+
+  # Don't send email; everything is fine
+
+  subject <- "No email. This won't be sent"
+  send_email <- FALSE
+}
+```
+
+The email body follows.
+
+::: {.email}
+
+Our profit was `{r} profit` this quarter and we felt you should know.
+
+::: {.subject}
+`{r} subject`
+:::
+
+::: {.email-scheduled}
+`{r} send_email`
+:::
+
+:::
+
+````
+
+As can be seen, the condition for sending or not was handled in the first code cell. The main email div is set up with child divs to handle the email subject (`.subject`) and whether the email should be sent (`.email-scheduled`). Inline R code injects those divs with values stored in variables; since `send_email` will either be `TRUE` or `FALSE` the email will be sent (or not) depending on the value of `profit`.
+
+### Previewing the HTML email locally
+
+For faster email development and iteration, it's possible to get a local .html file that previews the content of the email. With this option, one could use `quarto render <qmd-file>` and view the `email-preview.html` file that will always be located in the `email-preview` directory. To enable the writing of that file, you must use `email-preview: true` in the document's YAML header. When viewing the HTML file, note that the footer of the email will be an abbreviated version of what is normally generated through a Connect render. Also, there won't be any indication that attachments are included as part of the email (though email clients do tend to present email attachments differently: either as an extended footer and alternately as indicated in the client's top UI for a message).
+
+### Deploying to Connect
+
+Posit Connect has a few ways to render documents. They can be static assets that are fully rendered and sent to the Connect server. Another methodology involves sending the source document (and any needed resources) to Connect where the render occurs there. With respect to the Quarto Email feature, emails can only be rendered and sent when using the latter scheme. To do this in an R-based workflow can publish the .qmd document using the `quarto_publish_doc()` function from the `quarto` package. Here's an example of how this works:
+
+```r
+library(quarto)
+
+quarto_publish_doc(
+  "r_report.qmd",
+  name = "quarto-r-report-with-email",
+  server = "<Connect server address>",
+  account = "<username>",
+  render = "server"
+)
+```
+
+Once the render succeeds, you'll be given the option to navigate to the report in your Connect instance. In the rendered view of the report, the email portion is not visible. Given you are the author of the report you can send yourself the email by clicking on the email icon on the top navigation bar and selecting the option to send the email to yourself. Should the email look satisfactory, you can use various Connect options for the given report to regularly send the email upon render (at a frequency of your choosing) to authorized individuals added to this document.
+
+If using a Python-based workflow, all principles for formatting the document still apply. The method of deploying is a bit different: one should use the `rsconnect-python` library for deployment. It offers a CLI for deployment and many examples are available in the [project README](https://github.com/rstudio/rsconnect-python).

--- a/docs/prerelease/1.4/email.qmd
+++ b/docs/prerelease/1.4/email.qmd
@@ -6,15 +6,13 @@ title: "Connect Email Generation"
 
 ## Overview
 
-Quarto v1.4 has an email generation feature can be used for HTML documents published in Posit Connect (https://posit.co/products/enterprise/connect/). This feature contributes to the HTML output format and enables users to generate HTML and/or text emails that can be selectively delivered on document render in Connect.
+Quarto v1.4 adds an email generation feature that can be used for HTML documents published in [Posit Connect](https://posit.co/products/enterprise/connect/). This feature extends the HTML output format and enables users to generate HTML and/or text emails that can be selectively delivered when the document is rendered in Connect.
 
-### How to author an HTML document with a Connect email
+## Authoring a Connect Email
 
-Using this feature is fairly straightforward, and the first thing you need to know is that the email message must belong to a single region of content using a div (`:::`) with the class `.email`. Secondly, a subject line is required, and that belongs in its own div with the class `.subject`. The `.subject` div should be inside of the `.email` div and it needs to consist of only text. Optionally, you could include a `.email-text` div with a text-only version of the email. If this is included, it will serve as a fallback should an email client not be able to display HTML email.
+A connect email is authored as part of an HTML document. A typical HTML document with an associated Connect email might look something like this:
 
-A typical HTML document with an associated Connect email might look something like this:
-
-```
+```markdown
 ---
 format: email
 ---
@@ -31,22 +29,34 @@ The subject line.
 An optional text-only version of the email message..
 :::
 
-The HTML email content. Here you can add code cells and write accompanying text.
+The HTML email content. Here you can add code cells, produce images, and write accompanying text.
 This content is not seen when viewing the rendered document on Connect (it's only
 seen when sending an email from the Connect document page). Emails from Connect
-can be sent manually, and, they can also be scheduled.
+can be sent manually, and they can also be scheduled.
 
 :::
 
-Any additional report content.
+Any additional report content not part of the email message.
 
 ```
 
-The email div can appear anywhere in the HTML document so long as it only appears once. Any images generated in the email portion of the document (for example, static plots) will be embedded in the email message as Base64 images. This essentially means that all content, even images, will be self-contained and doesn't need to be stored elsewhere and retrieved. With email messages, we have to keep things simple by necessity and this means that interactive or otherwise complex outputs cannot be used (since they cannot be understood by email clients).
+The key things to note are:
 
-If your reporting creates data files (like CSVs or Excel files), these can attached to the email message. We can make this happen by declaring the file names in the YAML header. Say, for instance, the files `"raw_data.csv"` and `"summary.csv"` were written to the working directory through a render of the document. We could make these available as email attachments by using the `email-attachments` option in the YAML, like this:
+* In the document YAML the format is set to email: `format: email`.
 
-```
+* The email content goes inside a fenced div (`:::`) with the class `.email`. The `.email` div can appear anywhere in the HTML document so long as it only appears once. Inside this `.email` div:
+
+    * The subject line goes inside a div with the class `.subject`. The `.subject` div is **required**, and should only contain text.
+
+    * A text-only version of the email goes inside a div with the class `.email-text`. The `email-text` div is **optional**, and will serve as a fallback should an email client not be able to display HTML email.
+
+Any images generated in the email portion of the document (for example, static plots) will be embedded in the email message as Base64 images. This ensures the email content is be self-contained and doesn't need to be stored elsewhere and retrieved. By necessity, interactive or otherwise complex outputs cannot be used since they cannot be understood by email clients.
+
+### Adding Attachments
+
+If your reporting creates data files (like CSVs or Excel files), these can attached to the email message. You can do this by declaring the file names in `email-attachments` in the YAML header. Say, for instance, the files `"raw_data.csv"` and `"summary.csv"` were written to the working directory through a render of the document. You could make these available as email attachments like this:
+
+```yaml
 ---
 format: email
 email-attachments:
@@ -57,16 +67,20 @@ email-attachments:
 
 It doesn't matter where in the document those files were generated (e.g., inside or outside of the `.email` div), the key thing is that those files _were_ generated through a document render.
 
-### Suppressing scheduled Connect email messages
+### Suppressing Scheduled Emails
 
-Emails on Connect can be set up to be regularly sent upon render. We could suppress that behavior though and ask that an email associated with the main document _not_ be sent upon rendering at the scheduled time (this is known in Connect as suppressing a scheduled email). Put another way we could _allow_ the regular sending of an email message should a .qmd have email components and there is a schedule in place. We can have control over this with by using a div with the `.email-scheduled` class. Running code inside of that should result in a `TRUE`, `True`, or `"yes"` (something _truthy_) if we want emails to be sent unimpeded. If we want to suppress the sending of email at the next scheduled Connect render, the code within that div should return `FALSE`, `False`, or `"no"` (which is _falsy_). Here is an example where the associated email is _only_ sent when a certain condition is true. It's set up using R but could also be equivalently done with Python or other types of computation engines available in Quarto.
+Emails on Connect can be set to regularly send upon render. However, you may have conditions where you would like an email associated with the main document _not_ be sent upon rendering at the scheduled time --- this is known in Connect as suppressing a scheduled email. 
 
-````
+You can control whether an email is sent, using a div with the `.email-scheduled` class. The contents of the `.email-scheduled` div should be `TRUE`, `True`, or `"yes"` (something _truthy_) if we want emails to be sent unimpeded. To suppress the sending of email on a Connect render, the contents of the `.email-scheduled` div should be `FALSE`, `False`, or `"no"` (which is _falsy_). 
+
+Here is an example where the associated email is _only_ sent when a certain condition is true. The example uses R but could equivalently be done with Python or any of the other computation engines available in Quarto.
+
+````markdown
 ---
 format: email
 ---
 
-```{r}
+```{{r}}
 #| echo: false
 
 library(profitcalcs)
@@ -107,15 +121,35 @@ Our profit was `{r} profit` this quarter and we felt you should know.
 
 ````
 
-As can be seen, the condition for sending or not was handled in the first code cell. The main email div is set up with child divs to handle the email subject (`.subject`) and whether the email should be sent (`.email-scheduled`). Inline R code injects those divs with values stored in variables; since `send_email` will either be `TRUE` or `FALSE` the email will be sent (or not) depending on the value of `profit`.
+The condition for sending or not, whether `profit < 0`, is computed in the first code cell. The main email div is set up with child divs to handle the email subject (`.subject`) and whether the email should be sent (`.email-scheduled`). Inline R code injects those divs with values stored in variables; since `send_email` will either be `TRUE` or `FALSE` the email will be sent (or not) depending on the value of `profit`.
 
-### Previewing the HTML email locally
+## Previewing an Email
 
-For faster email development and iteration, it's possible to get a local .html file that previews the content of the email. With this option, one could use `quarto render <qmd-file>` and view the `email-preview.html` file that will always be located in the `email-preview` directory. To enable the writing of that file, you must use `email-preview: true` in the document's YAML header. When viewing the HTML file, note that the footer of the email will be an abbreviated version of what is normally generated through a Connect render. Also, there won't be any indication that attachments are included as part of the email (though email clients do tend to present email attachments differently: either as an extended footer and alternately as indicated in the client's top UI for a message).
+When you locally render a document with the `email` format, you'll get HTML output that excludes the `.email` div. For faster email development and iteration, you'll likely want to preview the email content itself. 
 
-### Deploying to Connect
+To preview the email content, set `email-preview: true` in the document's YAML header:
 
-Posit Connect has a few ways to render documents. They can be static assets that are fully rendered and sent to the Connect server. Another methodology involves sending the source document (and any needed resources) to Connect where the render occurs there. With respect to the Quarto Email feature, emails can only be rendered and sent when using the latter scheme. To do this in an R-based workflow can publish the .qmd document using the `quarto_publish_doc()` function from the `quarto` package. Here's an example of how this works:
+```{.yaml filename="report.qmd"}
+---
+format: email
+email-preview: true
+---
+```
+
+With this option set, when you render, e.g. with `quarto render report.qmd`, an HTML file `email-preview.html` will be produced in the `email-preview/` directory. 
+
+When viewing the HTML file, note that the footer of the email will be an abbreviated version of what is normally generated through a Connect render. Also, there won't be any indication that attachments are included as part of the email (though email clients do tend to present email attachments differently: either as an extended footer and alternately as indicated in the client's top UI for a message).
+
+
+## Deploying to Connect
+
+Posit Connect has a two ways to deploy documents: documents are rendered locally, then sent to the Connect server; or document source code (along with any needed resources) is sent to the Connect server and rendered on the server. Quarto emails can only be rendered and sent when using the latter scheme. 
+
+::: {.panel-tabset}
+
+### R
+
+To do this in an R-based workflow, publish the .qmd document using the `quarto_publish_doc()` function from the `quarto` package. Here's an example of how this works:
 
 ```r
 library(quarto)
@@ -129,6 +163,10 @@ quarto_publish_doc(
 )
 ```
 
-Once the render succeeds, you'll be given the option to navigate to the report in your Connect instance. In the rendered view of the report, the email portion is not visible. Given you are the author of the report you can send yourself the email by clicking on the email icon on the top navigation bar and selecting the option to send the email to yourself. Should the email look satisfactory, you can use various Connect options for the given report to regularly send the email upon render (at a frequency of your choosing) to authorized individuals added to this document.
+### Python
 
 If using a Python-based workflow, all principles for formatting the document still apply. The method of deploying is a bit different: one should use the `rsconnect-python` library for deployment. It offers a CLI for deployment and many examples are available in the [project README](https://github.com/rstudio/rsconnect-python).
+
+::: 
+
+Once the render on Connect succeeds, navigate to the report in your Connect instance. In the rendered view of the report, the email portion is not visible. Given you are the author of the report you can send yourself the email by clicking on the email icon on the top navigation bar and selecting the option to send the email to yourself. Should the email look satisfactory, you can use various Connect options for the given report to regularly send the email upon render (at a frequency of your choosing) to authorized individuals added to this document.


### PR DESCRIPTION
This adds v1.4 release notes for the Connect emailing feature introduced in https://github.com/quarto-dev/quarto-cli/pull/6181.