### PR TITLE
Updates based on changelog

### DIFF
--- a/bug-reports.qmd
+++ b/bug-reports.qmd
@@ -92,42 +92,44 @@ For instance, the markdown code you would provide might look like this:
 
 ````md
 ```bash
-Quarto 99.9.9
+Quarto 1.5.42
 [✓] Checking versions of quarto binary dependencies...
-      Pandoc version 3.1.11: OK
-      Dart Sass version 1.69.5: OK
-      Deno version 1.37.2: OK
+      Pandoc version 3.2.0: OK
+      Dart Sass version 1.70.0: OK
+      Deno version 1.41.0: OK
+      Typst version 0.11.0: OK
 [✓] Checking versions of quarto dependencies......OK
 [✓] Checking Quarto installation......OK
-      Version: 99.9.9
-      Path: /quarto-cli/package/dist/bin
+      Version: 1.5.42
+      Path: /Applications/quarto/bin
 
 [✓] Checking tools....................OK
-      TinyTeX: v2024.01
+      TinyTeX: v2024.03.13
       Chromium: (not installed)
 
 [✓] Checking LaTeX....................OK
       Using: TinyTex
       Path: /Users/username/Library/TinyTeX/bin/universal-darwin
-      Version: 2023
+      Version: 2024
 
 [✓] Checking basic markdown render....OK
 
 [✓] Checking Python 3 installation....OK
       Version: 3.12.1
       Path: /.venv/bin/python3
-      Jupyter: 5.7.1
+      Jupyter: 5.7.2
       Kernels: julia-1.10, python3
 
 [✓] Checking Jupyter engine render....OK
 
 [✓] Checking R installation...........OK
-      Version: 4.3.2
-      Path: /Library/Frameworks/R.framework/Resources
+      Version: 4.3.3
+      Path: /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
       LibPaths:
-        - /Users/username/Library/Caches/org.R-project.R/R/renv/sandbox/R-4.3/aarch64-apple-darwin20/ac5c2659
+        - /Users/username/Library/R/arm64/4.3/library
+        - /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/library
       knitr: 1.45
-      rmarkdown: 2.25
+      rmarkdown: 2.26
 
 [✓] Checking Knitr engine render......OK
 ```

--- a/docs/authoring/variables.qmd
+++ b/docs/authoring/variables.qmd
@@ -75,4 +75,12 @@ The `env` shortcode enables you to read values from environment variables. For e
 Version {{< env PRODUCT_VERSION >}} is a minor upgrade.
 ```
 
+You can provide a fallback value if the environment variable isn't set by providing a second argument:
+
+``` {.markdown shortcodes="false"}
+Version {{< env PRODUCT_VERSION "*.*" >}} is a minor upgrade.
+```
+
+You can read more about setting environment variables in Quarto projects in  [Environment Variables](/docs/projects/environment.qmd).
+
 {{< include ../extensions/_shortcode-escaping.qmd >}}

--- a/docs/dashboards/data-display.qmd
+++ b/docs/dashboards/data-display.qmd
@@ -357,6 +357,8 @@ The `color` can be any CSS color value, however there are some color aliases tha
 
 {{< include _valuebox-colors.md >}}
 
+You can override these defaults by specifying [value box Sass variables](theming.qmd#value-boxes) in a custom theme.
+
 While the aliases apply to all [themes](theming.qmd), the colors they correspond to vary.
 
 ### Shiny

--- a/docs/dashboards/theming.qmd
+++ b/docs/dashboards/theming.qmd
@@ -1,6 +1,7 @@
 ---
 title: "Dashboard Theming"
 tbl-colwidths: [40,60]
+is_dashboards: true
 ---
 
 ## Overview

--- a/docs/output-formats/_theme-variables.md
+++ b/docs/output-formats/_theme-variables.md
@@ -159,18 +159,18 @@ You can also customize the colors of the button which appears for `code-copy: tr
 
 ### Value Boxes
 
-Use the `$valuebox-bg-*` variables to override the color of value boxes.
+Use the `$valuebox-bg-{type}` variables to override the background color of value boxes that are set with `color: type`.
 
