### PR TITLE
Advanced Docs Landing Page

### DIFF
--- a/docs/advanced/environment-vars.qmd
+++ b/docs/advanced/environment-vars.qmd
@@ -50,10 +50,10 @@ ENV["QUARTO_DOCUMENT_PATH"]
 :::
 
 
-| Variable                  | Description |
-|---------------------------|-------------|
-| `QUARTO_PROJECT_ROOT`     |             |
-| `QUARTO_DOCUMENT_PATH`    |             |
-|                           |             |
+| Variable               | Description                                                                                                |
+|------------------------|------------------------------------------------------------------------------------------------------------|
+| `QUARTO_PROJECT_ROOT`  |  Root of the project, or the directory of the file if not in project mode                                  |
+| `QUARTO_DOCUMENT_PATH` |  Directory of the document being rendered                                                                  |
+| `QUARTO_PROFILE`       |  Profile used, e.g `QUARTO_PROFILE=advanced,production` for `quarto render --profile advanced,production`  |
 
 

--- a/docs/advanced/environment-vars.qmd
+++ b/docs/advanced/environment-vars.qmd
@@ -9,7 +9,7 @@ draft: true
 
 These are variables that you can set to control how Quarto renders documents. For example, you can set them explicitly before running `quarto render`:
 
-```{.bash filename="Terminal"}
+``` {.bash filename="Terminal"}
 export QUARTO_R=/opt/R/4.2.3/bin
 quarto render
 ```
@@ -26,34 +26,30 @@ You can read about other ways to set environment variables in Quarto Projects in
 
 These variables are set by Quarto you can query them. For example, you can query them in an executable code cell:
 
-::: {.panel-tabset}
-
+::: panel-tabset
 ## R
 
-```r
+``` r
 Sys.getenv("QUARTO_DOCUMENT_PATH")
 ```
 
 ## Python
 
-```python
+``` python
 import os
 print(os.environ["QUARTO_DOCUMENT_PATH"])
 ```
 
-## Julia 
+## Julia
 
-```julia
+``` julia
 ENV["QUARTO_DOCUMENT_PATH"]
 ```
-
 :::
 
-
-| Variable               | Description                                                                                                |
-|------------------------|------------------------------------------------------------------------------------------------------------|
-| `QUARTO_PROJECT_ROOT`  |  Root of the project, or the directory of the file if not in project mode                                  |
-| `QUARTO_DOCUMENT_PATH` |  Directory of the document being rendered                                                                  |
-| `QUARTO_PROFILE`       |  Profile used, e.g `QUARTO_PROFILE=advanced,production` for `quarto render --profile advanced,production`  |
-
-
+| Variable | Description |
+|----------------|--------------------------------------------------------|
+| `QUARTO_PROJECT_ROOT` | Root of the project, or the directory of the file if not in project mode |
+| `QUARTO_DOCUMENT_PATH` | Directory of the document being rendered |
+| `QUARTO_PROFILE` | Profile used, e.g `QUARTO_PROFILE=advanced,production` for `quarto render --profile advanced,production` |
+| `QUARTO_FIG_WIDTH` and `QUARTO_FIG_HEIGHT` | Values for `fig-width` and `fig-height` as set in the document metadata |

--- a/docs/advanced/environment-vars.qmd
+++ b/docs/advanced/environment-vars.qmd
@@ -1,0 +1,59 @@
+---
+title: "Environment Variables"
+summary: Environment variables Quarto inspects and sets
+format: html
+draft: true
+---
+
+## Variables Quarto inspects
+
+These are variables that you can set to control how Quarto renders documents. For example, you can set them explicitly before running `quarto render`:
+
+```{.bash filename="Terminal"}
+export QUARTO_R=/opt/R/4.2.3/bin
+quarto render
+```
+
+You can read about other ways to set environment variables in Quarto Projects in [Environment Variables](/docs/projects/environment.qmd).
+
+| Variable        | Description |
+|-----------------|-------------|
+| `QUARTO_R`      |             |
+| `QUARTO_PYTHON` |             |
+|                 |             |
+
+## Variables Quarto sets
+
+These variables are set by Quarto you can query them. For example, you can query them in an executable code cell:
+
+::: {.panel-tabset}
+
+## R
+
+```r
+Sys.getenv("QUARTO_DOCUMENT_PATH")
+```
+
+## Python
+
+```python
+import os
+print(os.environ["QUARTO_DOCUMENT_PATH"])
+```
+
+## Julia 
+
+```julia
+ENV["QUARTO_DOCUMENT_PATH"]
+```
+
+:::
+
+
+| Variable                  | Description |
+|---------------------------|-------------|
+| `QUARTO_PROJECT_ROOT`     |             |
+| `QUARTO_DOCUMENT_PATH`    |             |
+|                           |             |
+
+

--- a/docs/advanced/index.qmd
+++ b/docs/advanced/index.qmd
@@ -1,0 +1,12 @@
+---
+title: "Advanced User Documentation"
+format: html
+search: false
+listing: 
+  type: table
+  fields: [title, summary]
+  field-display-names:
+    summary: Summary
+---
+
+Topics on this page may be of interest to advanced users of Quarto. 

--- a/docs/advanced/jupyter/kernel-execution.qmd
+++ b/docs/advanced/jupyter/kernel-execution.qmd
@@ -1,6 +1,7 @@
 ---
 title: Jupyter Kernel Execution
 format: html
+summary: How to support Quarto from a Jupyter kernel
 ---
 
 Quarto executes Jupyter notebooks using [`nbclient`](https://github.com/jupyter/nbclient) together with a few additional options


### PR DESCRIPTION
* Listing page at `docs/advanced/index.qmd`: [Preview](https://deploy-preview-1145.quarto.org/docs/advanced/)
    * Not included in search (but pages in `docs/advanced` are)
    * Not linked from navigation
    * Drafts will not appear in published listing, but will appear in previews