### PR TITLE
Added tabset explaining creating subtables in a python computation block

### DIFF
--- a/docs/authoring/tables.qmd
+++ b/docs/authoring/tables.qmd
@@ -279,7 +279,10 @@ kable(head(cars))
 
 If your code cell produces multiple tables, you can also specify subcaptions and layout using cell options:
 
-```{{r}}
+::: {.panel-tabset}
+## R
+
+``` {.r}
 #| label: tbl-example
 #| tbl-cap: "Example"
 #| tbl-subcap: 
@@ -292,6 +295,22 @@ library(knitr)
 kable(head(cars))
 kable(head(pressure))
 ```
+
+## Python
+
+``` {.python}
+#| label: tbl-example
+#| tbl-cap: "Example"
+#| tbl-subcap: 
+#|   - "Cars"
+#|   - "Pressure"
+#| layout-ncol: 2
+#| echo: fenced
+
+Markdown(cars + pressure)
+```
+
+:::
 
 ## Grid Tables
 


### PR DESCRIPTION
The R instructions call `kable` *twice* to produce the 2 tables, but in python calling `Markdown` twice does not work. Instead I found that `Markdown(table1 + table2)` seems to work, so I created a `tabset` with instructions for R and Python.

