### PR TITLE
Add example of customizing format-links

### DIFF
--- a/docs/output-formats/html-multi-format.qmd
+++ b/docs/output-formats/html-multi-format.qmd
@@ -70,6 +70,29 @@ format:
 format-links: [ipynb]
 ```
 
+You can also customize the links by passing `format-links` an object with keys:
+
+* `format`, the format to be linked
+* `text`, the text to be displayed for the link
+* `icon`, the name of a [Bootstrap icons](https://icons.getbootstrap.com)
+
+For example, here a link to the `typst` format is displayed as the text "PDF" along with a PDF file icon:
+
+```yaml
+title: Sample Page
+author: Norah Jones
+date: last-modified
+toc: true
+format: 
+  html: default
+  typst: default
+format-links:
+  - html
+  - format: typst
+    text: PDF
+    icon: file-pdf
+```
+
 ## Hiding All Links
 
 To prevent format links from being shown at all, specify `format-links: false` in your document front matter. For example this front matter will not display the **Other Formats** links:

--- a/docs/output-formats/html-multi-format.qmd
+++ b/docs/output-formats/html-multi-format.qmd
@@ -93,6 +93,16 @@ format-links:
     icon: file-pdf
 ```
 
+You can also provide `format-links` items using the same options as [Code Links and Other Links](html-basics.html#code-links-and-other-links). 
+For example, rather than another format, you could to add a link to an external URL:
+
+```yaml
+format-links:
+  - text: Other Link
+    href: https://quarto.org/
+    icon: hand-thumbs-up
+```
+
 ## Hiding All Links
 
 To prevent format links from being shown at all, specify `format-links: false` in your document front matter. For example this front matter will not display the **Other Formats** links:


### PR DESCRIPTION
Adds example in [Guide > HTML > Including Other Formats](https://deploy-preview-1167.quarto.org/docs/output-formats/html-multi-format.html#specifying-formats-to-link)

Closes https://github.com/quarto-dev/quarto-cli/issues/8610