### PR TITLE
Fix typo in navbar reference

### DIFF
--- a/docs/reference/projects/navbar.json
+++ b/docs/reference/projects/navbar.json
@@ -45,7 +45,7 @@
   },
   {
     "name": "right",
-    "description": "List of items for the left side of the navbar (see [Nav Items](#nav-items))"
+    "description": "List of items for the right side of the navbar (see [Nav Items](#nav-items))"
   },
   {
     "name": "toggle-position",

--- a/tools/reference.ts
+++ b/tools/reference.ts
@@ -409,7 +409,7 @@ writeProjectTable("sidebartool", sidebarToolOptions);
 
 const navbarOptions = readDefinitionsObject("navbar", {
   "left": "List of items for the left side of the navbar (see [Nav Items](#nav-items))",
-  "right": "List of items for the left side of the navbar (see [Nav Items](#nav-items))"
+  "right": "List of items for the right side of the navbar (see [Nav Items](#nav-items))"
 });
 writeProjectTable("navbar", navbarOptions);
 


### PR DESCRIPTION
`navbar: right:` "left" -> "right" at: https://deploy-preview-1015--mystifying-jepsen-fa4396.netlify.app/docs/reference/projects/websites.html#navbar
Closes https://github.com/quarto-dev/quarto-cli/issues/8676