### PR TITLE
Add example of block environment for beamer slides

### DIFF
--- a/docs/presentations/_creating-slides.md
+++ b/docs/presentations/_creating-slides.md
@@ -1,6 +1,6 @@
 ## Creating Slides
 
-In markdown, slides are delineated using headings. For example, here is a simple slide show with two slides (each defined with a level 2 heading (`##`):
+In markdown, slides are delineated using headings. For example, here is a simple slide show with two slides (each defined with a level 2 heading (`##`)):
 
 ``` markdown
 ---
@@ -74,4 +74,4 @@ format: {{< meta slide-format >}}
 
 ```
 
-The examples above all use level 2 headings for slides and level 1 headings for sections/title slides. You can customize this using the `slide-level` option (See the Pandoc documentation on [structuring the slide show](https://pandoc.org/MANUAL.html#structuring-the-slide-show) for additional details.
+The examples above all use level 2 headings for slides and level 1 headings for sections/title slides. You can customize this using the `slide-level` option (See the Pandoc documentation on [structuring the slide show](https://pandoc.org/MANUAL.html#structuring-the-slide-show) for additional details).

--- a/docs/presentations/beamer.qmd
+++ b/docs/presentations/beamer.qmd
@@ -13,6 +13,46 @@ See the Beamer [format reference](/docs/reference/formats/presentations/beamer.q
 
 {{< include _creating-slides.md >}}
 
+In Beamer, headings below `slide-level` will place content inside a `block` environment:
+
+```markdown
+---
+title: "Habits"
+author: "John Doe"
+format: 
+  beamer:
+    slide-level: 2
+---
+
+## Slide
+
+### Simple block
+
+Content
+```
+
+Add the `.alert` or `.example` class to place content inside an `alertblock` or `exampleblock` environment respectively:
+
+```markdown
+---
+title: "Habits"
+author: "John Doe"
+format: 
+  beamer:
+    slide-level: 2
+---
+
+## Slide
+
+### Alert block {.alert}
+
+Content
+
+### Example block {.example}
+
+Content
+```
+
 {{< include _incremental-lists.md >}}
 
 {{< include _incremental-pause.md >}}

--- a/docs/presentations/beamer.qmd
+++ b/docs/presentations/beamer.qmd
@@ -15,7 +15,7 @@ See the Beamer [format reference](/docs/reference/formats/presentations/beamer.q
 
 In Beamer, headings below `slide-level` will place content inside a `block` environment:
 
-```markdown
+``` markdown
 ---
 title: "Habits"
 author: "John Doe"
@@ -33,7 +33,7 @@ Content
 
 Add the `.alert` or `.example` class to place content inside an `alertblock` or `exampleblock` environment respectively:
 
-```markdown
+``` markdown
 ---
 title: "Habits"
 author: "John Doe"
@@ -58,8 +58,6 @@ Content
 {{< include _incremental-pause.md >}}
 
 {{< include _columns.md >}}
-
-
 
 The div containers with classes `columns` and `column` can optionally have an `align` attribute. The class `columns` can optionally have a `totalwidth` attribute or an `onlytextwidth` class.
 
@@ -101,49 +99,7 @@ See Section 12.7 of the [Beamer User's Guide](http://mirrors.ctan.org/macros/lat
 
 ## Beamer Options
 
-These variables change the appearance of PDF slides using `beamer`.
-
-**`aspectratio`**
-
-:   slide aspect ratio (`43` for 4:3 \[default\], `169` for 16:9, `1610` for 16:10, `149` for 14:9, `141` for 1.41:1, `54` for 5:4, `32` for 3:2)
-
-**`beamerarticle`**
-
-:   produce an article from Beamer slides
-
-**`beameroption`**
-
-:   add extra beamer option with `\setbeameroption{}`
-
-**`institute`**
-
-:   author affiliations: can be a list when there are multiple authors
-
-**`logo`**
-
-:   logo image for slides
-
-**`navigation`**
-
-:   controls navigation symbols (default is `empty` for no navigation symbols; other valid values are `frame`, `vertical`, and `horizontal`)
-
-**`section-titles`**
-
-:   enables "title pages" for new sections (default is true)
-
-**`theme`, `colortheme`, `fonttheme`, `innertheme`, `outertheme`**
-
-:   beamer themes
-
-**`themeoptions`**
-
-:   options for LaTeX beamer themes (a list).
-
-**`titlegraphic`**
-
-:   image for title slide
-
-For example, here we use several of these options:
+Set additional options to change the appearance of PDF slides using `beamer`:
 
 ``` yaml
 ---
@@ -156,6 +112,21 @@ format:
     colortheme: lily
 ---
 ```
+
+The options available are:
+
+| Option | Description |
+|------------------------|------------------------------------------------|
+| `aspectratio` | Slide aspect ratio: `43` for 4:3 \[default\], `169` for 16:9, `1610` for 16:10, `149` for 14:9, `141` for 1.41:1, `54` for 5:4, `32` for 3:2 |
+| `beamerarticle` | Produce an article from Beamer slides |
+| `beameroption` | Extra beamer options provided to `\setbeameroption{}` |
+| `institute` | Author affiliations: can be a list when there are multiple authors |
+| `logo` | Logo image for slides |
+| `navigation` | Controls navigation symbols (default is `empty` for no navigation symbols; other valid values are `frame`, `vertical`, and `horizontal`) |
+| `section-titles` | Enables "title pages" for new sections (default is true) |
+| `theme, colortheme, fonttheme, innertheme, outertheme` | Beamer themes |
+| `themeoptions` | Options for LaTeX beamer themes (a list) |
+| `titlegraphic` | Image for title slide |
 
 ## Frame Attributes
 
@@ -176,5 +147,5 @@ To provide a common background image for all slides in a Beamer presentation, us
 format:
   beamer:
     background-image: background.png
-    
+---    
 ```


### PR DESCRIPTION
Adds example of block environments to: [Guide > Presentations > Beamer](https://deploy-preview-1206.quarto.org/docs/presentations/beamer.html#creating-slides)
Plus some other minor improvements
Partially addresses https://github.com/quarto-dev/quarto-cli/issues/5617