### PR TITLE
Improve 1.4 prerelease navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -568,8 +568,47 @@ website:
               href: docs/prerelease/1.3/pdf.qmd
             - text: "`kbd` Shortcode"
               href: docs/authoring/markdown-basics.qmd#keyboard-shortcuts
-
- 
+    - title: "Quarto 1.4"
+      contents:
+        - section: "Quarto 1.4 Highlights"
+          href: docs/prerelease/1.4/index.qmd
+          contents:
+            - text: "Manuscripts"
+              href: docs/manuscripts/index.qmd 
+            - text: "Dashboards"
+              href: docs/dashboards/index.qmd 
+            - text: "Typst Format"
+              href: docs/prerelease/1.4/typst.qmd 
+            - section: "Cross-References"
+              contents:
+                - text: Div Syntax
+                  href: docs/authoring/cross-references-divs.qmd  
+                - text: Custom Types
+                  href: docs/authoring/cross-references-custom.qmd  
+                - text: Listings for Executable Code
+                  href: docs/authoring/cross-references-listings.qmd
+                - text: Callouts
+                  href: docs/authoring/cross-references-callouts.qmd
+                - text: Behind the Scenes
+                  href: docs/prerelease/1.4/crossref.qmd
+            - text: Shiny for Python
+              href: docs/dashboards/interactivity/shiny-python/index.qmd
+            - text: Jupyter Inline Execution
+              href: docs/prerelease/1.4/inline.qmd
+            - text: Script Rendering
+              href: docs/prerelease/1.4/script.qmd
+            - text: Binder Config
+              href: docs/prerelease/1.4/binder.qmd
+            - text: Connect Emails
+              href: docs/prerelease/1.4/email.qmd
+            - text: Cloud Publishing
+              href: docs/publishing/posit-cloud.qmd
+            - text: Lightbox Images
+              href: docs/prerelease//1.4/lightbox.qmd
+            - text: Lua Changes
+              href: docs/prerelease/1.4/lua_changes.qmd
+            - text: AST Processing
+              href: docs/prerelease/1.4/ast.qmd
 
 bibliography: references.bib
 

--- a/docs/prerelease/1.4/_highlights.qmd
+++ b/docs/prerelease/1.4/_highlights.qmd
@@ -6,6 +6,18 @@ Quarto 1.4 includes the following new features:
 
 -   [Typst Format](/docs/prerelease/1.4/typst.qmd)---Support for the `typst` output format. [Typst](https://github.com/typst/typst) is a new open-source markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.
 
+-   Cross-reference changes:
+    
+    -  Adds a new [Cross-Reference Div Syntax](/docs/authoring/cross-references-divs.qmd) to more flexibly define cross-referenceable elements.
+    
+    - Allows the definition of [Custom Cross-Reference Types](/docs/authoring/cross-references-custom.qmd) via document or project YAML.
+    
+    - Adds `lst-label` and `lst-cap` code cell options to create [Cross-referenceable Listings for Executable Code](/docs/authoring/cross-references-listings.qmd).
+
+    - Allows [Cross-Referencing Callouts](/docs/authoring/cross-references-callouts.qmd).
+    
+    - Makes other [behind the scenes changes](/docs/prerelease/1.4/crossref.qmd).
+
 -   [Shiny for Python](/docs/dashboards/interactivity/shiny-python/index.qmd)---Support for using Shiny for Python within Quarto documents. 
 
 -   [Inline Execution for Jupyter](/docs/prerelease/1.4/inline.qmd)---Support for executing inline expressions when using Jupyter kernels. 
@@ -21,17 +33,5 @@ Quarto 1.4 includes the following new features:
 -   [Lightbox Treatment for Images and Figures](/docs/prerelease//1.4/lightbox.qmd)---Support for zooming into images and figures using a `lightbox`. Includes support for grouping multiple images into a gallery.
 
 -   [Lua changes](/docs/prerelease/1.4/lua_changes.qmd)---Quarto v1.4 adds new features to writers of Lua filters.
-
--   Crossref changes---Quarto v1.4:
-    
-    -  Adds a new [Cross-Reference Div Syntax](/docs/authoring/cross-references-divs.qmd) to more flexibly define cross-referenceable elements.
-    
-    - Allows the definition of [Custom Cross-Reference Types](/docs/authoring/cross-references-custom.qmd) via document or project YAML.
-    
-    - Adds `lst-label` and `lst-cap` code cell options to create [Cross-referenceable Listings for Executable Code](/docs/authoring/cross-references-listings.qmd).
-
-    - Allows [Cross-Referencing Callouts](/docs/authoring/cross-references-callouts.qmd).
-    
-    - Makes other [behind the scenes changes](/docs/prerelease/1.4/crossref.qmd).
 
 -   [AST processing changes](/docs/prerelease/1.4/ast.qmd)---Quarto v1.4 improves on the HTML table processing added in v1.3 and adds a way for LaTeX raw blocks to include Quarto-compatible markdown for processing.


### PR DESCRIPTION
Adds sidebar nav to the 1.4 highlights page [[Preview](https://deploy-preview-932--mystifying-jepsen-fa4396.netlify.app/docs/prerelease/1.4)]

For features that aren't already integrated into main docs (e.g. not manuscripts or dashboards), improves:
* Navigation between 1.4 highlights 
* Context through the "Quarto 1.4 Highlights" breadcrumb

For example:
<img width="705" alt="Screenshot 2023-12-04 at 10 22 51 AM" src="https://github.com/quarto-dev/quarto-web/assets/25964/24d2a8f0-e4c7-434b-b833-0748bfbf246d">
