### PR TITLE
Small typos found in quarto syntax

### DIFF
--- a/docs/output-formats/docusaurus.qmd
+++ b/docs/output-formats/docusaurus.qmd
@@ -28,11 +28,12 @@ If you use the `filename` attribute in Quarto, it will automatically become the 
 
 Code folding is also automatically applied. So, for example the following executable code block:
 
-``` python
+```` python
 ```{{python}}
 #| code-fold: true
 1 + 1
 ```
+````
 
 Is rendered as a collasable block in Docusaurus:
 

--- a/docs/projects/binder.qmd
+++ b/docs/projects/binder.qmd
@@ -72,12 +72,12 @@ The following files will be written:
 └─────────────┴────────────────────────────────────────┘
 
  ? Continue? (Y/n) › 
- ```
+```
  
 After a final confirmation, Quarto will then write these files to the project:
 
- ```{.default}
- Writing configuration files
+```{.default}
+Writing configuration files
 [✓] postBuild
 [✓] apt.txt
 [✓] runtime.txt


### PR DESCRIPTION
I am using the qmd documents in this repo as a way of checking the parsing functionality of [parsermd](https://github.com/rundel/parsermd) and I came across a couple of small inconsistencies in a couple of the documents that I believe are unintentional typos.

This pull request has these corrections which were needed to get things to work correctly with parsermd's parser.