### PR TITLE
Mention use of name particles with reference link

### DIFF
--- a/docs/authoring/create-citeable-articles.qmd
+++ b/docs/authoring/create-citeable-articles.qmd
@@ -24,8 +24,7 @@ citation:
 bibliography: biblio.bib
 ---
 ```
-
-If you omit the citation url, Quarto will attempt to generate a citation url by using the `site-url` and the current page's location. If you'd like to allow Quarto to generate the citation url, you can omit the citation url and simply enable citation output on the page. For example:
+Name particles can be further defined in the `name` key following the [Citation Style Language (CSL) specification for naming particles](https://docs.citationstyles.org/en/stable/specification.html#name-particles). If you omit the citation url, Quarto will attempt to generate a citation url by using the `site-url` and the current page's location. If you'd like to allow Quarto to generate the citation url, you can omit the citation url and simply enable citation output on the page. For example:
 
 ``` yaml
 ---


### PR DESCRIPTION
Editing name particles is addressed with a link to the CSL specification section on naming particles.