### PR TITLE
Emphasize extension options can be set in _quarto.yml

### DIFF
--- a/docs/projects/quarto-projects.qmd
+++ b/docs/projects/quarto-projects.qmd
@@ -9,7 +9,7 @@ Quarto projects are directories that provide:
 
 -   A way to render all or some of the files in a directory with a single command (e.g. `quarto render myproject`).
 
--   A way to share YAML configuration across multiple documents.
+-   A way to share YAML configuration across multiple documents, including extension options.
 
 -   The ability to redirect output artifacts to another directory.
 
@@ -70,9 +70,14 @@ format:
     documentclass: report
     margin-left: 30mm
     margin-right: 30mm
+
+lightbox:
+  match: auto
+filters:
+  - lightbox
 ```
 
-Note that the project file contains both global options that apply to all formats (e.g. `toc` and `bibliography`) as well as format-specific options.
+Note that the project file contains both global options that apply to all formats (e.g. `toc` and `bibliography`), format-specific options, and extension-specific options (e.g. `lightbox`).
 
 You can further customize project metadata based on different project profiles (e.g. development vs. production or creating multiple versions of a book or website). See the article on [Project Profiles](profiles.qmd) for additional details.
 


### PR DESCRIPTION
Modifies the existing _quarto.yml to showcase how to set a global extension value for `lightbox`.

Follow up to the discussion in: 

https://github.com/quarto-dev/quarto-cli/discussions/6968