### PR TITLE
[GHA] Trigger publishing only when changes detected when regenerating (pre)release information

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,18 +2,13 @@ on:
   workflow_dispatch:
   push:
     branches: main
-  workflow_run:
-    workflows: [Update Downloads]
-    branches: [main]
-    types:
-      - completed
+  workflow_call:
 
 name: Quarto Publish
 
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4 

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   update-downloads:
     runs-on: ubuntu-latest
+    outputs:
+      changes_detected: ${{ steps.auto-commit.outputs.changes_detected }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -23,6 +25,7 @@ jobs:
           pre-redirects-template: /download/prerelease/$$prefix$$-$$suffix$$.$$extension$$
           github-token: ${{ github.token }}          
       - name: Commit Changes
+        id: auto-commit
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           repository: .
@@ -30,3 +33,8 @@ jobs:
           commit_user_email: runner@quarto.org
           commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           skip_checkout: true
+
+  publish-changes:
+    needs: [ update-downloads ]
+    if: ${{ needs.update-downloads.outputs.changes_detected }}
+    uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
We shouldn't publish each time update-downloads run, so just trigger publish when required