### PR TITLE
Add info about looking in the next section

### DIFF
--- a/docs/output-formats/_theme-options.md
+++ b/docs/output-formats/_theme-options.md
@@ -12,7 +12,7 @@ theme:
   - custom.scss
 ```
 
-Your `custom.scss` file might look something like this:
+Your `custom.scss` file should include variables defined in sass variables section and might look something like this:
 
 ``` css
 /*-- scss:defaults --*/


### PR DESCRIPTION
In the quarto dashboard theming section, I find it confusing where to look for to create `custom.scss`.

https://quarto.org/docs/dashboards/theming.html#theme-options

This link https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss is very prominent, but it's not the correct place to look for.

The correct place to look for is actually https://quarto.org/docs/dashboards/theming.html#sass-variables

I am not sure how to put it, but I think that it should be more obvious.

I got confused in https://github.com/quarto-dev/quarto-cli/discussions/8351.

This is probably not right, maybe the correct thing would be to add {#sec-sass-variables} in  https://github.com/quarto-dev/quarto-web/blob/main/docs/output-formats/_theme-variables.md but I don't know how it works with < include >