### PR TITLE
Move footnotes to markdown basics

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -131,7 +131,7 @@ website:
                 contents:
                   - docs/authoring/front-matter.qmd
                   - docs/authoring/title-blocks.qmd
-                  - docs/authoring/footnotes-and-citations.qmd
+                  - docs/authoring/citations.qmd
                   - section: Cross-References
                     contents:
                       - text: Basics

--- a/docs/authoring/citations.qmd
+++ b/docs/authoring/citations.qmd
@@ -6,7 +6,7 @@ aliases:
   - /docs/authoring/footnotes-and-citations.html
 ---
 
-## Overview
+## Overview {#citations}
 
 Quarto will use Pandoc to automatically generate citations and a bibliography in a number of styles. To use this capability, you will need:
 

--- a/docs/authoring/citations.qmd
+++ b/docs/authoring/citations.qmd
@@ -1,11 +1,12 @@
 ---
-title: Citations & Footnotes
+title: Citations
 format: html
 link-citations: true
-section-title-footnotes: Example Footnotes
+aliases: 
+  - /docs/authoring/footnotes-and-citations.html
 ---
 
-## Citations
+## Overview
 
 Quarto will use Pandoc to automatically generate citations and a bibliography in a number of styles. To use this capability, you will need:
 
@@ -15,7 +16,7 @@ Quarto will use Pandoc to automatically generate citations and a bibliography in
 
 -   Optionally, a `CSL` file which specifies the formatting to use when generating the citations and bibliography (when not using `natbib` or `biblatex` to generate the bibliography).
 
-### Bibliography Files
+## Bibliography Files
 
 Quarto supports bibliography files in a wide variety of formats including BibLaTeX and CSL. Add a bibliography to your document using the `bibliography` YAML metadata field. For example:
 
