### PR TITLE
feat: add quarto invoice-typst format

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -39,3 +39,10 @@
   author: "[DamonCharlesRoberts](https://github.com/DamonCharlesRoberts/)"
   description: |
     A PDF format that brings LaTeX's `fancyhdr` package into Quarto for miscellaneous documents.
+
+- name: invoice-typst
+  path: https://github.com/mcanouil/quarto-invoice
+  author: "[Mickaël CANOUIL](https://github.com/mcanouil)"
+  description: |
+    Quarto Typst template extension to make invoices.
+  

--- a/docs/extensions/listings/revealjs-formats.yml
+++ b/docs/extensions/listings/revealjs-formats.yml
@@ -5,7 +5,7 @@
   description: |
     Medieval inspired format for Revealjs 
 
-- name: ceeos-revealjs
+- name: coeos-revealjs
   path: https://github.com/mcanouil/quarto-revealjs-coeos
   author: "[Mickaël CANOUIL](https://github.com/mcanouil)"
   description: |


### PR DESCRIPTION
This fixes a typo in a format name and add `invoice-typst` format extension to create invoices with Quarto and Typst.