### PR TITLE
Revert "AST processing phases had a change of names (#970)"

### DIFF
--- a/docs/prerelease/1.4/lua_changes.qmd
+++ b/docs/prerelease/1.4/lua_changes.qmd
@@ -126,15 +126,15 @@ In Quarto 1.4, Lua filters can be inserted before or after any of these stages:
 
 ```yaml
 filters:
-  - at: pre-ast
+  - at: before-ast
     path: filter1.lua
-  - at: post-quarto
+  - at: after-quarto
     path: filter2.lua
-  - at: post-render
+  - at: after-render
     path: filter3.lua
 ```
 
-Any of the stages can be prefixed by `pre-` or `post-`.
-In Quarto 1.4, `pre-quarto` and `post-ast` correspond to the same insertion location in the filter chain, as do `post-quarto` and `pre-render`.
-Quarto 1.3's "pre" filters correspond to `pre-quarto`, and "post" filters correspond to `post-render`. `pre-ast` and `pre-render` are new insertion locations.
+Any of the stages can be prefixed by `before-` or `after`.
+In Quarto 1.4, `before-quarto` and `after-ast` correspond to the same insertion location in the filter chain, as do `after-quarto` and `before-render`.
+Quarto 1.3's "pre" filters correspond to `before-quarto`, and "post" filters correspond to `after-render`. `before-ast` and `before-render` are new insertion locations.
 We will consider adding more insertion locations, should the need arise.


### PR DESCRIPTION
I should have merged to `main` since this applies to our currently available highlights.

This reverts commit e253967a9d26b7746ca31c6570cc25a13ec443eb. 