### PR TITLE
Add note on changing the alt text behavior with backslash

### DIFF
--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -85,6 +85,15 @@ Note that the figure caption, title, and alt text can all be different. For exam
 <img src="elephant.png" title="Title: An elephant" alt="A drawing of an elephant.">
 ```
 
+To render the text within square brackets
+as the alt text instead of as the caption,
+you can append a backslash to the line
+as detailed in [the pandoc documentation](https://pandoc.org/MANUAL.html#extension-implicit_figures):
+
+``` markdown
+![A drawing of an elephant.](elephant.png)\
+```
+
 ### Multiformat Figures
 
 You can write markdown that provides a distinct image file format depending on the target output format. To do this simply leave-off the extension, for example:


### PR DESCRIPTION
Follow up from https://github.com/quarto-dev/quarto-cli/discussions/9310. I think it is helpful to document this behavior as it is the default in many other markdown specs and could help transitioning existing material to quarto.