### PR TITLE
typo in link to page-footer part

### DIFF
--- a/tools/reference.ts
+++ b/tools/reference.ts
@@ -377,7 +377,7 @@ writeProjectTable("open-graph", openGraphOptions);
 const websiteOptions = readDefinitionsId("base-website", {
   "navbar": "Navbar options (see [Navbar](#navbar))",
   "sidebar": "Sidebar options (see [Sidebar](#sidebar))",
-  "page-footer": "Page footer. Text content or [page footer](#page-footer) definition.",
+  "page-footer": "Page footer. Text content or [page footer](#footer) definition.",
   "open-graph": "Generate Open Graph metadata (see [Open Graph](#open-graph) options)",
   "twitter-card": "Generate Twitter Card metadata (see [Twitter Card](#twitter-card) options)",
   "search": "Site search (`true` or `false` to enable/disable, or provide custom [Search Options](#search)"


### PR DESCRIPTION
fixes quarto-dev/quarto-cli#8839

I am not sure this will update the reference page though, because `references.ts` is called at each release I believe (we don't update reference pages between version in the doc). 

@cscheid can we do patch release of the documentation ? I am thinking backporting this commit to `v1.4` and regenerate the reference pages when we do our next patch release for v1.4

