### PR TITLE
docs: add note about header promotion in book

### DIFF
--- a/docs/books/book-structure.qmd
+++ b/docs/books/book-structure.qmd
@@ -42,6 +42,8 @@ title: "Introduction"
 ---
 ```
 
+In the absence of a level-one header or a title set in the YAML front matter, the first header in the page will be used as the title.
+
 ## Chapter Numbers
 
 All chapters are numbered by default. If you want a chapter to be unnumbered simply add the `.unnumbered` class to its main header. For example:


### PR DESCRIPTION
Currently, the documentation for books only mention level-one header and YAML title, while in the absence of those, the first header found (independently of its level) will be promoted to title.