### PR TITLE
Confirming printing to PDF in Firefox

### DIFF
--- a/docs/presentations/revealjs/presenting.qmd
+++ b/docs/presentations/revealjs/presenting.qmd
@@ -150,7 +150,7 @@ The `show-slide-number` option supports the following values:
 Reveal presentations can be exported to PDF via a special print stylesheet.
 
 ::: callout-note
-Note: This feature has only been confirmed to work in [Google Chrome](https://google.com/chrome) and [Chromium](https://www.chromium.org/Home).
+Note: This feature has been confirmed to work in [Google Chrome](https://google.com/chrome), [Chromium](https://www.chromium.org/Home) as well as in [Firefox](https://www.mozilla.org/en-US/firefox/).
 :::
 
 To Print to PDF, do the following:


### PR DESCRIPTION
I'm confirming that the instructions for printing a Revealjs presentation into PDF work perfectly for Firefox, too.
I'm also changing the text to reflect that.