-| Variable                     | Notes                                                           |
-|------------------------------|-----------------------------------------------------------------|
-| `$valuebox-bg-primary`       |  The background color for value boxes of `color: primary`.      |
-| `$valuebox-bg-secondary`     |  The background color for value boxes of `color: secondary`.    |
-| `$valuebox-bg-success`       |  The background color for value boxes of `color: success`.      |
-| `$valuebox-bg-info`          |  The background color for value boxes of `color: info`.         |
-| `$valuebox-bg-warning`       |  The background color for value boxes of `color: warning`.      |
-| `$valuebox-bg-danger`        |  The background color for value boxes of `color: danger`.       |
-| `$valuebox-bg-light`         |  The background color for value boxes of `color: light`.        |
-| `$valuebox-bg-dark`          |  The background color for value boxes of `color: dark`.         |
+| Variable                     | Type                   |
+|------------------------------|------------------------|
+| `$valuebox-bg-primary`       |  `color: primary`      |
+| `$valuebox-bg-secondary`     |  `color: secondary`    |
+| `$valuebox-bg-success`       |  `color: success`      |
+| `$valuebox-bg-info`          |  `color: info`         |
+| `$valuebox-bg-warning`       |  `color: warning`      |
+| `$valuebox-bg-danger`        |  `color: danger`       |
+| `$valuebox-bg-light`         |  `color: light`        |
+| `$valuebox-bg-dark`          |  `color: dark`         |
 
 ::: 
 

--- a/docs/output-formats/_theme-variables.md
+++ b/docs/output-formats/_theme-variables.md
@@ -174,4 +174,6 @@ Use the `$valuebox-bg-*` variables to override the color of value boxes.
 
 ::: 
 
