### PR TITLE
Suggest linux users put execs in ~/.local/bin

### DIFF
--- a/docs/download/tarball.qmd
+++ b/docs/download/tarball.qmd
@@ -37,21 +37,23 @@ tar -C ~/opt -xvzf quarto-^version^-linux-amd64.tar.gz
 
 **3. Create a Symlink**
 
-Create a symlink to `bin/quarto` in a folder that is in your path. If there is no such folder, you can create a folder such as `~/bin` and place the symlink there. For example:
+Create a symlink to `bin/quarto` in a folder that is in your path. If there is no such folder, you can create a folder such as `~/.local/bin` and place the symlink there. For example:
 
 For example:
 
 ```{.bash filename="Terminal"}
-mkdir ~/bin
-ln -s ~/opt/quarto-^version^/bin/quarto ~/bin/quarto
+mkdir ~/.local/bin
+ln -s ~/opt/quarto-^version^/bin/quarto ~/.local/bin/quarto
 ```
 
-**4. Add Folder to Path**
+**4. Ensure Folder in on Path**
 
-Ensure that the folder where you created a symlink is in the path. For example:
+If you can run `quarto -v` at this point, jump ahead to the next step.
+
+Otherwise, ensure that the folder where you created a symlink is in the path. For example:
 
 ```{.bash filename="Terminal"}
-( echo ""; echo 'export PATH=$PATH:~/bin\n' ; echo "" ) >> ~/.profile
+( echo ""; echo 'export PATH=$PATH:~/.local/bin\n' ; echo "" ) >> ~/.profile
 source ~/.profile
 ```
 


### PR DESCRIPTION
On many Linux distributions, both `~/bin` and `~/.local/bin` will be automatically put on PATH, thanks to this common snippet in the /etc/profile file:

    PATH=/usr/local/bin:/usr/bin:/bin
    if test "$HOME" != "/" ; then
    for dir in $HOME/bin/$CPU $HOME/bin $HOME/.local/bin/$CPU $HOME/.local/bin ; do
        test -d $dir && PATH=$dir:$PATH
    done
    fi

So, it is prudent to suggest that users check this before modifying their .profile file. Furthermore, while `~/bin` has been informally used for a while, `~/.local/bin` is part of the XDG Base Directory Spec, which is increasingly embraced by the Linux ecosystem.