### PR TITLE
Update _plots-interactive.md, edit the tip in R Graphics heading

### DIFF
--- a/docs/dashboards/_plots-interactive.md
+++ b/docs/dashboards/_plots-interactive.md
@@ -1,4 +1,4 @@
-For static dashboards, there are pros and cons to using JavaScript-based plots. While JavaScript-based plots handle resizing to fill their container better that static plots, they also embed the underlying data directly in the published page (one copy of the dataset per plot) which can lead to slower load times.
+For static dashboards, there are pros and cons to using JavaScript-based plots. While JavaScript-based plots handle resizing to fill their container better than static plots, they also embed the underlying data directly in the published page (one copy of the dataset per plot), which can lead to slower load times.
 
-For interactive Shiny dashboards all plot types are sized dynamically so resizing behavior is not a concern as it is with static dashboards.
+For interactive Shiny dashboards, all plot types are sized dynamically, so resizing behavior is not a concern as it is with static dashboards.
 


### PR DESCRIPTION
Noticed a typo, 'than' was spelt 'that' and a few missed commas in the tip under the R Graphics heading in this [page](https://quarto.org/docs/dashboards/data-display.html).