### PR TITLE
document confluence env vars

### DIFF
--- a/docs/publishing/ci.qmd
+++ b/docs/publishing/ci.qmd
@@ -184,3 +184,11 @@ export CONNECT_SERVER=https://connect.example.com/
 export CONNECT_API_KEY=7C0947A852D8
 quarto publish connect --id DDA36416-F950-4647-815C-01A24233E294
 ```
+
+```{.bash filename="Terminal"}
+# render and publish to Confluence based on _publish.yml
+export CONFLUENCE_AUTH_TOKEN=7C0947A852D8
+export CONFLUENCE_USER_EMAIL=email@domain.com
+export CONFLUENCE_DOMAIN=https://domain.atlassian.net/
+quarto publish confluence --no-browser --no-prompt
+```

--- a/docs/publishing/ci.qmd
+++ b/docs/publishing/ci.qmd
@@ -127,11 +127,12 @@ If you have multiple publishing targets saved within `_publish.yml` then the `--
 
 You can specify publishing credentials either using environment variables or via command line parameters. The following environment variables are recognized for various services:
 
-| Service         | Variables                              |
-|-----------------|----------------------------------------|
-| Quarto Pub      | `QUARTO_PUB_AUTH_TOKEN`                |
-| Netlify         | `NETLIFY_AUTH_TOKEN`                   |
-| Posit Connect   | `CONNECT_SERVER` and `CONNECT_API_KEY` |
+| Service         | Variables                                                                 |
+|-----------------|---------------------------------------------------------------------------|
+| Quarto Pub      | `QUARTO_PUB_AUTH_TOKEN`                                                   |
+| Netlify         | `NETLIFY_AUTH_TOKEN`                                                      |
+| Posit Connect   | `CONNECT_SERVER` and `CONNECT_API_KEY`                                    |
+| Confluence      | `CONFLUENCE_AUTH_TOKEN`, `CONFLUENCE_USER_EMAIL`, and `CONFLUENCE_DOMAIN` |
 
 Set these environment variables within your script before calling `quarto publish`. For example:
 


### PR DESCRIPTION
I could not find which Confluence environmental variables are valid. I wasn't sure where it was most appropriate to document them. I put them on the CI page, but perhaps the Confluence page would be even better. I chose CI since there were other env vars there. 

This was the only location where I found these env vars defined: https://github.com/quarto-dev/quarto-cli/discussions/6915