### PR TITLE
Remove duplicate section-numbering option in Typst documentation

### DIFF
--- a/docs/prerelease/1.4/typst.qmd
+++ b/docs/prerelease/1.4/typst.qmd
@@ -44,7 +44,6 @@ The following options are available for customizing Typst output:
 | `margin`              | Margins: `x`, `y`, `top`, `bottom`, `left`, `right`. Specified with units (e.g. `y: 1.25in` or `x: 2cm`).                                                                          |
 | `papersize`           | Paper size: `a4`, `us-letter`, etc. See the docs on [paper sizes](https://typst.app/docs/reference/layout/page/#parameters–paper) for all available sizes.                         |
 | `fontsize`            | Font size (e.g., `12pt`)                                                                                                                                                           |
-| `section-numbering`   | Schema to use for numbering sections, e.g. `1.1.a`.                                                                                                                                |
 | `columns`             | Number of columns for body text.                                                                                                                                                   |
 | `include-in-header`   | `.typ` file to include in header                                                                                                                                                   |
 | `include-before-body` | `.typ` file to include before body                                                                                                                                                 |


### PR DESCRIPTION
Lines 43 and 47 of `typst.qmd` were duplicates. I removed line 47, since line 43 seemed to be the more appropriate position in the table (after the `toc` and `section-numbers` options).