### PR TITLE
Fix typo in layouts.qmd

### DIFF
--- a/docs/dashboards/layouts.qmd
+++ b/docs/dashboards/layouts.qmd
@@ -316,7 +316,7 @@ format: dashboard
 
 ## Tabset (Nested)
 
-You can include tabsets are arbitrarily deep levels. Here we include a tabset within a column of a top level row.
+You can include tabsets as arbitrarily deep levels. Here we include a tabset within a column of a top level row.
 
 ::: {.chart-example .grid}
 ::: g-col-6


### PR DESCRIPTION
Fixes minor typo, 'are' to 'as'.