### PR TITLE
quarto-required not quarto-version

### DIFF
--- a/docs/extensions/project-types.qmd
+++ b/docs/extensions/project-types.qmd
@@ -71,7 +71,7 @@ Let's explore the code for the extension first. Here is the main `_extension.yml
 title: Lexdocs Project
 author: Lexcorp, Inc.
 version: 1.0.0
-quarto-version: ">=1.2.0"
+quarto-required: ">=1.2.0"
 contributes:
   project:
     project:


### PR DESCRIPTION
Most other extension documentation uses `quarto-required`, not `quarto-version`. It appears that `quarto-required` is the correct field.