### PR TITLE
Update citation.json

### DIFF
--- a/docs/reference/metadata/citation.json
+++ b/docs/reference/metadata/citation.json
@@ -4,6 +4,10 @@
     "title": "Citation",
     "options": [
       {
+        "name": "id",
+        "description": "Identifier of the item (usually comprised of some combination of author last name, year of publication, and first word of the article title."
+      },
+      {
         "name": "abstract",
         "description": "Abstract of the item (e.g. the abstract of a journal article)"
       },


### PR DESCRIPTION
I guess you can use the `id` parameter to customize the identifier that shows up at the top. 

<img width="715" alt="Screenshot 2024-06-18 at 1 11 16 PM" src="https://github.com/quarto-dev/quarto-web/assets/1328807/1e56d8f2-60fe-4e97-84fc-5529225fbe40">

Adding this info to the docs.
