### PR TITLE
Rework advanced section

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -121,13 +121,7 @@ website:
                 - docs/authoring/figures.qmd
                 - docs/authoring/tables.qmd
                 - docs/authoring/diagrams.qmd
-                - section: "Shortcodes"
-                  href: docs/authoring/shortcodes.qmd
-                  contents:
-                    - text: "Placeholder Image"
-                      href: docs/authoring/placeholder.qmd
-                    - text: "Lorem Lipsum Text"
-                      href: docs/authoring/lipsum.qmd
+                - docs/authoring/shortcodes.qmd            
                 - docs/authoring/videos.qmd
                 - text: "Embeds"
                   href: docs/authoring/notebook-embed.qmd
@@ -151,6 +145,16 @@ website:
                           href: docs/authoring/cross-references-custom.qmd
                     - docs/authoring/create-citeable-articles.qmd
                     - docs/authoring/appendices.qmd
+                - section: Advanced Authoring
+                  contents:
+                    - docs/authoring/includes.qmd
+                    - docs/authoring/variables.qmd
+                    - docs/authoring/conditional.qmd
+                    - text: "Placeholder Images"
+                      href: docs/authoring/placeholder.qmd
+                    - text: "Placeholder Text"
+                      href: docs/authoring/lipsum.qmd
+                    - docs/authoring/language.qmd
             - section: "Computations"
               contents:
                 - docs/computations/python.qmd
@@ -204,6 +208,7 @@ website:
                     - docs/output-formats/html-multi-format.qmd
                     - docs/output-formats/html-lightbox-figures.qmd
                     - docs/output-formats/html-publishing.qmd
+                    - docs/output-formats/page-layout.qmd
                 - section: "PDF"
                   contents:
                     - docs/output-formats/pdf-basics.qmd
@@ -404,17 +409,8 @@ website:
                 - docs/projects/scripts.qmd
                 - docs/projects/virtual-environments.qmd
                 - docs/projects/binder.qmd
-            - section: "Advanced"
-              contents:
-                - docs/authoring/includes.qmd
-                - docs/authoring/variables.qmd
-                - docs/output-formats/page-layout.qmd
-                - docs/authoring/language.qmd
-                - docs/authoring/conditional.qmd
-                - docs/extensions/nbfilter.qmd
-                - section: "Jupyter"
-                  contents:
-                    - docs/advanced/jupyter/kernel-execution.qmd
+            - text: "Advanced"
+              href: docs/advanced/index.qmd
     - id: extensions
       title: "Extensions"
       contents:

--- a/docs/advanced/nbfilter.qmd
+++ b/docs/advanced/nbfilter.qmd
@@ -1,5 +1,8 @@
 ---
 title: "Notebook Filters"
+summary: Pre-processing Jupyter notebooks prior to conversion to markdown
+aliases:
+  - /docs/extenstions/nbfilter.html
 ---
 
 ## Overview

--- a/docs/guide/guide.yml
+++ b/docs/guide/guide.yml
@@ -180,19 +180,3 @@
       href: ../projects/scripts.qmd
     - text: Virtual Environments
       href: ../projects/virtual-environments.qmd
-
-- title: Advanced
-  subtitle: Refine documents with advanced tools
-  links:
-    - text: "Includes"
-      href: ../authoring/includes.qmd
-    - text: "Variables"
-      href: ../authoring/variables.qmd
-    - text: "Page Layout"
-      href: ../output-formats/page-layout.qmd
-    - text: "Document Language"
-      href: ../authoring/language.qmd
-    - text: "Conditional Content"
-      href: ../authoring/conditional.qmd
-    - text: "Notebook Filters"
-      href: ../extensions/nbfilter.qmd


### PR DESCRIPTION
A proposed rework of the "Guide > Advanced":
* Create a new "Guide > Authoring > Advanced Authoring" section, and move in:
    * Includes
    * Variables
    * Conditional Content
    * Placeholder text
    * Placeholder images
    * Document Language 
* Move "Page Layout" out of "Guide > Advanced" and into "Guide > Documents > HTML"
* Move `docs/extensions/nbfilter.qmd` to `docs/advanced/nbfilter.qmd`
* Make the existing "Guide > Advanced" section a link to `docs/advanced/index.qmd`

<img width="257" alt="Screenshot 2024-06-26 at 11 44 13 AM" src="https://github.com/quarto-dev/quarto-web/assets/25964/b5e6f84e-52cd-4a65-a4e4-47fb38f85182">
