### PR TITLE
Add highlight about rendering R scripts

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -608,8 +608,12 @@ website:
               href: docs/dashboards/interactivity/shiny-python/index.qmd
             - text: Jupyter Inline Execution
               href: docs/computations/inline-code.qmd
-            - text: Script Rendering
-              href: docs/prerelease/1.4/script.qmd
+            - section: Script Rendering
+              contents:
+                - text: Jupyter
+                  href: docs/prerelease/1.4/script.qmd
+                - text: Knitr
+                  href: docs/prerelease/1.4/script-r.qmd
             - text: Binder Config
               href: docs/projects/binder.qmd
             - text: Connect Emails

--- a/docs/prerelease/1.4/_highlights.qmd
+++ b/docs/prerelease/1.4/_highlights.qmd
@@ -24,7 +24,7 @@ Quarto 1.4 includes the following new features:
 
 -   [Script Rendering for Jupyter](/docs/prerelease/1.4/script.qmd)---Support for rendering script files (e.g. `.py`, `.jl`, or `.r`) that are [specially formatted](https://jupytext.readthedocs.io/en/latest/formats-scripts.html) as notebooks.
 
--   [Script Rendering for Knitr](/docs/prerelease/1.4/script.qmd)---Support for rendering R script files (e.g. `.r` or `.R`) that are formatted for report using [`knitr::spin()` syntax](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html).
+-   [Script Rendering for Knitr](/docs/prerelease/1.4/script-r.qmd)---Support for rendering R script files (e.g. `.r` or `.R`) that are formatted for report using [`knitr::spin()` syntax](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html).
    
 -   [Easy Binder Configuration for Quarto Projects](/docs/projects/binder.qmd)---Support for generating files required to deploy a Quarto project using Binder.
 

--- a/docs/prerelease/1.4/_highlights.qmd
+++ b/docs/prerelease/1.4/_highlights.qmd
@@ -24,6 +24,8 @@ Quarto 1.4 includes the following new features:
 
 -   [Script Rendering for Jupyter](/docs/prerelease/1.4/script.qmd)---Support for rendering script files (e.g. `.py`, `.jl`, or `.r`) that are [specially formatted](https://jupytext.readthedocs.io/en/latest/formats-scripts.html) as notebooks.
 
+-   [Script Rendering for Knitr](/docs/prerelease/1.4/script.qmd)---Support for rendering R script files (e.g. `.r` or `.R`) that are formatted for report using [`knitr::spin()` syntax](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html).
+   
 -   [Easy Binder Configuration for Quarto Projects](/docs/projects/binder.qmd)---Support for generating files required to deploy a Quarto project using Binder.
 
 -   [Connect Email Generation](/docs/prerelease/1.4/email.qmd)---Extends the `html` output format so that HTML/text emails can be created and selectively delivered through Posit Connect.

--- a/docs/prerelease/1.4/script-r.qmd
+++ b/docs/prerelease/1.4/script-r.qmd
@@ -1,0 +1,78 @@
+---
+title: "Script Rendering for knitr"
+---
+
+{{< include _pre-release-feature.qmd >}}
+
+## Overview
+
+Quarto v1.4 includes support for rendering R script files (e.g. `.r` or `.R`) that are specially formatted as report. Script rendering is based on `knitr::spin()` feature and makes use of the same [syntax rules](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html), with slight additions: 
+
+- The R script must start with YAML block header inside roxygen comment i.e. using `#'` special comment.
+- Cell options can be passed using YAML syntax comment as in `.qmd` i.e. using `#|` special comment.
+
+For example, here is an R script that includes both markdown and code cells:
+
+``` {.r filename="script.R"}
+#' ---
+#' title: Palmer Penguins
+#' author: Norah Jones
+#' date: 3/12/23
+#' format: html
+#' ---
+
+library(palmerpenguins)
+
+#' ## Exploring the data
+#' See @fig-bill-sizes for an exploration of bill sizes by species.
+
+#| label: fig-bill-sizes
+#| fig-cap: Bill Sizes by Species
+#| warning: false
+library(ggplot2)
+ggplot(data = penguins,
+       aes(x = bill_length_mm,
+           y = bill_depth_mm,
+           group = species)) +
+  geom_point(aes(color = species,
+                 shape = species),
+             size = 3,
+             alpha = 0.8) +
+  labs(title = "Penguin bill dimensions",
+       subtitle = "Bill length and depth for Adelie, Chinstrap and Gentoo Penguins at Palmer Station LTER",
+       x = "Bill length (mm)",
+       y = "Bill depth (mm)",
+       color = "Penguin species",
+       shape = "Penguin species")
+
+```
+
+Usual `.qmd` content lines starts with `#'`, which includes the YAML header block and any in-document Markdown content. R code is the main content of the R script and included without any delimitation. Cell options are included as normal using `#|` prefixed comments (e.g. `#| echo: false`), and apply to any R code below. Cells are split when Markdown content are inserted in-between R code, e.g. use `#'` to create another block.
+
+## Render and Preview
+
+Rendering and previewing notebook scripts works exactly like `.qmd`. For example, the following commands are all valid:
+
+```bash
+$ quarto render script.R
+
+$ quarto preview script.R
+```
+
+R scripts rendered with Quarto must begin with a YAML block with lined starting by `#'` (which normally includes the `title` and other YAML options). This convention is how Quarto knows that it should render the `.R` script to output format. The YAML block must follow usual rules and be indented properly.
+
+## Scripts in Projects
+
+R scripts can also be included within [projects](/docs/projects/quarto-projects.qmd) (e.g. websites, blogs, etc.). Scripts within projects are only rendered by Quarto when they start with YAML block header prefixed by `#'` comments.
+
+If for some reason you need to ignore such script, you can create an explict render list in `_quarto.yml` that excludes individual scripts as required, for example:
+
+```yaml
+project:
+  type: website
+  render:
+    - "*.{qmd,R}"
+    - "!utils.R"
+```
+
+Note that this technique is documented for the sake of completeness---in practice you should almost never need to do this since R scripts rarely begin with a YAML block unless you are authoring them specifically for report rendering. 

--- a/docs/prerelease/1.4/script-r.qmd
+++ b/docs/prerelease/1.4/script-r.qmd
@@ -1,15 +1,15 @@
 ---
-title: "Script Rendering for knitr"
+title: "Script Rendering for Knitr"
 ---
 
 {{< include _pre-release-feature.qmd >}}
 
 ## Overview
 
-Quarto v1.4 includes support for rendering R script files (e.g. `.r` or `.R`) that are specially formatted as report. Script rendering is based on `knitr::spin()` feature and makes use of the same [syntax rules](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html), with slight additions: 
+Quarto v1.4 includes support for rendering R script files (e.g. `.r` or `.R`) that are specially formatted as a report. Script rendering is based on the `knitr::spin()` feature and makes use of the same [syntax rules](https://bookdown.org/yihui/rmarkdown-cookbook/spin.html), with slight additions: 
 
-- The R script must start with YAML block header inside roxygen comment i.e. using `#'` special comment.
-- Cell options can be passed using YAML syntax comment as in `.qmd` i.e. using `#|` special comment.
+- The R script must start with YAML block header inside roxygen comments i.e. using the special `#'` comment.
+- Cell options can be passed using YAML syntax as in `.qmd` i.e. using the special `#|` comment.
 
 For example, here is an R script that includes both markdown and code cells:
 
@@ -47,7 +47,7 @@ ggplot(data = penguins,
 
 ```
 
-Usual `.qmd` content lines starts with `#'`, which includes the YAML header block and any in-document Markdown content. R code is the main content of the R script and included without any delimitation. Cell options are included as normal using `#|` prefixed comments (e.g. `#| echo: false`), and apply to any R code below. Cells are split when Markdown content are inserted in-between R code, e.g. use `#'` to create another block.
+Lines that would be content in a `.qmd` start with `#'` and  include the YAML header block and any in-document Markdown content. R code is the main content of the R script and is included without any delimitation. Cell options are included as normal using `#|` prefixed comments (e.g. `#| echo: false`), and apply to any R code below. Code cells are split when Markdown content occurs , e.g. use `#'` to create another code block.
 
 ## Render and Preview
 
@@ -59,13 +59,13 @@ $ quarto render script.R
 $ quarto preview script.R
 ```
 
-R scripts rendered with Quarto must begin with a YAML block with lined starting by `#'` (which normally includes the `title` and other YAML options). This convention is how Quarto knows that it should render the `.R` script to output format. The YAML block must follow usual rules and be indented properly.
+R scripts rendered with Quarto must begin with a YAML block whose lines start with `#'` (which normally includes the `title` and other YAML options). This convention is how Quarto knows that it should render the `.R` script. The YAML block must follow the usual rules and be indented properly.
 
 ## Scripts in Projects
 
-R scripts can also be included within [projects](/docs/projects/quarto-projects.qmd) (e.g. websites, blogs, etc.). Scripts within projects are only rendered by Quarto when they start with YAML block header prefixed by `#'` comments.
+R scripts can also be included within [projects](/docs/projects/quarto-projects.qmd) (e.g. websites, blogs, etc.). Scripts within projects are only rendered by Quarto when they start with a YAML block header prefixed by `#'` comments.
 
-If for some reason you need to ignore such script, you can create an explict render list in `_quarto.yml` that excludes individual scripts as required, for example:
+If for some reason you need to ignore such a script, you can create an explict render list in `_quarto.yml` that excludes individual scripts as required, for example:
 
 ```yaml
 project:


### PR DESCRIPTION
This PR adds a doc about rendering R scripts with Quarto based on `knitr::spin()`

This is written based on the same one for Jupyter https://quarto.org/docs/prerelease/1.4/script.html 

Both could be mixed probably. 

Related to closing: 

* https://github.com/quarto-dev/quarto-cli/issues/7899
