### PR TITLE
Fix internal links using `.qmd`

### DIFF
--- a/docs/websites/_page-navigation.md
+++ b/docs/websites/_page-navigation.md
@@ -17,7 +17,7 @@ page-navigation: false
 ---
 ```
 
-Or to control page navigation for all pages in a directory specify `page-navigation` in [`_metadata.yml`](https://quarto.org/docs/projects/quarto-projects.qmd#directory-metadata):
+Or to control page navigation for all pages in a directory specify `page-navigation` in [`_metadata.yml`](/docs/projects/quarto-projects.qmd#directory-metadata):
 
 ``` {.yaml filename="_metadata.yml"}
 page-navigation: false


### PR DESCRIPTION
They need to be internal link to support `.html` transformation correctly.

This fixes https://github.com/quarto-dev/quarto-cli/issues/8902

As noted by @mcanouil, there is quite a number of links that are using absolute links starting with `https://quarto.org` instead of internal links started with `/docs/...`

@cwickham we are not sure if we are missing something regarding usage of absolute links. Probably internal links could be used instead (so that they work correctly locally or on preview for example). 

@mcanouil offered to make a PR is needed. 

Thanks