@@ -32,7 +33,7 @@ You can provide more than one bibliography file if you would like by setting the
 
 See the [Pandoc Citations](https://pandoc.org/MANUAL.html#citations) documentation for additional information on bibliography formats.
 
-### Citation Syntax {#sec-citations}
+## Citation Syntax {#sec-citations}
 
 Quarto uses the standard Pandoc markdown representation for citations (e.g. `[@citation]`) --- citations go inside square brackets and are separated by semicolons. Each citation must have a key, composed of '\@' + the citation identifier from the database, and may optionally have a prefix, a locator, and a suffix. The citation key must begin with a letter, digit, or `_`, and may contain alphanumerics, `_`, and internal punctuation characters (`:.#$%&-+?<>~/`). Here are some examples:
 
@@ -62,7 +63,7 @@ You can also write in-text citations, as follows:
 
 See the [Pandoc Citations](https://pandoc.org/MANUAL.html#citations) documentation for additional information on citation syntax.
 
-### Citation Style  {#sec-citations-style}
+## Citation Style  {#sec-citations-style}
 
 
 Quarto uses Pandoc to format citations and bibliographies. By default, Pandoc will use the [Chicago Manual of Style](https://chicagomanualofstyle.org/) author-date format, but you can specify a custom formatting using CSL ([Citation Style Language](https://citationstyles.org)). To provide a custom citation stylesheet, provide a path to a CSL file using the `csl` metadata field in your document, for example:
@@ -79,7 +80,7 @@ You can find CSL files or learn more about using styles at the [CSL Project](htt
 
 `CSL` styling is only available when the `cite-method` is `citeproc` (which it is by default). If you are using another `cite-method`, you can control the formatting of the references using the mechanism provided by that method.
 
-### Bibliography Generation
+## Bibliography Generation
 
 By default, Pandoc will automatically generate a list of works cited and place it in the document if the style calls for it. It will be placed in a div with the id `refs` if one exists:
 
@@ -103,7 +104,7 @@ Here's an example of a generated bibliography:
 ::: {#refs}
 :::
 
-### Including Uncited Items
+## Including Uncited Items
 
 If you want to include items in the bibliography without actually citing them in the body text, you can define a dummy `nocite` metadata field and put the citations there:
 
@@ -123,63 +124,6 @@ It is possible to create a bibliography with all the citations, whether or not t
       @*
     ---
 
-### Using BibLaTeX or natbib {#sec-biblatex}
+## Using BibLaTeX or natbib {#sec-biblatex}
 
 {{< include ../output-formats/_pdf-citations.md >}} 
-
-
-## Footnotes
-
-Pandoc supports numbering and formatting footnotes using the following syntax:
-
-``` markdown
-Here is a footnote reference,[^1] and another.[^longnote]
-
-[^1]: Here is the footnote.
-
-[^longnote]: Here's one with multiple blocks.
-
-    Subsequent paragraphs are indented to show that they
-belong to the previous footnote.
-
-        { some.code }
-
-    The whole paragraph can be indented, or just the first
-    line.  In this way, multi-paragraph footnotes work like
-    multi-paragraph list items.
-
-This paragraph won't be part of the note, because it
-isn't indented.
-```
-
-#### Output
-
-Here is a footnote reference,[^1] and another.[^2]
-
-This paragraph won't be part of the note, because it isn't indented.
-
-In addition, you can also write single paragraph footnotes inline using the following syntax:
-
-``` markdown
-Here is an inline note.^[Inlines notes are easier to write,
-since you don't have to pick an identifier and move down to
-type the note.]
-```
-
-#### Output
-
-Here is an inline note.[^3]
-
-The footnotes that are generated from the above examples are included in the following section. See the [Pandoc Footnotes](https://pandoc.org/MANUAL.html#footnotes) for additional information.
-
-[^1]: Here is the footnote.
-
-[^2]: Here's one with multiple blocks.
-
-    Subsequent paragraphs are indented to show that they belong to the previous footnote.
-
-        { some.code }
-
-    The whole paragraph can be indented, or just the first line. In this way, multi-paragraph footnotes work like multi-paragraph list items.
-
-[^3]: Inlines notes are easier to write, since you don't have to pick an identifier and move down to type the note.

--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -1,6 +1,8 @@
 ---
 title: Markdown Basics
 format: html
+language: 
+  section-title-footnotes: Example Footnotes
 aliases: 
   - /docs/authoring/
 ---
@@ -161,6 +163,67 @@ This document provides examples of the most commonly used markdown syntax. See t
 +-----------------------------------+---------------------------------+
 
 Note that unlike other Markdown renderers (notably Jupyter and GitHub), lists in Quarto require an entire blank line above the list. Otherwise the list will not be rendered in list form, rather it will all appear as normal text along a single line.
+
+## Footnotes
+
+Pandoc supports numbering and formatting footnotes using the following syntax:
+
+``` markdown
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous footnote.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the first
+    line.  In this way, multi-paragraph footnotes work like
+    multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+```
+
+The above syntax generates the following output:
+
+:::{.border .p-3}
+Here is a footnote reference,[^1] and another.[^2]
+
+This paragraph won't be part of the note, because it isn't indented.
+:::
+
+In addition, you can also write single paragraph footnotes inline using the following syntax:
+
+``` markdown
+Here is an inline note.^[Inlines notes are easier to write,
+since you don't have to pick an identifier and move down to
+type the note.]
+```
+
+This syntax generates the following output:
+
+::: {.border .p-3}
+Here is an inline note.[^3]
+:::
+
+The footnotes that are generated from the above examples are included in the [Example Footnotes](#example-footnotes) section at the bottom of the page. See the [Pandoc Footnotes](https://pandoc.org/MANUAL.html#footnotes) for additional information.
+
+[^1]: Here is the footnote.
+
+[^2]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they belong to the previous footnote.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the first line. In this way, multi-paragraph footnotes work like multi-paragraph list items.
+
+[^3]: Inlines notes are easier to write, since you don't have to pick an identifier and move down to type the note.
+
 
 ## Tables
 

--- a/docs/get-started/authoring/_text-editor.md
+++ b/docs/get-started/authoring/_text-editor.md
@@ -214,7 +214,7 @@ Here is what this document looks like when rendered.
 ![](/docs/get-started/authoring/images/citations-render.png){.border width="600" fig-alt="Rendered document with references section at the bottom the content of which reads 'Knuth, Donald E. 1984. Literate Programming. The Computer Journal 27 (2): 97-111.'"}
 
 \
-The `@` citation syntax is very flexible and includes support for prefixes, suffixes, locators, and in-text citations. See the documentation on [Citations and Footnotes](/docs/authoring/footnotes-and-citations.qmd) to learn more.
+The `@` citation syntax is very flexible and includes support for prefixes, suffixes, locators, and in-text citations. See the documentation on [Citations](/docs/authoring/citations.qmd) to learn more.
 
 ## Cross References
 

--- a/docs/get-started/authoring/jupyter.qmd
+++ b/docs/get-started/authoring/jupyter.qmd
@@ -274,7 +274,7 @@ Here is what this document looks like when rendered.
 
 \
 The `@` citation syntax is very flexible and includes support for prefixes, suffixes, locators, and in-text citations.
-See the documentation on [Citations and Footnotes](/docs/authoring/footnotes-and-citations.qmd) to learn more.
+See the documentation on [Citations](/docs/authoring/citations.qmd) to learn more.
 
 ## Cross References
 

--- a/docs/get-started/authoring/rstudio.qmd
+++ b/docs/get-started/authoring/rstudio.qmd
@@ -277,7 +277,7 @@ Here is what this document looks like when rendered (with middle sections remove
 ![](images/rstudio-references.png){.border fig-alt="Document with a single citation and a references section at the end."}
 
 The `@` citation syntax is very flexible and includes support for prefixes, suffixes, locators, and in-text citations.
-See the documentation on [Citations and Footnotes](/docs/authoring/footnotes-and-citations.qmd) to learn more.
+See the documentation on [Citations](/docs/authoring/citations.qmd) to learn more.
 
 ## Cross References
 

--- a/docs/guide/guide.yml
+++ b/docs/guide/guide.yml
@@ -10,8 +10,8 @@
       href: ../authoring/tables.qmd
     - text: Diagrams
       href: ../authoring/diagrams.qmd
-    - text: Citations & Footnotes
-      href: ../authoring/footnotes-and-citations.qmd
+    - text: Citations
+      href: ../authoring/citations.qmd
     - text: Cross References
       href: ../authoring/cross-references.qmd
     - text: Article Layout

--- a/docs/manuscripts/authoring/_citations.qmd
+++ b/docs/manuscripts/authoring/_citations.qmd
@@ -53,7 +53,7 @@ This renders as:
 
 > A prior study of the magma systems feeding the volcano proposed that there are two main magma reservoirs feeding the Cumbre Vieja volcano (Marrero et al. 2019).
 
-There are many other syntax variations to include page numbers, chapters, or exclude the author names. You can read more in the [Citations & Footnotes](/docs/authoring/footnotes-and-citations.qmd) documentation.
+There are many other syntax variations to include page numbers, chapters, or exclude the author names. You can read more in the [Citations](/docs/authoring/citations.qmd) documentation.
 
 ::: {.content-visible unless-meta="tool.is_jupyterlab"}
 

--- a/docs/output-formats/_pdf-citations.md
+++ b/docs/output-formats/_pdf-citations.md
@@ -8,7 +8,7 @@ format:
 
 The default is to use `citeproc` (Pandoc's built in citation processor).
 
-See the main article on using [Citations](../authoring/footnotes-and-citations.qmd) with Quarto for additional details on citation syntax, available bibliography formats, etc.
+See the main article on using [Citations](../authoring/citations.qmd) with Quarto for additional details on citation syntax, available bibliography formats, etc.
 
 ### Options
 

--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -157,7 +157,7 @@ bibliography: refs.bib
 csl: https://www.zotero.org/styles/apa-with-abstract
 ```
 
-To provide a citation style file to Pandoc's citation processing system use the `csl` option, as described in [Citation Style](/docs/authoring/footnotes-and-citations.qmd#sec-citations-style).
+To provide a citation style file to Pandoc's citation processing system use the `csl` option, as described in [Citation Style](/docs/authoring/citations.qmd#sec-citations-style).
 
 
 ## Typst Blocks


### PR DESCRIPTION
Closes https://github.com/quarto-dev/quarto-cli/issues/9964

Footnotes move to: [Guide > Authoring > Markdown Basics](https://deploy-preview-1188.quarto.org/docs/authoring/markdown-basics.html#footnotes)

Citations are now stand-alone: [Guide > Authoring > Scholarly Writing > Citations](https://deploy-preview-1188.quarto.org/docs/authoring/citations.html)