### PR TITLE
[Typo]: Fixed a very simple typo in `starter-templates.qmd`

### DIFF
--- a/docs/extensions/starter-templates.qmd
+++ b/docs/extensions/starter-templates.qmd
@@ -19,7 +19,7 @@ Starter templates are essentially just GitHub repositories that are copied to a 
 
 ## Creating a Template
 
-To create a starter template, just create a GitHub repository that includes the files you want copied into projects created with the template. All of the files in the repository are copied save for:
+To create a starter template, just create a GitHub repository that includes the files you want copied into projects created with the template. All of the files in the repository are copied except for:
 
 1.  Hidden files (any file or directory name that starts with `.` (e.g. `.gitignore`).
 


### PR DESCRIPTION
Simple typo fix for the docs in [starter-templates.qmd](https://github.com/quarto-dev/quarto-web/blob/main/docs/extensions/starter-templates.qmd).

Changed "All of the files in the repository are copied save for:" to "All of the files in the repository are copied except for:".

***

I noticed this while reading the [starter templates documentation](https://quarto.org/docs/extensions/starter-templates.html):

![image](https://github.com/quarto-dev/quarto-web/assets/32652297/1f3bf010-a79a-4e16-80db-9e0107759cde)

