### PR TITLE
fix: aliases use qmd instead of html

### DIFF
--- a/docs/extensions/filters.qmd
+++ b/docs/extensions/filters.qmd
@@ -1,8 +1,8 @@
 ---
 title: "Creating Filters"
 aliases: 
-  - /docs/authoring/shortcodes-and-filters.qmd
-  - /docs/authoring/filters.qmd
+  - /docs/authoring/shortcodes-and-filters.html
+  - /docs/authoring/filters.html
 ---
 
 {{< include _extension-version.qmd >}}

--- a/docs/extensions/shortcodes.qmd
+++ b/docs/extensions/shortcodes.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Creating Shortcodes"
 aliases: 
-  - /docs/authoring/shortcodes.qmd
+  - /docs/authoring/shortcodes.html
 ---
 
 {{< include _extension-version.qmd >}}

--- a/docs/projects/binder.qmd
+++ b/docs/projects/binder.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Using Binder With Quarto"
 aliases: 
-  - /docs/prerelease/1.4/binder.qmd
+  - /docs/prerelease/1.4/binder.html
 ---
 
 {{< include /docs/_require-1.4.qmd >}}


### PR DESCRIPTION
This pull request fixes the file extensions of the aliases in the documentation files. The aliases were previously using the .qmd extension instead of the correct .html extension.

Fixes quarto-dev/quarto-cli#9494