### PR TITLE
Fix localhost links to documentation

### DIFF
--- a/docs/authoring/cross-references-divs.qmd
+++ b/docs/authoring/cross-references-divs.qmd
@@ -340,7 +340,7 @@ This renders as:
 
 ## Computed Captions
 
-If you want to include computed values in a caption, use the cross-reference div syntax, along with an [inline code expression](http://localhost:6234/docs/computations/execution-options.html#inline-code). For example:
+If you want to include computed values in a caption, use the cross-reference div syntax, along with an [inline code expression](../computations/execution-options.html#inline-code). For example:
 
 :::: {.panel-tabset}
 

--- a/docs/extensions/project-types.qmd
+++ b/docs/extensions/project-types.qmd
@@ -29,7 +29,7 @@ If you additionally include some basic scaffolding as a [Starter Template](start
 quarto use template lexcorp/lexdocs
 ```
 
-Note that it is possible to bundle and distribute project type extensions as simple gzip archives (as opposed to using a GitHub repository as described above). See the article on [Distributing Extensions](http://localhost:7603/docs/extensions/distributing.html) for additional details.
+Note that it is possible to bundle and distribute project type extensions as simple gzip archives (as opposed to using a GitHub repository as described above). See the article on [Distributing Extensions](distributing.html) for additional details.
 
 ## Development Tools
 


### PR DESCRIPTION
This commit removes some remaining links to other documentation pages or anchors which pointed at absolute localhost versions instead of relative html links, presumably leftover from dev previewing.

This should fix all remaining actually false localhost links, leaving `localhost:` in all locations where it is actually desired. 

Hope this is the right format to present the small PR in!