### PR TITLE
Custom prefix per-reference

### DIFF
--- a/docs/books/book-crossrefs.qmd
+++ b/docs/books/book-crossrefs.qmd
@@ -41,6 +41,12 @@ To refer to a section, include a cross-reference to it using an `@` identifier a
 See @sec-introduction for additional discussion.
 ```
 
+To suppress cross-reference prefix prepend `-` before `@`, like so `[-@citation]`, will suppress default prefix, e.g. `[-@sec-visualization]` will produce just `1.1` (or whatever number this section happens to be) without `Section` prefix.
+
+``` markdown
+See [-@sec-visualization].
+```
+
 To refer to a chapter or appendix explicitly you should spell out "Chapter" or "Appendix" and use the number-only form of cross reference:
 
 ``` markdown

--- a/docs/books/book-crossrefs.qmd
+++ b/docs/books/book-crossrefs.qmd
@@ -50,7 +50,7 @@ See [-@sec-visualization].
 To refer to a chapter or appendix explicitly you should spell out "Chapter" or "Appendix" and use the number-only form of cross reference:
 
 ``` markdown
-See [Chapter -@sec-visualization] for more details on visualizing model diagnostics.
+See [Chapter @sec-visualization] for more details on visualizing model diagnostics.
 ```
 
 


### PR DESCRIPTION
As we have in [pandoc documentation](https://lierdakil.github.io/pandoc-crossref/#custom-prefix-per-reference), it is not necessary to enter the `-` to have a custom prefix.