### PR TITLE
Specify caveats of book-project bibliographies

### DIFF
--- a/docs/authoring/footnotes-and-citations.qmd
+++ b/docs/authoring/footnotes-and-citations.qmd
@@ -90,7 +90,7 @@ By default, Pandoc will automatically generate a list of works cited and place i
 :::
 ```
 
-If no such div is found, the works cited list will be placed at the end of the document. 
+If no such div is found, the works cited list will be placed at the end of the document. Book project must explicitly specify the div.
 
 If your bibliography is being generated using BibLaTeX or natbib (@sec-biblatex), the bibliography will always appear at the end of the document and the `#refs` div will be ignored.
 

--- a/docs/books/book-structure.qmd
+++ b/docs/books/book-structure.qmd
@@ -75,6 +75,8 @@ You should include a `div` with the id `#refs` at the location in your book wher
 :::
 ```
 
+Here, the bibliography of all cited works in the project will be placed. It is not possible in the Book project type to have per-page bibliographies, even if an explicit file specified in the `bibliography:` section of the markdown header of that page.
+
 Note that you can change the chapter title to whatever you like, remove `.unnumbered` to have it be numbered like other chapters, and add other content before or after the bibliography as necessary.
 
 ## Creating an Index


### PR DESCRIPTION
As per [this discussion](https://github.com/quarto-dev/quarto-cli/discussions/9337#discussioncomment-9082769) and it appears in multiple places, there is confusion on what is possible in Book project types when it comes to bibliographies.

It appears many people (including myself) assume if a dedicated bibliography file is specified in the header of a page, it should be possible that only the cited works on the page will be rendered in a bibliography of that page. This is because many acadmic 'edited volume' books indeed has a standalone reference section per chapter.

However @mcanouil stated this is not possible with Quarto., and that there can only be single bibliography in a Book project - and even if there is HTML on the page with what was expected, it is hidden using css with no (apparent?) way to make this visible (see original discussion).

I've made a (likely overly wordy) attempt to clarify single-bibliography behaviour  of books, as I found it is not clear from the current documentation, and can be easily misinterpreted (the current phrasing is rather implicit).

I have not made reference to @mcanouil 's section-biblography extension  as I'm not sure if that is allowed on the 'main' Quarto documenation - but I would think it would be useful.