+### Bootstrap Variables
+
 In addition to the above Sass variables, Bootstrap itself supports hundreds of additional variables. You can [learn more about Bootstrap's use of Sass variables](https://getbootstrap.com/docs/5.1/customize/sass/) or review the [raw variables and their default values](https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss).

--- a/docs/output-formats/_theme-variables.md
+++ b/docs/output-formats/_theme-variables.md
@@ -155,4 +155,23 @@ You can also customize the colors of the button which appears for `code-copy: tr
 |                          | | `important` | `$red`    |                                                                                                                                        |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
+::: {.content-hidden unless-meta="is_dashboards"}
+
+### Value Boxes
+
+Use the `$valuebox-bg-*` variables to override the color of value boxes.
+
+| Variable                     | Notes                                                           |
+|------------------------------|-----------------------------------------------------------------|
+| `$valuebox-bg-primary`       |  The background color for value boxes of `color: primary`.      |
+| `$valuebox-bg-secondary`     |  The background color for value boxes of `color: secondary`.    |
+| `$valuebox-bg-success`       |  The background color for value boxes of `color: success`.      |
+| `$valuebox-bg-info`          |  The background color for value boxes of `color: info`.         |
+| `$valuebox-bg-warning`       |  The background color for value boxes of `color: warning`.      |
+| `$valuebox-bg-danger`        |  The background color for value boxes of `color: danger`.       |
+| `$valuebox-bg-light`         |  The background color for value boxes of `color: light`.        |
+| `$valuebox-bg-dark`          |  The background color for value boxes of `color: dark`.         |
+
+::: 
+
 In addition to the above Sass variables, Bootstrap itself supports hundreds of additional variables. You can [learn more about Bootstrap's use of Sass variables](https://getbootstrap.com/docs/5.1/customize/sass/) or review the [raw variables and their default values](https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss).

--- a/docs/output-formats/_theme-variables.md
+++ b/docs/output-formats/_theme-variables.md
@@ -159,7 +159,7 @@ You can also customize the colors of the button which appears for `code-copy: tr
 
 ### Value Boxes
 
-Use the `$valuebox-bg-{type}` variables to override the background color of value boxes that are set with `color: type`.
+Use the `$valuebox-bg-<type>` variables to override the background color of value boxes that are set with `color: <type>`.
 
 | Variable                     | Type                   |
 |------------------------------|------------------------|

--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -119,6 +119,12 @@ The `columns` option expects a number - the number of columns your body content 
 
 {{< include /docs/output-formats/_document-options-toc.md >}}
 
+The `toc-indent` option controls how far entries are indented in the displayed table of contents. The default is equivalent to:
+
+```{.yaml}
+toc-indent: 1.5em
+```
+
 {{< include /docs/output-formats/_document-options-section-numbering.md >}}
 
 You can also customize the display of the section numbers with the `section-numbering` YAML option. This option expects a string that describes the numbering schema. For example, the following schema describes numbering sections with numerals, subsection with uppercase letters, and subsubsections with lower case letters, using `.` as a separator:

--- a/docs/troubleshooting/index.qmd
+++ b/docs/troubleshooting/index.qmd
@@ -37,7 +37,7 @@ Quarto 1.5.42
 
 [✓] Checking Python 3 installation....OK
       Version: 3.12.1
-      Path: /Users/username/Documents/posit/quarto-web/.venv/bin/python3
+      Path: /.venv/bin/python3
       Jupyter: 5.7.2
       Kernels: julia-1.10, python3
 

--- a/docs/troubleshooting/index.qmd
+++ b/docs/troubleshooting/index.qmd
@@ -13,31 +13,44 @@ but this page might help you get up and running quickly.
 You can check the version of Quarto and its dependencies by running `quarto check`. Here's an example of the output it generates:
 
 ```
+Quarto 1.5.42
 [✓] Checking versions of quarto binary dependencies...
-      Pandoc version 2.19.2: OK
-      Dart Sass version 1.32.8: OK
+      Pandoc version 3.2.0: OK
+      Dart Sass version 1.70.0: OK
+      Deno version 1.41.0: OK
+      Typst version 0.11.0: OK
 [✓] Checking versions of quarto dependencies......OK
 [✓] Checking Quarto installation......OK
-      Version: 1.2.313
-      Path: /Users/cscheid/repos/github/quarto-dev/quarto-cli/package/dist/bin
+      Version: 1.5.42
+      Path: /Applications/quarto/bin
+
+[✓] Checking tools....................OK
+      TinyTeX: v2024.03.13
+      Chromium: (not installed)
+
+[✓] Checking LaTeX....................OK
+      Using: TinyTex
+      Path: /Users/username/Library/TinyTeX/bin/universal-darwin
+      Version: 2024
 
 [✓] Checking basic markdown render....OK
 
 [✓] Checking Python 3 installation....OK
-      Version: 3.10.9
-      Path: /Users/cscheid/virtualenvs/homebrew-python3/bin/python3
-      Jupyter: 5.1.3
-      Kernels: python3, julia-1.6, julia-1.8
+      Version: 3.12.1
+      Path: /Users/username/Documents/posit/quarto-web/.venv/bin/python3
+      Jupyter: 5.7.2
+      Kernels: julia-1.10, python3
 
 [✓] Checking Jupyter engine render....OK
 
 [✓] Checking R installation...........OK
-      Version: 4.2.2
-      Path: /Library/Frameworks/R.framework/Resources
+      Version: 4.3.3
+      Path: /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
       LibPaths:
-        - /Users/cscheid/repos/github/quarto-dev/quarto-web/renv/library/R-4.2/aarch64-apple-darwin20
-        - /private/var/folders/nm/m64n9_z9307305n0xtzpp54m0000gn/T/RtmpXmQfZA/renv-system-library
-      rmarkdown: 2.14
+        - /Users/username/Library/R/arm64/4.3/library
+        - /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/library
+      knitr: 1.45
+      rmarkdown: 2.26
 
 [✓] Checking Knitr engine render......OK
 ```

--- a/docs/websites/website-navigation.qmd
+++ b/docs/websites/website-navigation.qmd
@@ -397,6 +397,15 @@ website:
   bread-crumbs: false
 ```
 
+You can also disable breadcrumbs on individual pages:
+
+```{.yaml filename="document.qmd"}
+---
+title: Page without breadcrumbs
+bread-crumbs: false
+---
+```
+
 {{< include _page-navigation.md >}}
 
 ### Separators


### PR DESCRIPTION
Edits based on items in changelog as of 5ec7da0 06/06/24:

## Website

- [X] ([#8108](https://github.com/quarto-dev/quarto-cli/issues/8108)): Individual pages can suppress breadcrumbs using `bread-crumbs: false`
  Added example to: /docs/websites/website-navigation.html#breadcrumbs

## Typst

- [X] ([#9293](https://github.com/quarto-dev/quarto-cli/pull/9293)): Add `toc-indent` to control indentation of entries in the table of contents.

  Added example to: /docs/output-formats/typst.html#table-of-contents

## Shortcodes

- [X] ([#8316](https://github.com/quarto-dev/quarto-cli/issues/8316)): Add fallback value for the `env` shortcode.

  Added example to /docs/authoring/variables.html#env

## `quarto check`

- [X] `quarto check` now checks a minimal version of Typst and prints the version, to aid with troubleshooting.

  Updated example output in `bug-reports.html` and `docs/troubleshooting/`

## Other Fixes and Improvements

- [X] ([#9460](https://github.com/quarto-dev/quarto-cli/pulls/9460)): `$valuebox-bg-{color}` Sass variables, e.g. `$valuebox-bg-primary`, can now be set directly for custom value box background colors.

    Added conditionally to `_theme-variables.md` which gets included in: `docs/dashboards/theming.html#sass-variables`
    Closes: https://github.com/quarto-dev/quarto-cli/issues/9487


