### PR TITLE
Add crossref to reference pages

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -540,6 +540,8 @@ website:
                 href: docs/reference/globs.qmd
               - text: "Citations"
                 href: docs/reference/metadata/citation.qmd
+              - text: "Cross-References"
+                href: docs/reference/metadata/crossref.qmd
     - id: prerelease
       title: "Quarto 1.3"
       contents:

--- a/docs/reference/formats/asciidoc.json
+++ b/docs/reference/formats/asciidoc.json
@@ -185,6 +185,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/context.json
+++ b/docs/reference/formats/context.json
@@ -283,6 +283,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/docbook.json
+++ b/docs/reference/formats/docbook.json
@@ -175,6 +175,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/docx.json
+++ b/docs/reference/formats/docx.json
@@ -237,6 +237,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/epub.json
+++ b/docs/reference/formats/epub.json
@@ -349,6 +349,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/fb2.json
+++ b/docs/reference/formats/fb2.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/haddock.json
+++ b/docs/reference/formats/haddock.json
@@ -185,6 +185,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/html.json
+++ b/docs/reference/formats/html.json
@@ -501,6 +501,20 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      },
+      {
+        "name": "crossrefs-hover",
+        "description": "Enables a hover popup for cross references that shows the item being referenced."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/icml.json
+++ b/docs/reference/formats/icml.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/ipynb.json
+++ b/docs/reference/formats/ipynb.json
@@ -189,6 +189,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/jats.json
+++ b/docs/reference/formats/jats.json
@@ -209,6 +209,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/man.json
+++ b/docs/reference/formats/man.json
@@ -185,6 +185,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/markdown/commonmark.json
+++ b/docs/reference/formats/markdown/commonmark.json
@@ -207,6 +207,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/markdown/gfm.json
+++ b/docs/reference/formats/markdown/gfm.json
@@ -215,6 +215,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/markdown/markua.json
+++ b/docs/reference/formats/markdown/markua.json
@@ -207,6 +207,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/ms.json
+++ b/docs/reference/formats/ms.json
@@ -231,6 +231,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/muse.json
+++ b/docs/reference/formats/muse.json
@@ -195,6 +195,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/odt.json
+++ b/docs/reference/formats/odt.json
@@ -205,6 +205,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/opml.json
+++ b/docs/reference/formats/opml.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/org.json
+++ b/docs/reference/formats/org.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/pdf.json
+++ b/docs/reference/formats/pdf.json
@@ -487,6 +487,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/presentations/beamer.json
+++ b/docs/reference/formats/presentations/beamer.json
@@ -541,6 +541,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/presentations/pptx.json
+++ b/docs/reference/formats/presentations/pptx.json
@@ -203,6 +203,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/presentations/revealjs.json
+++ b/docs/reference/formats/presentations/revealjs.json
@@ -689,6 +689,20 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      },
+      {
+        "name": "crossrefs-hover",
+        "description": "Enables a hover popup for cross references that shows the item being referenced."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/rst.json
+++ b/docs/reference/formats/rst.json
@@ -191,6 +191,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/rtf.json
+++ b/docs/reference/formats/rtf.json
@@ -185,6 +185,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/tei.json
+++ b/docs/reference/formats/tei.json
@@ -185,6 +185,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/texinfo.json
+++ b/docs/reference/formats/texinfo.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/textile.json
+++ b/docs/reference/formats/textile.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/typst.json
+++ b/docs/reference/formats/typst.json
@@ -221,6 +221,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/wiki/dokuwiki.json
+++ b/docs/reference/formats/wiki/dokuwiki.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/wiki/jira.json
+++ b/docs/reference/formats/wiki/jira.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/wiki/mediawiki.json
+++ b/docs/reference/formats/wiki/mediawiki.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/wiki/xwiki.json
+++ b/docs/reference/formats/wiki/xwiki.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/formats/wiki/zimwiki.json
+++ b/docs/reference/formats/wiki/zimwiki.json
@@ -181,6 +181,16 @@
     ]
   },
   {
+    "name": "crossref",
+    "title": "Cross-References",
+    "options": [
+      {
+        "name": "crossref",
+        "description": "Configuration for crossref labels and prefixes. See [Cross-Reference Options](https://quarto.org/docs/reference/metadata/crossref.html) for more details."
+      }
+    ]
+  },
+  {
     "name": "citation",
     "title": "Citation",
     "options": [

--- a/docs/reference/metadata/crossref.json
+++ b/docs/reference/metadata/crossref.json
@@ -1,0 +1,247 @@
+[
+  {
+    "name": "crossref",
+    "title": "Crossref",
+    "options": [
+      {
+        "name": "custom",
+        "description": "A custom cross reference type. See [Custom](#custom) for more details."
+      },
+      {
+        "name": "chapters",
+        "description": "Use top level sections (H1) in this document as chapters."
+      },
+      {
+        "name": "title-delim",
+        "description": "The delimiter used between the prefix and the caption."
+      },
+      {
+        "name": "fig-title",
+        "description": "The title prefix used for figure captions."
+      },
+      {
+        "name": "tbl-title",
+        "description": "The title prefix used for table captions."
+      },
+      {
+        "name": "eq-title",
+        "description": "The title prefix used for equation captions."
+      },
+      {
+        "name": "lst-title",
+        "description": "The title prefix used for listing captions."
+      },
+      {
+        "name": "thm-title",
+        "description": "The title prefix used for theorem captions."
+      },
+      {
+        "name": "lem-title",
+        "description": "The title prefix used for lemma captions."
+      },
+      {
+        "name": "cor-title",
+        "description": "The title prefix used for corollary captions."
+      },
+      {
+        "name": "prp-title",
+        "description": "The title prefix used for proposition captions."
+      },
+      {
+        "name": "cnj-title",
+        "description": "The title prefix used for conjecture captions."
+      },
+      {
+        "name": "def-title",
+        "description": "The title prefix used for definition captions."
+      },
+      {
+        "name": "exm-title",
+        "description": "The title prefix used for example captions."
+      },
+      {
+        "name": "exr-title",
+        "description": "The title prefix used for exercise captions."
+      },
+      {
+        "name": "fig-prefix",
+        "description": "The prefix used for an inline reference to a figure."
+      },
+      {
+        "name": "tbl-prefix",
+        "description": "The prefix used for an inline reference to a table."
+      },
+      {
+        "name": "eq-prefix",
+        "description": "The prefix used for an inline reference to an equation."
+      },
+      {
+        "name": "sec-prefix",
+        "description": "The prefix used for an inline reference to a section."
+      },
+      {
+        "name": "lst-prefix",
+        "description": "The prefix used for an inline reference to a listing."
+      },
+      {
+        "name": "thm-prefix",
+        "description": "The prefix used for an inline reference to a theorem."
+      },
+      {
+        "name": "lem-prefix",
+        "description": "The prefix used for an inline reference to a lemma."
+      },
+      {
+        "name": "cor-prefix",
+        "description": "The prefix used for an inline reference to a corollary."
+      },
+      {
+        "name": "prp-prefix",
+        "description": "The prefix used for an inline reference to a proposition."
+      },
+      {
+        "name": "cnj-prefix",
+        "description": "The prefix used for an inline reference to a conjecture."
+      },
+      {
+        "name": "def-prefix",
+        "description": "The prefix used for an inline reference to a definition."
+      },
+      {
+        "name": "exm-prefix",
+        "description": "The prefix used for an inline reference to an example."
+      },
+      {
+        "name": "exr-prefix",
+        "description": "The prefix used for an inline reference to an exercise."
+      },
+      {
+        "name": "fig-labels",
+        "description": "The numbering scheme used for figures."
+      },
+      {
+        "name": "tbl-labels",
+        "description": "The numbering scheme used for tables."
+      },
+      {
+        "name": "eq-labels",
+        "description": "The numbering scheme used for equations."
+      },
+      {
+        "name": "sec-labels",
+        "description": "The numbering scheme used for sections."
+      },
+      {
+        "name": "lst-labels",
+        "description": "The numbering scheme used for listings."
+      },
+      {
+        "name": "thm-labels",
+        "description": "The numbering scheme used for theorems."
+      },
+      {
+        "name": "lem-labels",
+        "description": "The numbering scheme used for lemmas."
+      },
+      {
+        "name": "cor-labels",
+        "description": "The numbering scheme used for corollaries."
+      },
+      {
+        "name": "prp-labels",
+        "description": "The numbering scheme used for propositions."
+      },
+      {
+        "name": "cnj-labels",
+        "description": "The numbering scheme used for conjectures."
+      },
+      {
+        "name": "def-labels",
+        "description": "The numbering scheme used for definitions."
+      },
+      {
+        "name": "exm-labels",
+        "description": "The numbering scheme used for examples."
+      },
+      {
+        "name": "exr-labels",
+        "description": "The numbering scheme used for exercises."
+      },
+      {
+        "name": "lof-title",
+        "description": "The title used for the list of figures."
+      },
+      {
+        "name": "lot-title",
+        "description": "The title used for the list of tables."
+      },
+      {
+        "name": "lol-title",
+        "description": "The title used for the list of listings."
+      },
+      {
+        "name": "labels",
+        "description": "The number scheme used for references."
+      },
+      {
+        "name": "subref-labels",
+        "description": "The number scheme used for sub references."
+      },
+      {
+        "name": "ref-hyperlink",
+        "description": "Whether cross references should be hyper-linked."
+      },
+      {
+        "name": "appendix-title",
+        "description": "The title used for appendix."
+      },
+      {
+        "name": "appendix-delim",
+        "description": "The delimiter beween appendix number and title."
+      }
+    ]
+  },
+  {
+    "name": "crossref-custom",
+    "title": "Custom",
+    "description": "Use the `custom` option to `crossref` to define new types of cross reference. For example: \n\n```yaml\n---\ncrossref:\n  custom:\n    - key: vid\n      kind: float\n      reference-prefix: Video\n---\n```\n",
+    "options": [
+      {
+        "name": "kind",
+        "description": "The kind of cross reference (currently only \"float\" is supported)."
+      },
+      {
+        "name": "reference-prefix",
+        "description": "The prefix used in rendered references when referencing this type."
+      },
+      {
+        "name": "caption-prefix",
+        "description": "The prefix used in rendered captions when referencing this type. If omitted, the field `reference-prefix` is used."
+      },
+      {
+        "name": "space-before-numbering",
+        "description": "If false, use no space between crossref prefixes and numbering."
+      },
+      {
+        "name": "key",
+        "description": "The key used to prefix reference labels of this type, such as \"fig\", \"tbl\", \"lst\", etc."
+      },
+      {
+        "name": "latex-env",
+        "description": "In LaTeX output, the name of the custom environment to be used."
+      },
+      {
+        "name": "latex-list-of-file-extension",
+        "description": "In LaTeX output, the extension of the auxiliary file used by LaTeX to collect names to be used in the custom \"list of\" command. If omitted, a string with prefix `lo` and suffix with the value of `ref-type` is used."
+      },
+      {
+        "name": "latex-list-of-description",
+        "description": "The description of the crossreferenceable object to be used in the title of the \"list of\" command. If omitted, the field `reference-prefix` is used."
+      },
+      {
+        "name": "caption-location",
+        "description": "The location of the caption relative to the crossreferenceable content."
+      }
+    ]
+  }
+]

--- a/docs/reference/metadata/crossref.qmd
+++ b/docs/reference/metadata/crossref.qmd
@@ -2,7 +2,7 @@
 title: Cross Reference Options
 ---
 
-The `crossref` option is used to customize the appearance and behavior of cross-references.  
+The `crossref` option is used to customize the appearance and behavior of cross-references. You can read more about using [Cross-References in the Guide](/docs/authoring/cross-references.qmd).
 
 ```yaml
 ---

--- a/docs/reference/metadata/crossref.qmd
+++ b/docs/reference/metadata/crossref.qmd
@@ -8,6 +8,6 @@ The `crossref` option is used to customize the appearance and behavior of cross-
 ---
 crossref:
   labels: roman
-  title-delim: " - "
+  title-delim: "-"
 ---
 ```

--- a/docs/reference/metadata/crossref.qmd
+++ b/docs/reference/metadata/crossref.qmd
@@ -1,0 +1,13 @@
+---
+title: Cross Reference Options
+---
+
+The `crossref` option is used to customize the appearance and behavior of cross-references.  
+
+```yaml
+---
+crossref:
+  labels: roman
+  title-delim: " - "
+---
+```

--- a/docs/reference/projects/book.json
+++ b/docs/reference/projects/book.json
@@ -460,14 +460,6 @@
     "description": "Base URL for website source code repository"
   },
   {
-    "name": "repo-link-target",
-    "description": "The value of the target attribute for repo links"
-  },
-  {
-    "name": "repo-link-rel",
-    "description": "The value of the rel attribute for repo links"
-  },
-  {
     "name": "repo-subdir",
     "description": "Subdirectory of repository containing website"
   },
@@ -542,10 +534,6 @@
   {
     "name": "image",
     "description": "Default site thumbnail image for `twitter` /`open-graph`\n"
-  },
-  {
-    "name": "image-alt",
-    "description": "Default site thumbnail image alt text for `twitter` /`open-graph`\n"
   },
   {
     "name": "comments",

--- a/docs/reference/projects/website.json
+++ b/docs/reference/projects/website.json
@@ -24,14 +24,6 @@
     "description": "Base URL for website source code repository"
   },
   {
-    "name": "repo-link-target",
-    "description": "The value of the target attribute for repo links"
-  },
-  {
-    "name": "repo-link-rel",
-    "description": "The value of the rel attribute for repo links"
-  },
-  {
     "name": "repo-subdir",
     "description": "Subdirectory of repository containing website"
   },
@@ -106,10 +98,6 @@
   {
     "name": "image",
     "description": "Default site thumbnail image for `twitter` /`open-graph`\n"
-  },
-  {
-    "name": "image-alt",
-    "description": "Default site thumbnail image alt text for `twitter` /`open-graph`\n"
   },
   {
     "name": "comments",

--- a/docs/reference/reference.yml
+++ b/docs/reference/reference.yml
@@ -70,4 +70,6 @@
      href: globs.qmd
    - text: "Citations"
      href: metadata/citation.qmd
+   - text: "Cross-References"
+     href: metadata/crossref.qmd
 

--- a/tools/reference.ts
+++ b/tools/reference.ts
@@ -120,7 +120,7 @@ const cellOptions = Object.keys(cellGroups).map(group => {
 // document options
 const documentGroups = groups["document"];
 const documentOptions = Object.keys(documentGroups)
-  .filter(group => !["comments", "crossref"].includes(group))
+  .filter(group => !["comments"].includes(group))
   .map(group => {
 
     const title = documentGroups[group]["title"];
@@ -311,18 +311,37 @@ function findVal(object: any, key: string) {
 }
 
 // Metadata pages
-function writeMetadataTable(name: string, options: Array<Option>) {
+function writeMetadataTable(name: string, title: string, options: Array<Option>) {
   const path = `docs/reference/metadata/${name}.json`;
   const metadata = [{
-    "name": "citation",
-    "title": "Citation",
+    "name": name,
+    "title": title,
     "options": options
   }];
   Deno.writeTextFileSync(path, JSON.stringify(metadata, undefined, 2));
 }
 
 const citationOptions = readDefinitionsId("csl-item");
-writeMetadataTable("citation", citationOptions);
+writeMetadataTable("citation", "Citation", citationOptions);
+
+// Crossref Page
+const crossrefs = readSchema("document-crossref.yml");
+const crossrefOptions = crossrefs.find(value => value.name ==  "crossref")["schema"]["anyOf"][1]["object"]["properties"];
+const customCrossrefOptions = findVal(crossrefs, "custom")["arrayOf"]["object"]["properties"];
+
+const crossrefMetadata = [
+{
+  "name": "crossref",
+  "title": "Crossref",
+  "options": readProjectProperties(crossrefOptions)
+},
+{
+  "name": "crossref-custom",
+  "title": "Custom",
+  "description": "Use the `custom` option to `crossref` to define new types of cross reference. For example: \n\n```yaml\n---\ncrossref:\n  custom:\n    - key: vid\n      kind: float\n      reference-prefix: Video\n---\n```\n",
+  "options": readProjectProperties(customCrossrefOptions),
+}];
+Deno.writeTextFileSync(`docs/reference/metadata/crossref.json`, JSON.stringify(crossrefMetadata, undefined, 2));
 
 function writeProjectTable(name: string, options: Array<Option>) {
   const path = `docs/reference/projects/${name}.json`;


### PR DESCRIPTION
Adds a page under More > Cross-Reference Options: [Preview](https://deploy-preview-947--mystifying-jepsen-fa4396.netlify.app/docs/reference/metadata/crossref.html)

Primarily need feedback on the changes in tools/reference.ts

https://github.com/quarto-dev/quarto-cli/pull/7884 in quarto-cli edits the schema to add some links from format pages to the cross-reference page.