### PR TITLE
Update website-navigation.qmd to use `_index.qmd`

### DIFF
--- a/docs/websites/website-navigation.qmd
+++ b/docs/websites/website-navigation.qmd
@@ -186,9 +186,9 @@ Using `contents: auto` at the root level will result in all documents in your we
 
 1.  Navigation item titles will be read from the `title` field of documents.
 
-2.  Sub-directories will create sections and will be automatically titled based on the directory name (including adding capitalization and substituting spaces for dashes and underscores). Use an `index.qmd` in the directory to provide an explicit `title` if you don't like the automatic one.
+2.  Sub-directories will create sections and will be automatically titled based on the directory name (including adding capitalization and substituting spaces for dashes and underscores). Use an `_index.qmd` in the directory to provide an explicit `title` if you don't like the automatic one.
 
-3.  Order is alphabetical (by filename) unless a numeric `order` field is provided in document metadata.
+3.  Order is alphabetical (by filename) unless a numeric `order` field is provided in document metadata. Use an `_index.qmd` file in a sub-directory to set its `order` position.
 
 Automatic navigation automatically includes items in sub-directories. If you prefer not to do this, use an explicit `/*` to indicate only the documents in the root directory:
 


### PR DESCRIPTION
Two tweaks here would have helped me understand the "auto" option for creating navigation in websites a little bit better.

- Using `_index.qmd` instead of `index.qmd` because the latter creates its own page, which is often not what you want.
- Telling the user they can also control the order of a sub-directory using `_index.qmd`.