### PR TITLE
docs: add example combining when/unless for revealjs/html

### DIFF
--- a/docs/authoring/conditional.qmd
+++ b/docs/authoring/conditional.qmd
@@ -45,6 +45,22 @@ Will not appear in PDF.
 
 Then `when-format` and `unless-format` attributes match the current Pandoc output format with some additional intelligence to alias related formats (e.g. html, html4, and html5). Details are provided below in [Format Matching](#format-matching)
 
+`when-format` and `unless-format` can also be combined to create more complex conditions:
+
+``` markdown
+::: {.content-visible when-format="html" unless-format="revealjs"}
+
+Will only appear in HTML and not in Reveal.js, but actually it appears.
+
+:::
+
+::: {.content-visible when-format="revealjs"}
+
+Will only appear in Reveal.js and not in HTML or other formats.
+
+:::
+```
+
 ## .content-hidden
 
 To prevent content from being displayed when rendering to a given format, use the `.content-hidden` class. For example, here we mark content as hidden in HTML:


### PR DESCRIPTION
This PR adds an example to show how to combine `when-format` and `unless-format` in order to target `revealjs` and html separately.

This is a follow up on:
- https://github.com/quarto-dev/quarto-cli/discussions/7466

Also, this example is likely to be used a lot when using `revealjs` in a website for example.