### PR TITLE
Update _text-editor.md to fix typo in line 84

### DIFF
--- a/docs/get-started/authoring/_text-editor.md
+++ b/docs/get-started/authoring/_text-editor.md
@@ -81,7 +81,7 @@ format:
   pdf:
     geometry: 
       - top=30mm
-      - left=30mm
+      - left=20mm
   docx: default
 ```
 


### PR DESCRIPTION
In line 54, the geometry parameters were "left=20mm".

In line 84, the geometry parameters of the same code block now reads "left=30mm". 

This difference is most likely a typo error. I fixed it so that both line 54 and line 84 reads "left=20mm". Hopefully this will reduce confusion among more novice learners.