### PR TITLE
Refer to pre-release site for highlights

### DIFF
--- a/docs/prerelease/1.5/_highlights.qmd
+++ b/docs/prerelease/1.5/_highlights.qmd
@@ -1,9 +1,1 @@
-Quarto 1.5 includes the following new features:
-
--   [Website Draft Mode](/docs/prerelease/1.5/website-drafts.qmd)---Improved support for workflows involving draft posts and pages. 
-
--   [Native Julia Engine](/docs/computations/julia.qmd#using-the-julia-engine)---Execute Julia code in Quarto documents without requiring Jupyter.
-
--   [Project Pre Render Scripts](/docs/prerelease/1.5/pre-render.qmd)---Project metadata and the render list are now re-computed after any pre-render scripts have executed.
-
-- [Element-wide disabling of HTML processing](/docs/prerelease/1.5/lua-table-processing.qmd)---Additional control for table processing.
+You can view (in-progress) documentation for the next version of Quarto, v1.5, on our pre-release documentation site, [prerelease.quarto.org](https://prerelease.quarto.org), including a list of [highlights](https://prerelease.quarto.org/docs/prerelease/1.5/). 


### PR DESCRIPTION
From now on, pre-release highlights will live on the pre-release site. 

Highlights appear on:
* [1.5 Pre-release page](https://deploy-preview-1106.quarto.org/docs/prerelease/1.5/)
* [Pre-release download page](https://deploy-preview-1106.quarto.org/docs/download/prerelease)