### PR TITLE
Set Algolia index in prerelease-docs profile

### DIFF
--- a/_quarto-prerelease-docs.yml
+++ b/_quarto-prerelease-docs.yml
@@ -11,6 +11,9 @@ website:
     content: "Pre-release ({{< meta version >}}) Documentation: [Download {{< meta version >}}](/docs/download/prerelease.qmd), [Current Release Docs](http://quarto.org) "
   navbar:
     pinned: true
+  search:
+    algolia:
+      index-name: prerelease_QUARTO
 
 format:
   html:


### PR DESCRIPTION
I think I put the `algolia: index-name` in before we were using profiles. This undoes the change in `_quarto.yml` and instead sets it in `_quarto-prelease-docs.yml`:

```
website:
  search:
    algolia:
      index-name: prerelease_QUARTO
```