### PR TITLE
AST processing phases have change of names

### DIFF
--- a/docs/prerelease/1.4/lua_changes.qmd
+++ b/docs/prerelease/1.4/lua_changes.qmd
@@ -126,15 +126,15 @@ In Quarto 1.4, Lua filters can be inserted before or after any of these stages:
 
 ```yaml
 filters:
-  - at: before-ast
+  - at: pre-ast
     path: filter1.lua
-  - at: after-quarto
+  - at: post-quarto
     path: filter2.lua
-  - at: after-render
+  - at: post-render
     path: filter3.lua
 ```
 
-Any of the stages can be prefixed by `before-` or `after`.
-In Quarto 1.4, `before-quarto` and `after-ast` correspond to the same insertion location in the filter chain, as do `after-quarto` and `before-render`.
-Quarto 1.3's "pre" filters correspond to `before-quarto`, and "post" filters correspond to `after-render`. `before-ast` and `before-render` are new insertion locations.
+Any of the stages can be prefixed by `pre-` or `post-`.
+In Quarto 1.4, `pre-quarto` and `post-ast` correspond to the same insertion location in the filter chain, as do `post-quarto` and `pre-render`.
+Quarto 1.3's "pre" filters correspond to `pre-quarto`, and "post" filters correspond to `post-render`. `pre-ast` and `pre-render` are new insertion locations.
 We will consider adding more insertion locations, should the need arise.


### PR DESCRIPTION
I believe the names used in our codebase are not the one documented 

https://github.com/quarto-dev/quarto-cli/blob/fca967e5e541542a27a5f86d3978e6b28e03ac16/src/resources/schema/definitions.yml#L40-L49

https://github.com/quarto-dev/quarto-cli/blob/fca967e5e541542a27a5f86d3978e6b28e03ac16/src/resources/filters/main.lua#L423-L440

So I changed the doc to use `pre-` and `post-` instead of `before-` and `after-` 