### PR TITLE
Remove Quarto 1.4 pre-release callout

### DIFF
--- a/docs/dashboards/index.qmd
+++ b/docs/dashboards/index.qmd
@@ -16,8 +16,6 @@ format:
         </script>   
 ---
 
-{{< include /docs/prerelease/1.4/_pre-release-feature.qmd >}}
-
 ## Overview
 
 Quarto Dashboards make it easy to create interactive dashboards using Python, R, Julia, and Observable:

--- a/docs/dashboards/index.qmd
+++ b/docs/dashboards/index.qmd
@@ -16,6 +16,8 @@ format:
         </script>   
 ---
 
+{{< include /docs/_require-1.4.qmd >}}
+
 ## Overview
 
 Quarto Dashboards make it easy to create interactive dashboards using Python, R, Julia, and Observable:

--- a/docs/dashboards/interactivity/shiny-r.qmd
+++ b/docs/dashboards/interactivity/shiny-r.qmd
@@ -4,7 +4,7 @@ code-annotations: select
 lightbox: auto
 ---
 
-{{< include /docs/prerelease/1.4/_pre-release-feature.qmd >}}
+{{< include /docs/_require-1.4.qmd >}}
 
 
 ## Introduction


### PR DESCRIPTION
As Quarto 1.4 is released, the pre-release callout on the Dashboard documentation page can be removed.