### PR TITLE
Improve context on Reference > Websites

### DIFF
--- a/docs/reference/projects/_options.md
+++ b/docs/reference/projects/_options.md
@@ -1,11 +1,9 @@
 Options that define the type, render targets, and output of a project. Project options are specified under the `project` key. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 project:
   type: {{< meta project-type >}}
   output-dir: {{< meta project-output-dir >}}
----
 ```
 
 ::: {#table-project}
@@ -15,15 +13,13 @@ project:
 
 Specify options that control the behavior of `quarto preview` within the `preview` key. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 project:
   type: {{< meta project-type >}}
   output-dir: {{< meta project-output-dir >}}
   preview:
     port: 4200
     browser: false
----
 ```
 
 Available `preview` options include:
@@ -34,6 +30,17 @@ Available `preview` options include:
 ### Serve
 
 If you are creating a project extension for another publishing system that includes its own preview server (for example, [Hugo](../../output-formats/hugo.qmd) or [Docusaurus](../../output-formats/docusaurus.qmd)) then use the `preview: serve` options to customize the behavior of the preview server.
+
+```{.yaml filename="_quarto.yml"}
+project:
+  type: {{< meta project-type >}}
+    preview:
+      serve:
+        cmd: "hugo serve --port {port} --bind {host} --navigateToChanged"
+        env:
+          HUGO_RELATIVEURLS: "true"
+        ready: "Web Server is available at"
+```
 
 ::: {#table-serve}
 :::

--- a/docs/reference/projects/_websites-pre.md
+++ b/docs/reference/projects/_websites-pre.md
@@ -6,11 +6,9 @@
 
 Options that affect {{< meta project-type >}} output. {{< meta project-type-upper >}} options are specified under the `{{< meta project-type >}}` key. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   title: "My {{< meta project-type-upper >}}"
   image: opengraph.png
   page-navigation: true
----
 ```

--- a/docs/reference/projects/_websites.md
+++ b/docs/reference/projects/_websites.md
@@ -2,12 +2,10 @@
 
 Options that define the top navigation bar for a {{< meta project-type >}} For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   navbar:
     search: true
----
 ```
 
 ::: {#table-navbar}
@@ -17,15 +15,13 @@ Options that define the top navigation bar for a {{< meta project-type >}} For e
 
 Nav items appear in the `left` or `right` key of `navbar` definitions, or `contents` key of `sidebar` definitions. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   navbar:
     right:
       - icon: github
         href: https://github.com/
         aria-label: GitHub
----
 ```
 
 ::: {#table-navitem}
@@ -37,12 +33,10 @@ Note that the `icon` option is available for items in the Navbar, however items 
 
 Options that define the side navigation area for a {{< meta project-type >}}. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   sidebar:
     search: true
----
 ```
 
 ::: {#table-sidebar}
@@ -52,14 +46,12 @@ Options that define the side navigation area for a {{< meta project-type >}}. Fo
 
 Action buttons that appear on the sidebar. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   sidebar:
     tools:
       - icon: github
         href: https://github.com/
----
 ```
 
 ::: {#table-sidebartool}
@@ -69,8 +61,7 @@ Action buttons that appear on the sidebar. For example:
 
 {{< meta project-type-upper >}} page footer definition. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   page-footer:
     center: 
@@ -80,7 +71,6 @@ Action buttons that appear on the sidebar. For example:
         href: license.qmd
       - text: "Trademark"
         href: trademark.qmd
----
 ```
 
 ::: {#table-pagefooter}
@@ -90,13 +80,11 @@ Action buttons that appear on the sidebar. For example:
 
 Search options are specified under the `search` key of `{{< meta project-type >}}`. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   search:
     location: navbar
     type: overlay
----
 ```
 
 ::: {#table-search}
@@ -106,15 +94,13 @@ Search options are specified under the `search` key of `{{< meta project-type >}
 
 You can use an [Algolia](../../websites/website-search.qmd#using-algolia) index as the back end of {{< meta project-type >}} search. Specify Algolia options using the `algolia` sub-key of `search`, for example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   search:
     algolia:
       index-name: <my-index-name>
       application-id: <my-application-id>
       search-only-api-key: <my-search-only-api-key>
----
 ```
 
 ::: {#table-algolia}
@@ -129,21 +115,36 @@ The `index-fields` option provides sub-fields within the Algolia index to target
 
 Social metadata is provided as a subkey of `{{< meta project-type >}}` options. You can specify `true` to generate social metadata using a set of default option, or specify one or more Twitter or Open Graph specific options as enumerated below. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 {{< meta project-type >}}:
   open-graph: true
   twitter-card: 
     site: "@sitehandle"
----
 ```
 
 ### Twitter Card
+
+Set Twitter options under the `twitter-card` key:
+
+```{.yaml filename="_quarto.yml"}
+{{< meta project-type >}}:
+  twitter-card: 
+    site: "@sitehandle"
+```
 
 ::: {#table-twitter}
 :::
 
 ### Open Graph
+
+Set Open Graph options under the `open-graph` key:
+
+
+```{.yaml filename="_quarto.yml"}
+{{< meta project-type >}}:
+  open-graph: 
+    title: "Title for Open Graph"
+```
 
 ::: {#table-open-graph}
 :::
@@ -156,14 +157,12 @@ You can add commenting to your {{< meta project-type >}} using either [Hypothesi
 
 Enable and configure Hypothesis commenting via `comments` key. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 website:
   comments: 
     hypothesis:
       theme: clean
       openSidebar: false
----
 ```
 
 ::: {#table-hypothesis}
@@ -175,13 +174,11 @@ For additional documentation on the Hypothesis options enumerated above, see the
 
 Enable and configure Utterances commenting via the `comments` key. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 website:
   comments: 
     utterances:
       repo: quarto-dev/quarto-web
----
 ```
 
 ::: {#table-utterances}
@@ -191,13 +188,11 @@ website:
 
 Enable and configure usage of the [Giscus app](https://giscus.app) via the `comments` key. For example:
 
-``` yaml
----
+```{.yaml filename="_quarto.yml"}
 website:
   comments:
     giscus:
       repo: quarto-dev/quarto-web
----
 ```
 
 ::: {#table-giscus}
@@ -205,7 +200,7 @@ website:
 
 ## Listings
 
-[Listings](/docs/websites/website-listings.qmd) enable you to automatically generate the contents of a page (or region of a page) from a list of Quarto documents or other custom data. You can enable listings on a page using the `listing` option in the document front matter, for example:
+[Listings](/docs/websites/website-listings.qmd) enable you to automatically generate the contents of a page (or region of a page) from a list of Quarto documents or other custom data. You can enable listings on a page using the `listing` option in the document front matter. For example, setting `listing: default` will generate a listing of all documents in the directory (with the exception of the current document):
 
 ``` yaml
 ---
@@ -214,19 +209,57 @@ listing: default
 ---
 ```
 
+To customize the listing, specify additional options under the `listing` key:
+
+``` yaml
+---
+title: "Listing Example"
+listing: 
+  contents: posts
+  type: grid
+  grid-columns: 2
+---
+```
+
 ::: {#table-listing}
 :::
 
 ### Feed
 
-Enable an RSS feed for your listing by including the `feed` option.
+Enable an RSS feed for your listing by including the `feed` option:
+
+``` yaml
+---
+title: "Listing Example"
+listing:
+  contents: posts
+  feed:
+    items: 10
+---
+```
 
 ::: {#table-feed}
 :::
 
 ## About
 
-Layout a simple about page for an individual or organization. For more, see the [About Pages](/docs/websites/website-about.qmd) documentation.
+Layout a simple about page for an individual or organization. 
+Specify about page options under the `about` key in the document front matter:
+
+```yaml
+---
+title: About
+about:
+  template: jolla
+  image: profile.jpg
+  links:
+    - icon: twitter
+      text: twitter
+      href: https://twitter.com
+---
+```
+
+For more, see the [About Pages](/docs/websites/website-about.qmd) documentation. 
 
 ::: {#table-about}
 :::


### PR DESCRIPTION
[Reference > Websites](https://deploy-preview-1201.quarto.org/docs/reference/projects/websites.html):

* Add examples to each section
* Ensure project options are in a ` ```{.yaml filename="_quarto.yml"}` cell, and document options in ` ``` yaml ` cell with `---`.

Closes https://github.com/quarto-dev/quarto-cli/issues/7869