### PR TITLE
Document default fig-format being svg for typst

### DIFF
--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -248,7 +248,7 @@ fontsize: 11pt
 
 ## Computation Figure Format
 
-Typst has great support for vector graphics from SVG files, so `format: typst` defaults to `fig-format: svg`. This configuration will apply to any computation chunk to produce `.svg` image file as output. 
+Typst has great support for SVG graphics, so `format: typst` defaults to `fig-format: svg`. This configuration means executable code cells that produce images will produce `.svg` output. 
 
 If you prefer to include raster graphics, set `fig-format` to another value, like for example: 
 
@@ -258,7 +258,7 @@ format:
     fig-format: png
 ```
 
-See other Figure options in the [Typst reference page](/docs/reference/formats/typst.qmd#figures)
+See other figure options on the [Typst reference page](/docs/reference/formats/typst.qmd#figures)
 
 ## Includes
 

--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -246,6 +246,19 @@ fontsize: 11pt
 ---
 ```
 
+## Computation Figure Format
+
+Typst has great support for vector graphics from SVG files, so `format: typst` defaults to `fig-format: svg`. This configuration will apply to any computation chunk to produce `.svg` image file as output. 
+
+If you prefer to include raster graphics, set `fig-format` to another value, like for example: 
+
+```yaml
+format:
+  typst:
+    fig-format: png
+```
+
+See other Figure options in the [Typst reference page](/docs/reference/formats/typst.qmd#figures)
 
 ## Includes
 


### PR DESCRIPTION
Add a part about typst using svg as defauilt fig-format and how to change to raster if needed.

Add this precision in the documentation based on feedback at https://github.com/quarto-dev/quarto-cli/issues/7716#issuecomment-2038352708 

I think it could be useful to have this mention quickly in typst doc directly. 