### PR TITLE
Modify the download button to incorporate the release date of the Quarto version

### DIFF
--- a/docs/download/_download.html
+++ b/docs/download/_download.html
@@ -37,7 +37,10 @@
             downloadData.prefix,
             downloadData.releaseDesc,
             dlData.version,
-            dlData.assets
+            dlData.assets,
+            new Date(dlData.created).toLocaleString("en-US", {
+              dateStyle: "medium",
+            })
           );
           populateDownloadTable(
             downloadData.prefix,
@@ -143,7 +146,7 @@
     }
   }
 
-  function populateDownloadButton(idPrefix, releaseDesc, version, assets) {
+  function populateDownloadButton(idPrefix, releaseDesc, version, assets, releaseDate) {
     const osData = window["quarto-force-os"] || guessOS();
     const extension = window["quarto-force-download"]
       ? window["quarto-force-download"]
@@ -193,7 +196,7 @@
         secondaryTextEl.className = "secondary";
         secondaryTextEl.innerText = `${version}${
           releaseDesc ? " " + releaseDesc : ""
-        } (${osData.name})`;
+        } (${osData.name}) | Date: ${releaseDate}`;
         textContainerEl.append(secondaryTextEl);
 
         containerEl.append(textContainerEl);


### PR DESCRIPTION
The PR contains a modification of the Quarto Download button to incorporate in the release date of the Quarto version.
The change was discussed in: https://github.com/quarto-dev/quarto-cli/discussions/7549

Before:
<img width="580" alt="Quarto Download Button without the Date" src="https://github.com/quarto-dev/quarto-web/assets/833642/ce33832d-f3a4-41c5-8086-3b0401519a4e">


After:
<img width="578" alt="Quarto Download Button with Date" src="https://github.com/quarto-dev/quarto-web/assets/833642/8db51290-bc60-4178-9a59-1092644e9d03">


**Note:** This will apply the change across all instances of the Quarto download button, e.g. 

- https://deploy-preview-915--mystifying-jepsen-fa4396.netlify.app/docs/download/
- https://deploy-preview-915--mystifying-jepsen-fa4396.netlify.app/docs/download/prerelease
- https://deploy-preview-915--mystifying-jepsen-fa4396.netlify.app/docs/get-started/

[Edited by @cwickham to link to live preview of PR build]

(There may be more...)