### PR TITLE
Switch from URL from GH Wiki (deprecated) to Lua Site Wiki

### DIFF
--- a/docs/extensions/lua.qmd
+++ b/docs/extensions/lua.qmd
@@ -251,7 +251,7 @@ end
 
 ### Type Hints
 
-While Quarto provides type information for the Pandoc and Quarto Lua APIs, this doesn't cover functions that you write within your own extensions. You can however add type information using [Annotations](https://github.com/sumneko/lua-language-server/wiki/Annotations). For example, here we indicate that a function takes a `string` and a `pandoc.List()` and returns either a `pandoc.List()` or `nil`:
+While Quarto provides type information for the Pandoc and Quarto Lua APIs, this doesn't cover functions that you write within your own extensions. You can however add type information using [Annotations](https://luals.github.io/wiki/annotations). For example, here we indicate that a function takes a `string` and a `pandoc.List()` and returns either a `pandoc.List()` or `nil`:
 
 ``` lua
 ---@param text string
@@ -264,13 +264,13 @@ end
 
 With these type declarations, any attempt to call the function without the correct types will result in a diagnostic message. Further, if a caller fails to check for `nil` before using the return value a diagnostic will also occur.
 
-You can learn more about all of the available type annotations in the [Annotations Reference](https://github.com/sumneko/lua-language-server/wiki/Annotations) for the Lua Language Server.
+You can learn more about all of the available type annotations in the [Annotations Reference](https://luals.github.io/wiki/annotations) for the Lua Language Server.
 
 ### Settings
 
 The [Lua Language Server](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) extension includes a wide variety of options to customize its behavior (e.g. what diagnostics to show, which completions to offer, etc.).
 
-All of the available options are documented in the [Settings Reference](https://github.com/sumneko/lua-language-server/wiki/Settings) for the Lua Language Server.
+All of the available options are documented in the [Settings Reference](https://luals.github.io/wiki/settings/) for the Lua Language Server.
 
 Quarto provides a default configuration file (`.luarc.json`) within the root of any workspace that includes Quarto Lua extensions. This file is necessary because it provides a reference to the Lua type definitions for Pandoc and Quarto within your currently installed version of Quarto. Without it, the Lua extension wouldn't know anything about Quarto and would report errors for "unknown" Pandoc modules.
 
@@ -291,7 +291,7 @@ If, for example, Quarto is installed at `/opt/quarto/`, the default contents of 
 
 The `.luarc.json` file will also be automatically added to `.gitignore` since it points to the absolute path of Quarto on the local system.
 
-You can change any of the settings within this file save for the `Lua.workspace.library` and `Lua.runtime.plugin` (these are automatically maintained by the Quarto extension based on where Quarto is installed). See the [Settings Reference](https://github.com/sumneko/lua-language-server/wiki/Settings) for all available settings.
+You can change any of the settings within this file save for the `Lua.workspace.library` and `Lua.runtime.plugin` (these are automatically maintained by the Quarto extension based on where Quarto is installed). See the [Settings Reference](https://luals.github.io/wiki/settings/) for all available settings.
 
 If you prefer to manage this file manually, simply remove the `Generator` key and Quarto will no longer update the `Lua.workspace.library` and `Lua.runtime.plugin` settings automatically.
 


### PR DESCRIPTION
GH Wiki is displaying a deprecation warning at the top of the page:

This wiki has been replaced by the wiki on our website. This wiki will be removed in the future.

The warning redirects to update bookmarks to:

https://luals.github.io/wiki/<page>/