### PR TITLE
Update MathML note

### DIFF
--- a/docs/output-formats/html-basics.qmd
+++ b/docs/output-formats/html-basics.qmd
@@ -149,7 +149,7 @@ Available math rendering methods include:
 | `katex`   | Use [KaTeX](https://github.com/Khan/KaTeX) to display embedded TeX math in HTML output.                                                                                                                                          |
 | `webtex`  | Convert TeX formulas to `<img>` tags that link to an external script that converts formulas to images.                                                                                                                           |
 | `gladtex` | Enclose TeX math in `<eq>` tags in HTML output. The resulting HTML can then be processed by [GladTeX](https://humenda.github.io/GladTeX/) to produce images of the typeset formulas and an HTML file with links to these images. |
-| `mathml`  | Convert TeX math to [MathML](https://www.w3.org/Math/) (note that currently only Firefox and Safari natively support MathML)                                                                                                     |
+| `mathml`  | Convert TeX math to [MathML](https://www.w3.org/Math/)                                                                                                                                                                           |
 | `plain`   | No special processing (formulas are put inside a `span` with `class="math").`                                                                                                                                                    |
 
 Note that there is more detailed documentation on each of these options in the Pandoc [Math Rendering in HTML](https://pandoc.org/MANUAL.html#math-rendering-in-html) documentation.

--- a/docs/output-formats/html-basics.qmd
+++ b/docs/output-formats/html-basics.qmd
@@ -149,7 +149,7 @@ Available math rendering methods include:
 | `katex`   | Use [KaTeX](https://github.com/Khan/KaTeX) to display embedded TeX math in HTML output.                                                                                                                                          |
 | `webtex`  | Convert TeX formulas to `<img>` tags that link to an external script that converts formulas to images.                                                                                                                           |
 | `gladtex` | Enclose TeX math in `<eq>` tags in HTML output. The resulting HTML can then be processed by [GladTeX](https://humenda.github.io/GladTeX/) to produce images of the typeset formulas and an HTML file with links to these images. |
-| `mathml`  | Convert TeX math to [MathML](https://www.w3.org/Math/)                                                                                                                                                                           |
+| `mathml`  | Convert TeX math to [MathML](https://www.w3.org/Math/).                                                                                                                                                                          |
 | `plain`   | No special processing (formulas are put inside a `span` with `class="math").`                                                                                                                                                    |
 
 Note that there is more detailed documentation on each of these options in the Pandoc [Math Rendering in HTML](https://pandoc.org/MANUAL.html#math-rendering-in-html) documentation.


### PR DESCRIPTION
Chromium-based browsers support MathML as of January 2023. Firefox and Safari already did.