### PR TITLE
feat: add mcanouil/quarto-highlight-text filter

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -374,7 +374,6 @@
   description: |
     Convert embedded LaTeX to images and use .tex/.tikz files as image sources.
 
-
 - name: options
   path: https://github.com/coatless-quarto/options
   author: "[James Joseph Balamuta](https://github.com/coatless/)"
@@ -386,3 +385,9 @@
   author: "[James Joseph Balamuta](https://github.com/coatless/)"
   description: |
       Developer extension to parse options from custom code cells.
+
+- name: highlight-text
+  path: https://github.com/mcanouil/quarto-highlight-text
+  author: "[Mickaël CANOUIL](https://github.com/mcanouil)"
+  description: |
+    Quarto extension that allows to highlight text in a document for various formats: HTML, LaTeX, Typst, and Docx.


### PR DESCRIPTION
This pull request adds an extension filter to ease formatting of text in various format, in particular setting foreground and background colours.

<img width="825" alt="image" src="https://github.com/quarto-dev/quarto-web/assets/8896044/6545cfc2-7559-4e66-aa69-c8b4e448c9ad">
