### PR TITLE
Update _computations-text-editor.qmd

### DIFF
--- a/docs/get-started/computations/_computations-text-editor.qmd
+++ b/docs/get-started/computations/_computations-text-editor.qmd
@@ -32,7 +32,7 @@ plt.errorbar(x, y, yerr=yerr, uplims=upperlimits, lolims=lowerlimits,
              label='subsets of uplims and lolims')
 
 plt.legend(loc='lower right')
-plt.show(fig)
+plt.show()
 ```
 
 ## Plotly


### PR DESCRIPTION
`plt.show(fig)` was giving me the following error:

```python
TypeError                                 Traceback (most recent call last)
Cell In[37], line 17
     14 plt.errorbar(x, y, yerr=yerr, uplims=upperlimits, lolims=lowerlimits, label='subsets of uplims and lolims')
     16 plt.legend(loc='lower right')
---> 17 plt.show(fig)

File ~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/matplotlib/pyplot.py:527, in show(*args, **kwargs)
    483 """
    484 Display all open figures.
    485 
   (...)
    524 explicitly there.
    525 """
    526 _warn_if_gui_out_of_main_thread()
--> 527 return _get_backend_mod().show(*args, **kwargs)

TypeError: _Backend.show() takes 1 positional argument but 2 were given
```