### PR TITLE
Add pages for release notes

### DIFF
--- a/docs/download/changelog/1.1/_changelog.md
+++ b/docs/download/changelog/1.1/_changelog.md
@@ -1,0 +1,158 @@
+## Jupyter
+
+- Daemonize jupyter notebooks referenced within listings (e.g. in a blog)
+- Refine over-detection of Jupyter shell magics (which prevented kernel daemonization)
+- Use on-disk cache for filtered jupyter notebooks
+- Prevent error in `quarto check` when Jupyter is installed but has no Python kernel
+- Don't run `ipynb-filters` for qmd source files (only run them for ipynb source files)
+- More gracefully handle cell outputs with no data (don't print warning, just ignore)
+- Handle non-textual data from jupyter's plain text output more robustly (#1874)
+- Use IJulia's built-in conda environment / jupyter install for julia notebooks/qmds
+
+## Knitr
+
+- Correct handling of `knitr::include_graphics()` within inline expressions.
+- Improve error message for HTML being emitted in non-HTMl formats (#1745)
+- Compatibility with rgl plots (#1800, thanks @dmurdoch)
+
+## OJS
+
+- Better handle OJS code blocks that begin with empty lines
+- Better OJS support for dark vs light mode
+- Support passing Pandas Series
+- Update to latest OJS runtime (adding support for latest ObservableHQ runtime)
+- Fix multi-column regression (#1698)
+- Hide declarations in hugo format (#1812)
+- Enable OJS runtime in the presence of `ojs_define` (#1846)
+- Emit subcaptions correctly (#1711)
+- Use forward slashes in paths so OJS compilation works on windows (#1605)
+
+## Pandoc
+
+- Update to Pandoc 2.19
+- Support for `embed-resources` document option
+- Remove workaround for https://github.com/jgm/pandoc/issues/8099
+
+## References
+
+- Write additional citation metadata for compatibility with Highwire/Zotero (#1609)
+- Support for `nocite` within \_project.yml for book projects (#1660)
+- Improve support for Google Scholar metadata with extension to support Zotero / Highwire metadata
+  (see https://quarto.org/docs/authoring/create-citeable-articles.html#citation-fields)
+
+## Crossrefs
+
+- Use 'Appendix' as prefix for references to chapters in appendix
+- Index book crossrefs using shorter paths (fix path error seen in #1770)
+- Improve handling of solution/proof content (filter headings, support code blocks)
+- Insert non-breaking space between entity type (e.g. Figure/Table) and number.
+- Fix crossref numbering for docx books
+
+## Code Blocks
+
+- Support `filename` attribute for attaching a file name header to code blocks
+- Improve YAML parse error messages in `r` code blocks using `!expr` YAML (#1949)
+
+## Tables
+
+- Support captions in HTML tables with `df-print: paged` (#1597)
+- GT tables in HTML format can be themed by quarto and follow quarto themes by default (#1834)
+
+## Mermaid diagrams
+
+- Support `echo: true` and other per-document settings (#1485)
+
+## HTML Format
+
+- Respect toc-depth in the HTML format (bootstrap) rather than always acting as if depth is 3.
+- Add `group` attribute to `panel-tabset` for syncing selected tab across many tabsets
+- Properly uncollapse sidebars / toc when page width elements are displayed on a page
+- Properly display section numbers in the table of contents when enabled.
+- Properly display banner style title blocks at mobile size.
+- Improve CSS for print media formats (#1824) (thanks @hadley)
+- Fix 'flickering' TOC when margin content overlays a TOC
+
+## RevealJS Format
+
+- Don't ignore auto stretch rules when speaker notes are present
+- Target references and footnotes slides for citation and footnote links
+- Automatically include chalkboard src json as a resource when publishing
+- Respect styles of ordered lists (#1970)
+
+## ePub Format
+
+- Don't do knitr post-processing for ePub format (corrupts epub output file)
+
+## PDF Format
+
+- Don't include template path in the TeX search path when compiling PDFs. Use `format-resources` instead.
+
+## Docx Format
+
+- Don't error when code blocks appear in callouts (overly broad validation error)
+
+## Format Templates
+
+- Expand globs in template-partials (#1248)
+
+## Websites
+
+- Correctly align dark/light toggle in navbar (thanks @FabioRosado)
+- Support `navbar:logo-alt` to provide alternate text for navbar logos
+- Support `navbar:logo-href` to provide custom link for navbar logo & title
+- Improve appearance of blog categories in title block
+
+## Books
+
+- Support specifying and displaying DOI for books
+- Don't show chapter number in narrow HTML layouts (#1611)
+
+## Preview
+
+- Don't attempt to open browser when in a server session
+- Respect VSCODE_PROXY_URI set by code-server
+
+## Extensions
+
+- Properly copy `format-resources` for HTML based formats
+- Extension YAML files `_extension.yml` are now validated at render time. (#1268)
+- Support boolean values in Shortcode `meta` access
+- Make `quarto.base64` module available to extensions
+- Support installing extensions from any GitHub tag or branch (#1836)
+
+## Publishing
+
+- Detect authentication error for quarto.pub and re-establish credentials
+- More compact status display when running in CI environments
+- Automatically detect single file publishing source within directory
+- Automatically disable Netlify css/html/js asset optimization
+- Respect `site-url` specified in config for GitHub Pages
+
+## Localization
+
+- Finnish localization (thanks @jkseppan)
+- Dutch localization (thanks @bwelman)
+
+# Installation
+
+- Refactor configuration to make it easier to use external binaries
+- Added conda-recipe (thanks @msarahan)
+
+## Miscellaneous
+
+- Allow environment variables to override paths to binary dependencies
+- Support `cover-image-alt` to specify alt text for a book's cover image
+- Correctly support Giscus `category-id` property
+- Correctly support `output-file` names that contain `.` characters (like `file.name.html`)
+- Avoid file permission errors in additional cases (thanks @jmbuhr)
+- `QUARTO_PRINT_STACK` environment variable to print stack along with error messages
+- More compact download progress when installing Quarto tools in CI environments
+- Ignore case when loading date local files from `lang`
+- Don't break cells incorrectly with math expressions (#1781)
+- Development version cleans old vendor directory on success (https://github.com/quarto-dev/quarto-cli/pull/1863#issuecomment-1215452392)
+- properly support YAML scalar syntax (#1838)
+- Add support for Giscus lazy loading (use `loading: lazy` #1357)
+- Properly handle duplicated affilations in author metadata (#1286)
+- Display image path when an error occurs reading PNG metadata
+- `quarto run *.ts` preserves stdout and stderr (#1954)
+- Lua filters: quarto.utils.dump does not loop on circular structures (#1958)

--- a/docs/download/changelog/1.1/index.qmd
+++ b/docs/download/changelog/1.1/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "1.1 Release Notes"
+format: html
+---
+
+{{< include _changelog.md >}}
+

--- a/docs/download/changelog/1.2/_changelog.md
+++ b/docs/download/changelog/1.2/_changelog.md
@@ -1,0 +1,238 @@
+## New In This Patch Release
+
+- Fixes an issue on Windows where Quarto's built tinytex would not properly find the binary files included with TexLive 2023. This would result in errors compiling PDFs on Windows when using the most up to date version of TinyTex.
+
+## Fixed In Previous Patch Releases
+
+- Fixes an issue using Quarto with the most recent version of jupyter_client (version 8.0.0 and later)
+- Correct handling of the proxy url when starting preview server (fix issue previewing within IDEs)
+- Fix tinytex failure to install packages caused by invalid installation of tinytex on MacOS
+
+## Jupyter
+
+- Always ignore .ipynb inputs when they have a corresponding .qmd
+- Correctly interpret cell metadata with `false` values
+- Render text/latex outputs as markdown math when they consist entirely of $ math, or are wrapped in a LaTeX environment block (such as \begin{align} ... \end{align})
+- Use IPython 7.14 import syntax in `ojs_define`
+- Correct handling of multiple attachments in Jupyter Notebook classic
+- Prevent overwrite of source .ipynb when output format is ipynb
+- Prefer kernel declared in YAML front matter when executing notebooks
+- Fix v1.1 regression in handling of cell display_data w/ Juptyer widgets
+- Allow jupyter kernel to be determined project-wide ([#2853](https://github.com/quarto-dev/quarto-cli/issues/2853))
+- Ensure that Jupyter engine dependencies (widgets) appear after other dependencies (manage require/define conflicts)
+
+## Knitr
+
+- Support specification of `connection` option in cell yaml options.
+
+## OJS
+
+- support `revealjs` and `html` formats in `width` builtin, fallback gracefully otherwise ([#2058](https://github.com/quarto-dev/quarto-cli/issues/2058))
+- Don't emit `ojs_define` HTML in non-html formats ([#2338](https://github.com/quarto-dev/quarto-cli/issues/2338))
+- Support jszip and exceljs ([#1981](https://github.com/quarto-dev/quarto-cli/issues/1981))
+- Improve error messages when cell options are specified with wrong comment syntax ([#1856](https://github.com/quarto-dev/quarto-cli/issues/1856))
+- Hide `code-fold` chrome when OJS code is hidden ([#2134](https://github.com/quarto-dev/quarto-cli/issues/2134))
+
+## Extensions
+
+- Preview live reload for changes to extension source files
+- HTML dependencies may be provided by paths to files outside the extension directory
+- HTML dependencies may now include `serviceworkers`, which are copied into the output directory.
+- New `quarto.doc.attach_to_dependency` function to attach files to html dependencies (copies files into the lib dir for a named HTML dependency).
+- New `quarto.version`, which provides the Quarto version
+- New `quarto.project.profile` which provides the list of currently active profiles (or an empty table if none are active)
+- New `quarto.project.directory` which provides the current project directory (if a project is active)
+- New `quarto.project.output_directory` which provides the current project output directory (if a project is active)
+- New `quarto.project.offset` which provides an offset from the current input document to the project directory.
+- New `quarto.doc.input_file` which provides the path to the input document
+- New `quarto.doc.output_file` which provides the path to the output file
+- Ensure that `quarto.utils.dump` works with pandoc's builtin global variables ([#2254](https://github.com/quarto-dev/quarto-cli/issues/2254))
+- Provide a better error message for non-existent format resources ([#2291](https://github.com/quarto-dev/quarto-cli/issues/2291))
+- Ability to specify a minimum quarto version via the `quarto-required` option.
+- Extension may now contribute project types (project metadata which will be merged with a project when project of that type are rendered)
+- Include Pandoc `logging` Lua module from @wlupton
+- Improve path resolution of extensions
+- Add support for extensions that contribute revealjs-plugins
+- Fix issue loading extensions when the organization name is the same as the extension identifier
+- Fix issue preventing installation of archived extensions from an arbitrary url ([#2419](https://github.com/quarto-dev/quarto-cli/issues/2419))
+- Support installation of extensions using Github archive urls
+- Support installation of extensions from with subdirectories of a github repo
+- Lua `require` can now find modules adjacent to the current script
+- Use snake case for Quarto Lua API functions (match Pandoc API)
+- Fix theorem captions when there's no text ([#2166](https://github.com/quarto-dev/quarto-cli/issues/2166), [#2228](https://github.com/quarto-dev/quarto-cli/issues/2228))
+
+## Projects
+
+- Project configuration `profile` for varying configuration and output based on global `QUARTO_PROFILE` or `--profile` command-line option.
+- Project level environment variables (including local overrides)
+- Ensure that `execute-dir` is always resolved to an absolute path
+
+## HTML Format
+
+- Fix error when restoring preserved HTML in output files that use `output-file`
+- Properly maintain dark/light state when navigating between pages
+- Fix `code-copy` button issue when `page-layout` is full with no visible `toc` ([#2388](https://github.com/quarto-dev/quarto-cli/issues/2388))
+- Add support for scss variables to better control the table of contents appearance (`$toc-color`,`$toc-font-size`,`$toc-active-border`,`$toc-inactive-border`)
+- Provide more explicit code-copy feedback using a tooltip
+- Improve coloring of code copy button when using various `highlight-styles`.
+- Support scss variables to customize the code copy button using `$btn-code-copy-color`, `$btn-code-copy-color-active`
+- Add support for `date-modified` in document metadata
+- Wrap inline code elements if necessary
+
+## PDF Format
+
+- Provide a better error message for PDF output that produces an empty document
+- Improved detection of LaTeX caption regions ([#2295](https://github.com/quarto-dev/quarto-cli/issues/2295))
+- Handle LaTeX error messages with no file output more gracefully ([#2183](https://github.com/quarto-dev/quarto-cli/issues/2183))
+- Support cross reference-able figures with callouts
+- Allow cross references inside of a callout
+- Improve margin layout support for `twoside`, `oneside`, and `twoside=semi` options of `scrbook`
+- Properly default `number-sections` on when the documentclass is `scrbook`
+
+## Docx Format
+
+- Properly scale callout icons using DPI
+- Properly space a consecutive table and figure ([#2493](https://github.com/quarto-dev/quarto-cli/issues/2493))
+
+## Revealjs Format
+
+- Update to Reveal v4.3.1 (+ commit e281b32) to fix presentation scaling/zoom issues.
+- Improved title slide that uses normalized author and affiliation schema
+- Introduce template partials for RevealJS. You may provide partials for `title-slide.html` or `toc-slide.html`.
+- Ensure that `output-location` works properly in fenced divs
+- Change SCSS so styles respond to both linkColor and link-color ([#2820](https://github.com/quarto-dev/quarto-cli/issues/2820))
+- When mermaidjs diagrams exist, set viewdistance to cover entire slideshow ([#2607](https://github.com/quarto-dev/quarto-cli/issues/2607))
+
+## Markdown Formats
+
+- Support code folding for markdown output when `raw_html` is supported.
+- `docusaurus-md` format for Docusaurus compatible markdown
+- `docusaurus` and `hugo` project types for render/preview within external static site generators
+
+## Ipynb Format
+
+- Strip attributes from images when converting to `ipynb` (leaving the attributes caused problems w/ attachments in VS Code)
+
+## AST Formats
+
+- Remove intermediate metadata for AST formats (`native` and `json`)
+
+## Google Scholar
+
+- Properly read Google Scholar reference data from dynamically generated bibliography YML
+
+## Crossrefs
+
+- Fix problem with crossref indexing for listing code blocks
+
+## Tables
+
+- Don't require array brackets for `tbl-colwidths` specification
+- Override standard GT style in multiple-column spanners ([#3038](https://github.com/quarto-dev/quarto-cli/issues/3038))
+
+## Authors and Affiliations
+
+- Improve handling of empty authors
+- Parse `author` and `institute` (often used for RevealJs and Beamer) into normalized author schema
+
+## Websites
+
+- Properly allow `twitter-card` and `open-graph` to override the page description.
+- Don't discover resources within a site or book output directory
+- Enable use of custom HTML formats for websites
+- Automatically populate sidebar menu using `auto` option for contents
+- Properly handle `margin-header` and `margin-footer` files
+- Ensure that the `code-copy` button is functional even when margin content is present.
+- Add support for open graph image sizes
+- Fix issue preventing `twitter-card` `site` metadata from being emitted.
+- Prevent website content from shifting when page first loads
+- Improve animation smoothness when expanding navbar in mobile mode ([#1873](https://github.com/quarto-dev/quarto-cli/issues/1873))
+- Permit icons in top level navbar, if specified
+- Fix incorrect computation of the next and previous buttons after the first separator
+
+## Books
+
+- Fix issue that caused incomplete search indexes for books
+- Don't display the book description in each chapter's title block
+- Book YAML now accepts fields from csl-item schema ([#2148](https://github.com/quarto-dev/quarto-cli/issues/2148), [#2398](https://github.com/quarto-dev/quarto-cli/issues/2398))
+- Book YAML now accepts date-format explicitly ([#2148](https://github.com/quarto-dev/quarto-cli/issues/2148), [#2398](https://github.com/quarto-dev/quarto-cli/issues/2398))
+
+## Preview
+
+- Restart Jupyter kernel daemon if preview server is restarted.
+- Enable use of external preview servers for serving project output
+- Add `--no-serve` command line parameter to prevent serving altogether
+- Do not add trailing slash to VSCODE_PROXY_URI set by code-server
+
+## Publishing
+
+- Handle CNAME file for `gh-pages` either without or without protocol prefix (e.g. https://)
+
+## Languages
+
+- Italian translation for Quarto UI text
+- Polish translation for Quarto UI text
+- Korean translation for Quarto UI text
+
+## Listing and Feeds
+
+- Fix escaping issue in RSS feed fields
+- Properly support `max-desc-length` to trim descriptions within listings
+- Properly support exclude globs (like `!blog/index.qmd`) when resolve listing contents
+
+## Bibliographies and Citations
+
+- Support formats `bibtex`, `biblatex`, and `csljson`. When rendered to one of these formats any citations within the document will be rendered as the specified bibliography format.
+- Always add citeproc filter if `citeproc: true` is specified, even if there isn't a bibliography or references in the document ([#2294](https://github.com/quarto-dev/quarto-cli/issues/2294))
+- Don't process citations twice when `citeproc` is specified ([#2393](https://github.com/quarto-dev/quarto-cli/issues/2393))
+- Fix `citation-hover` for footnote style reference formats
+
+## TinyTex
+
+- `quarto install tinytex` will now install TinyTex even if a system installation of TeX is detected.
+- `quarto install tinytex` will no longer add TinyTex to the system path by default.
+- When rendering PDFs, Quarto will prefer an existing installation of TinyTex over a system Tex installation
+- To prevent Quarto from using an installation of TinyTex (if you'd prefer the system installation be used), set `latex-tinytex: false` in your project or document front matter.
+- To install TinyTex system wide, using the `--update-path` flag when installing (this will add TinyTex to the system path)
+
+## Video Shortcode
+
+- The video shortcode extension is now native to the Quarto CLI
+- Reveal-JS Video Snippet backgrounds are now better supported. For common video snippets, like YouTube, you can specify them as `background-video` and quarto will ensure the correct embed URL is used and swap to `background-iframe` background if needed.
+
+## Creating Artifacts
+
+- Introduce a new `quarto create` command which will create projects or extensions
+
+## Miscellaneous
+
+- Render: ability to set `enigne` and `jupyter` metadata values from the command line
+- Render: ability to compose `--to all` with other formats (e.g. `--to all,json`)
+- Don't call Deno.realPathSync on Windows (avoid problems w/ UNC paths)
+- Don't include Unicode literals on Windows directly ([#2184](https://github.com/quarto-dev/quarto-cli/issues/2184)), thanks @yihui
+- Improve YAML validation error messages on values of type object ([#2191](https://github.com/quarto-dev/quarto-cli/issues/2191))
+- Upgrade esbuild to 0.15.6
+- Implement --help option for quarto preview and quarto run
+- Increase contrast for a11y-light theme to work with default code-block background ([#2067](https://github.com/quarto-dev/quarto-cli/issues/2067), [#2528](https://github.com/quarto-dev/quarto-cli/issues/2528))
+- Use deno arm64 native binaries on macOS
+- Resolve absolute paths in include shortcodes ([#2320](https://github.com/quarto-dev/quarto-cli/issues/2320))
+- New metadata field `quarto-required` to specify required versions of quarto in a document
+- Provide project configuration for calls to `quarto inspect` for files
+- Improve YAML validation error messages on closed schemas ([#2349](https://github.com/quarto-dev/quarto-cli/issues/2349))
+- Don't use default width/height on mermaid diagrams when better information is available ([#2383](https://github.com/quarto-dev/quarto-cli/issues/2383))
+- Improve YAML validation error messages on invalid YAML objects that include `x = y` ([#2434](https://github.com/quarto-dev/quarto-cli/issues/2434))
+- Forward `--log-level` to Pandoc via `--trace`, `--verbose`, and `--quiet`
+- Disallow names with paths in command line option `--output` and YAML option `output-file` ([#2440](https://github.com/quarto-dev/quarto-cli/issues/2440))
+- Add possible chrome process running error to the error message thrown when quarto fails to connect to chrome headless ([#2499](https://github.com/quarto-dev/quarto-cli/issues/2499))
+- Only pass `pagetitle` metadata for HTML file output
+- Provide non-HTML treatment for code block `filename`
+- prevent Chrome CRI race during initialization ([#2733](https://github.com/quarto-dev/quarto-cli/issues/2733))
+- Work around `mermaid-format: svg` diagram clipping ([#1622](https://github.com/quarto-dev/quarto-cli/issues/1622))
+- Don't use tree-sitter outside of interactive IDE contexts ([#2502](https://github.com/quarto-dev/quarto-cli/issues/2502))
+- Support custom Lua writers in YAML front matter ([#2687](https://github.com/quarto-dev/quarto-cli/issues/2687))
+- Better error message with inadvertent `!` in YAML strings ([#2808](https://github.com/quarto-dev/quarto-cli/issues/2808))
+- More precise underlining of YAML validation errors ([#2681](https://github.com/quarto-dev/quarto-cli/issues/2681))
+- When converting raw html tables to pdf, use all tables generated ([#2615](https://github.com/quarto-dev/quarto-cli/issues/2615))
+- Fix theorem (thm, def, ...) environments in all formats ([#2866](https://github.com/quarto-dev/quarto-cli/issues/2866))
+- Upgrade to deno 1.25.2, which should lead to a 2-3x speedup in quarto startup time and fix an issue with Fedora 37 ([#3012](https://github.com/quarto-dev/quarto-cli/issues/3012))
+- quarto preview: only prefix paths with `/` when needed ([#3183](https://github.com/quarto-dev/quarto-cli/issues/3183))

--- a/docs/download/changelog/1.2/index.qmd
+++ b/docs/download/changelog/1.2/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "1.2 Release Notes"
+format: html
+---
+
+{{< include _changelog.md >}}
+

--- a/docs/download/changelog/1.3/_changelog.md
+++ b/docs/download/changelog/1.3/_changelog.md
@@ -1,0 +1,277 @@
+## Fixed In This Release
+
+- Fix incorrect preview behavior when reloading edited pages from listings (e.g. blog posts). Fixes ([#6026](https://github.com/quarto-dev/quarto-cli/issues/6026)) 
+
+## Fixed In Previous Releases
+
+- Fix issue that prevented Quarto from properly reporting crossreferenceable figures to IDEs (note that Quarto 1.3.427 contained an attempted fix for this issue which did not work properly. This release contains a functional fix.)
+- Fix incorrect behavior when previewing `--to all`
+- Fix missing handling of `rel="..."` values in the navbar's tools template ([#5756](https://github.com/quarto-dev/quarto-cli/issues/5756))
+- Disable browser cache using `Cache-Control` header config in the viewer redirect for PDF preview, correctly allowing a HTML preview later on same port. ([#5882](https://github.com/quarto-dev/quarto-cli/issues/5882))
+- Fix error when publishing a document in a subfolder ([quarto-dev/quarto#183](https://github.com/quarto-dev/quarto/issues/183)).
+- Fix error when publishing a document in a subfolder ([#5330](https://github.com/quarto-dev/quarto-cli/issues/5330)).
+- Fix duplicate bibliography when users enable `citeproc` directly. ([#5588](https://github.com/quarto-dev/quarto-cli/issues/5588)).
+- Fix issue where specificying `search: false` on an individual page would not exclude that page from the website search index.
+- Fix error when rendering document with HTML Widgets after updating to Knitr 1.43. ([#5702](https://github.com/quarto-dev/quarto-cli/issues/5702)).
+- Properly position margin elements ([#5289](https://github.com/quarto-dev/quarto-cli/issues/5289)).
+- Improve chrome detection for MacOS ([#2214](https://github.com/quarto-dev/quarto-cli/issues/2214)).
+- Correctly hide section numbers in responsive HTML view of books, when requested ([#5306](https://github.com/quarto-dev/quarto-cli/issues/5306)).
+- Properly handle figures within lists ([#5317](https://github.com/quarto-dev/quarto-cli/issues/5317), [#5461](https://github.com/quarto-dev/quarto-cli/issues/5461)).
+- Do not hide banner style title block when in responsive view ([#5296](https://github.com/quarto-dev/quarto-cli/issues/5296)).
+- Ensure global environment is available to LUA filters ([#5466](https://github.com/quarto-dev/quarto-cli/issues/5466)).
+- Ensure RevealJS navigation works properly even when there is a section called 'Theme' ([#5455](https://github.com/quarto-dev/quarto-cli/issues/5455)).
+
+## Confluence Publishing
+
+- Add support for publishing both documents and projects to Atlassian Confluence spaces and as children to Confluence pages.
+
+## Jupyter Notebooks
+
+- Add support for embedding cell outputs in quarto documents using `{{< embed >}}`. You can address cells by Id, Tag, or label, such as `{{< embed mynotebook.ipynb#fig-output >}}` which would embed the output of a cell with the label `fig-output`). You can also provide a list of ids like `{{< embed mynotebook.ipynb#fig-output,tbl-out >}}`.
+- Only attempt to postprocess `text/plain` output if it's nonempty ([#3896](https://github.com/quarto-dev/quarto-cli/issues/3896)).
+- Fix output of bokeh plots so the right number of cells is generated ([#2107](https://github.com/quarto-dev/quarto-cli/issues/2107)).
+- Fix output of code cells that contain triple backticks (or more) ([#3179](https://github.com/quarto-dev/quarto-cli/issues/3179)).
+- Don't install SIGCHLD signal handler since it interferes with IJulia in Julia 1.8.4 and greater ([#2539](https://github.com/quarto-dev/quarto-cli/issues/2539)).
+- Resolve full path to QUARTO_PYTHON binary
+- Improve handling of YAML and titles in notebooks (auto-merge heading based title with YAML front matter)
+- Discard matplotlib, seaborn, and plotnine intermediate objects from output
+- With IJulia's miniconda python env, search for `python` in addition to `python3` ([#4821](https://github.com/quarto-dev/quarto-cli/issues/4821)).
+- Allow `export:` as a cell yaml option to support new nbdev syntax ([#3152](https://github.com/quarto-dev/quarto-cli/issues/3152)).
+- merge multiple `stream` outputs to work around diverging behavior between `jupyter` and `nbclient` ([#4968](https://github.com/quarto-dev/quarto-cli/issues/4968)).
+
+## Knitr engine
+
+- Help rmarkdown find pandoc binary bundled with Quarto if none is found ([#3688](https://github.com/quarto-dev/quarto-cli/issues/3688)).
+- Do not bind knitr engine when only inline `r` expressions are found ([#3908](https://github.com/quarto-dev/quarto-cli/issues/3908)).
+- Fix an issue with `output: asis` in chunks with plots ([#3683](https://github.com/quarto-dev/quarto-cli/issues/3683)).
+
+## Code Annotation
+
+- Add support for annotation of code cells (executable or non-executable). You can read more about code annotation at [https://www.quarto.org/docs/prerelease/1.3.html](https://www.quarto.org/docs/prerelease/1.3.html).
+
+## HTML Format
+
+- Improved handling of margin references that appear within a callout. ([#3003](https://github.com/quarto-dev/quarto-cli/issues/3003))
+- Add support for customizing the baseline widths of grid columns using yaml or scss. For more information, see [https://www.quarto.org/docs/prerelease/1.3.html](https://www.quarto.org/docs/prerelease/1.3.html).
+- Fix wrapping of long `code` entries inside table cells ([#3221](https://github.com/quarto-dev/quarto-cli/issues/3221))
+- Fix author display to use the `url` for an author even when there is no affiliation.
+- Add support for linking to other formats, when more than one format is produced. Alternate formats will appear with the TOC. Control using `format-links`.
+- Add support for linking to source notebooks that provide embedded content. Control using `notebook-links`
+- Improve callout wrapping behavior for long strings with no word breaks.
+- Add overflow to tables generated from SQL code cells ([#3497](https://github.com/quarto-dev/quarto-cli/issues/3497)).
+- Fix support for parquet files in OJS code cells ([#3630](https://github.com/quarto-dev/quarto-cli/issues/3630)).
+- Forward bootstrap table classes from caption to table element ([#4036](https://github.com/quarto-dev/quarto-cli/issues/4036)).
+- Render code listings with names and captions correctly ([#2195](https://github.com/quarto-dev/quarto-cli/issues/2195)).
+- Fix issue with interactivity of elements in mobile size dispay when `toc-left` is being used. ([#4244](https://github.com/quarto-dev/quarto-cli/issues/4244)).
+- Allow control of the 'cite as' appendix in HTML documents using `appendix-cite-as` (pass `false`, `display`, or `bibtex`). ([#2625](https://github.com/quarto-dev/quarto-cli/issues/2625))
+- Properly anchor custom appendix sections ([#3112](https://github.com/quarto-dev/quarto-cli/issues/3112)).
+- Don't display custom appendix sections in the TOC ([#3113](https://github.com/quarto-dev/quarto-cli/issues/3113)).
+- Use custom `styles.html` template partial to better support checkbox alignment ([#4556](https://github.com/quarto-dev/quarto-cli/issues/4556)).
+- Improve ergonomics of text-highting in HTML output, not emitting difficult overwrite styles and better supporting theme -> CSS conversion. ([#4334](https://github.com/quarto-dev/quarto-cli/issues/4334)).
+- Improve CSS of nested tight and loose lists ([#4560](https://github.com/quarto-dev/quarto-cli/discussions/4650)).
+- Resolve Bootstrap responsive classes in tables ([#2997](https://github.com/quarto-dev/quarto-cli/issues/2997)).
+- Fine tuning of the appearance of computational and markdown table and more uniformly apply such styling.
+- Fine tuning of the appearance of header and body text.
+- Fix invalid figcaption DOM structure ([#5234](https://github.com/quarto-dev/quarto-cli/issues/5234)).
+
+## Article Layout
+
+- Improve positioning of margin content defined within tabsets ([#3280](https://github.com/quarto-dev/quarto-cli/issues/3280)).
+- Improve support for tables with margin positioned endnotes ([#4324](https://github.com/quarto-dev/quarto-cli/issues/4324)).
+
+## Revealjs Format
+
+- reduce font size of `df-print: paged` tables ([#3380](https://github.com/quarto-dev/quarto-cli/issues/3380))
+- `width` and `height` in percent are now correctly supported ([#4063](https://github.com/quarto-dev/quarto-cli/issues/4063))
+- add better margins to numbered lists in the presence of many items and `.scrollable` ([#4283](https://github.com/quarto-dev/quarto-cli/issues/4063)).
+- Properly support scss imports for RevealJS extensions ([#3414](https://github.com/quarto-dev/quarto-cli/issues/3414))
+- Authors on the title slides now correctly object customization of the `$presentation-title-slide-text-align` scss variable ([#3843](https://github.com/quarto-dev/quarto-cli/issues/3843))
+- Properly support `show-notes: separate-page` [#3996](https://github.com/quarto-dev/quarto-cli/issues/3996)
+- Improve footnote / aside layout for centered slides. [#4297](https://github.com/quarto-dev/quarto-cli/issues/4297)
+- Ensure anchors refer to the containing slide in case of crossrefs ([#3533](https://github.com/quarto-dev/quarto-cli/issues/4297)).
+- Support `output-location` as a top level option in Revealjs presentations ([#3261](https://github.com/quarto-dev/quarto-cli/issues/3261))
+- Fix PDF export keyboard shortcut and button in menu ([#2988](https://github.com/quarto-dev/quarto-cli/issues/2988))
+- Fix title slide CSS when `hash-type: number` ([#4418](https://github.com/quarto-dev/quarto-cli/issues/4418)).
+
+## EPUB Format
+
+- Enable webtex (epub2 format) or mathml (epub/epub3 format) by default for EPUB output [#4403](https://github.com/quarto-dev/quarto-cli/issues/4403)
+
+## Dates
+
+- Properly fall back to language only locale when a supported language-region locale isn't available. (#3059)
+
+## PDF Format
+
+- Fix wrong page number in the TOC for appendices ([#3164](https://github.com/quarto-dev/quarto-cli/issues/3164)) (Thank you, @iusgit!)
+- Add support for automatically converting SVG images to PDF ([#2575](https://github.com/quarto-dev/quarto-cli/issues/2575))
+- Previously, if the `pdf-engine` was set to `latexmk`, we would bypass many features of Quarto and use Pandoc to produce the PDF output. Starting in in Quarto 1.3, all Quarto features will be enabled for the `latexmk` engine and `latexmk` will be used to run the PDF generation loop.
+- Fix author processing in default PDFs for complex author names (#3483)
+- Remove excessive vertical space between theorem type blocks ([#3776](https://github.com/quarto-dev/quarto-cli/issues/3776)).
+- Fix temporary `.tex` filenames in the presence of multiple variants ([#3762](https://github.com/quarto-dev/quarto-cli/issues/3762)).
+  - Note that this fix changes the filenames used for PDF files with variants. In quarto 1.3, the automatic output names for PDF files include format variants and modifiers.
+- Correctly download online image on Windows ([#3982](https://github.com/quarto-dev/quarto-cli/issues/3982)).
+- Permissions of `.tex` file are now correct when `keep-tex: true` ([#4380](https://github.com/quarto-dev/quarto-cli/issues/4380)).
+- Better support footnotes within Callouts in PDF / LaTeX output ([#1235](https://github.com/quarto-dev/quarto-cli/issues/1235)).
+- Allow `fig-pos: false` to support custom figure environments that don't support the `H` option ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
+- Allow `fig-pos:` to specify complex arguments with square and curly braces ([#4854](https://github.com/quarto-dev/quarto-cli/discussions/4854)).
+
+## Beamer Format
+
+- Document `theme` format metadata option ([#3377](https://github.com/quarto-dev/quarto-cli/issues/3377))
+
+## Markdown Formats
+
+- Properly forward variants (e.g. `+yaml_metadata_block`) to `gfm` format.
+- `gfm` format now supports a local browser based preview when using `quarto preview`. If you'd like to see the raw markdown in preview, you can add `preview-mode: raw` to your document front matter or project.
+- `gfm` and `commonmark` output formats now use ATX style headers ([#4280](https://github.com/quarto-dev/quarto-cli/issues/4280))
+
+## Mermaid diagrams
+
+- Upgrade to mermaid 9.2.2
+- Add support for theming mermaid diagrams in Javascript formats ([#2165](https://github.com/quarto-dev/quarto-cli/issues/2165)). See the [prerelease documentation notes](https://quarto.org/docs/prerelease/1.3.html) for details.
+- Allow `%%| label` mermaid cell option that control the `id` of the resulting SVG, to facilitate CSS overrides.
+- Use `htmlLabels: false` in mermaid flowcharts.
+- Remove support for tooltips, which appear to not be working in mermaid 9.2.2.
+- Add support for `fig-align` in mermaid diagrams in HTML format ([#3294](https://github.com/quarto-dev/quarto-cli/issues/3294)).
+- Add support for `%%| file` mermaid cell option ([#3665](https://github.com/quarto-dev/quarto-cli/issues/3665)).
+- Fix `code-fold` support in mermaid (and dot) diagrams ([#4423](https://github.com/quarto-dev/quarto-cli/issues/4423)).
+- Fix caption insertion in the presence of alignment specifiers with `{}` in them ([#4748](https://github.com/quarto-dev/quarto-cli/issues/4748)).
+- Support `fig-env` and `fig-pos` in mermaid diagrams in PDF format ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
+
+## Dot diagrams
+
+- Support `fig-env` and `fig-pos` in dot diagrams in PDF format ([#4832](https://github.com/quarto-dev/quarto-cli/discussions/4832)).
+
+## Dates
+
+- Properly fall back to language only locale when a supported language-region locale isn't available. ([#3059](https://github.com/quarto-dev/quarto-cli/issues/3059))
+
+## About Pages
+
+- Add support for `image-alt` which provides alternate text for the about page image. ([#3010](https://github.com/quarto-dev/quarto-cli/issues/3010))
+- Add support for `image-title` on About pages ([#3077](https://github.com/quarto-dev/quarto-cli/issues/3077))
+
+## Article Layout
+
+- Improve the performance of extremely large documents with margin elements by improving the efficiency of positioning the elements.
+
+## Listings
+
+- Listings now support `template-params`, which will be passed to custom EJS templates in a variable called `templateParams` when a listing is rendered.
+- Custom listing objects now resolve `path: ` fields into the metadata that would be generated by standard listings, giving custom listing access to computed metadata like `reading-time`, etc.
+- Improve support for `date-modified` in listings
+- Improve support for `yml` based listings by supporting usage of title and description from `yml`.
+- Allow listings in project to point directly to non-input files (such as `yml` files) to use for contents.
+- Allow `sort: false` to disable any sorting, allowing items to appear in their original / natural order. (#3296)
+- Warn if listings are being used outside of a website ([#4267](https://github.com/quarto-dev/quarto-cli/issues/4267))
+- Permit using computation outputs (plots/figures) as the preview image for an item in a listing ([#2324](https://github.com/quarto-dev/quarto-cli/issues/2324))
+- Use alt text from preview image that is discovered for a page in a listing ([#3706](https://github.com/quarto-dev/quarto-cli/issues/3706))
+- Add support for `includes:` and `excludes:` in listings, which will use filter the items included in a listing. ([#2577](https://github.com/quarto-dev/quarto-cli/issues/2577)).
+- Properly render structured author names in listings ([#4881](https://github.com/quarto-dev/quarto-cli/issues/4881))
+
+## Websites
+
+- Add suport for 'Back to top' navigational button. Controlled using `back-to-top-navigation:` under `website:`, can be disabled by setting `back-to-top-navigation: false` on individual pages.
+- Fix issue assigning specific sidebar to a specific page using `sidebar:` (#3389)
+- Change behavior of `publish gh-pages` to always render into a clean directory.
+  Previous behavior was to add to existing contents of `gh-pages` branch. ([#3199](https://github.com/quarto-dev/quarto-cli/discussions/3199), @ijlyttle)
+- Order sidebar entries using filename rather than title
+- Position `repo-actions` in the page footer if there is nowhere else to position them ([#3998](https://github.com/quarto-dev/quarto-cli/issues/3998))
+- Render `page-footer` even when a Navbar isn't present ([#4053](https://github.com/quarto-dev/quarto-cli/issues/4053))
+- Don't treat links with no `href` as external when `link-external-icon` is enabled ([#3645](https://github.com/quarto-dev/quarto-cli/issues/3645))
+- Escape HTML from code cells that appears inline in search results ([#4404](https://github.com/quarto-dev/quarto-cli/issues/4404))
+- Use input last modified timestamp when updating sitemap ([#3251](https://github.com/quarto-dev/quarto-cli/issues/3251))
+- Add support for overriding the url used to report an issue with a website using `issue-url` (which can be provided even if there is no repo provided for the website).
+- Properly localize search button title and various toggle aria-labels ([#4559](https://github.com/quarto-dev/quarto-cli/issues/4559))
+- Support `navbar: true` to turn on a top navbar even if there are no contents
+- Improve title recognition for pages that don't include a title in metadata ([#4528](https://github.com/quarto-dev/quarto-cli/issues/4528))
+- Ensure that footnote are properly indexed for website and book searches ([#4601](https://github.com/quarto-dev/quarto-cli/issues/4601)).
+- Permit sidebar items to include icons ([#3830](https://github.com/quarto-dev/quarto-cli/issues/3830)).
+- Improve the appearance of the collapsed navbar toggle button
+- Properly respect the footer border when set explicitly in `_quarto.yml` ([#4982](https://github.com/quarto-dev/quarto-cli/issues/4982))
+
+## Books
+
+- Remove chapter number of HTML head title when `number-sections` is `false` (#3304).
+- Non-HTML book output formats will now be placed in subdirectories (`book-<format>`) within the project output directory (`_books`)
+- Don't discard the first chapter header when a chapter title is declared using YAML.
+- Support for rendering to Asciidoc
+- Support for rendering to LaTeX
+- Properly support localized appendex name in book website navigation ([#4578](https://github.com/quarto-dev/quarto-cli/issues/4578))
+- Don't emit duplicate bibliography heading when LaTeX/PDF books are rendering using `natbib` or `biblatex` ([#2770](https://github.com/quarto-dev/quarto-cli/issues/2770))
+
+## Preview
+
+- Correct redirect for VS Code Server (#3352) (Thank you, @benz0li!)
+
+## LUA
+
+- `quarto.version()` now returns `Version` object that simplifies comparison (thank you @tarleb)
+
+## HTML Output
+
+- HTML output will not decorate links within source code (for example, from `code-link: true`) with external icons. (#3755)
+- Use `toc-expand` to control to what level the TOC will expand by default in HTML documents.
+- Improve tab border coloring across themes ([#4868](https://github.com/quarto-dev/quarto-cli/issues/4868)).
+
+## Miscellaneous
+
+- Work around pandoc strict checking of `number-offset` type. ([#3126](https://github.com/quarto-dev/quarto-cli/issues/3126))
+- Warn instead of crash on bad URI ([#3220](https://github.com/quarto-dev/quarto-cli/issues/3220))
+- ensure `video` shortcode works with `embed-resources` and `self-contained` ([#3310](https://github.com/quarto-dev/quarto-cli/issues/3310))
+- Add optional `rel` attribute to navigation links ([#3212](https://github.com/quarto-dev/quarto-cli/issues/3212))
+- Use the right port when CRI is initialized multiple times ([#3066](https://github.com/quarto-dev/quarto-cli/issues/3066))
+- Allow custom themes for giscus ([#3105](https://github.com/quarto-dev/quarto-cli/issues/3105))
+- Add new `kbd` shortcode, to describe keyboard keys ([#3384](https://github.com/quarto-dev/quarto-cli/issues/3384)). See the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for details.
+- Replace default style for date picker component in OJS ([#2863](https://github.com/quarto-dev/quarto-cli/issues/2863)).
+- `quarto check` now supports `quarto check versions` for checking binary dependency versions in the case of custom binaries ([#3602](https://github.com/quarto-dev/quarto-cli/issues/3602)).
+- the API for shortcode handlers in lua now accepts a fourth parameter `raw_args` which hold the unparsed arguments in a table ([#3833](https://github.com/quarto-dev/quarto-cli/issues/3833)).
+- remove scaffolding div from conditional content in final output ([#3847](https://github.com/quarto-dev/quarto-cli/issues/3847)).
+- ensure proof titles are appended to paragraph nodes ([#3772](https://github.com/quarto-dev/quarto-cli/issues/3772)).
+- Support parsing markdown in table captions in LaTeX and HTML tables ([#2573](https://github.com/quarto-dev/quarto-cli/issues/2573)).
+- Improve parsing of include shortcodes ([#3159](https://github.com/quarto-dev/quarto-cli/issues/3159)).
+- Add support for Youtube privacy-enhanced urls in `video` shortcodes ([#4060](https://github.com/quarto-dev/quarto-cli/issues/4060)).
+- Don't emit empty cells ([#4034](https://github.com/quarto-dev/quarto-cli/issues/4034)).
+- Resolve link tags correctly in html dependencies ([#4304](https://github.com/quarto-dev/quarto-cli/discussions/4304)) (Thank you, @jdlom!).
+- use correct language code for Korean ([#4187](https://github.com/quarto-dev/quarto-cli/discussions/4187)).
+- resolve YAML options correctly for comments with open+close syntax ([#3901](https://github.com/quarto-dev/quarto-cli/issues/3901)).
+- Work around rare deno tempfile creation bug ([#4352](https://github.com/quarto-dev/quarto-cli/issues/4352)).
+- Only open "safe ports" for Chromium ([#4514](https://github.com/quarto-dev/quarto-cli/issues/4514)).
+- Detect potential bad argument ordering in `quarto render` ([#3581](https://github.com/quarto-dev/quarto-cli/issues/3581)).
+- Detect potential git merge conflict in `\_freeze` files ([#4529](https://github.com/quarto-dev/quarto-cli/issues/4529)).
+- Trim whitespace from the end of yaml strings in jupyter engine to work around poyo parsing issue ([#4573](https://github.com/quarto-dev/quarto-cli/issues/4573)).
+- Use "iso" date form instead of "short" to format citations properly ([#4586](https://github.com/quarto-dev/quarto-cli/issues/4586)).
+- Fix typo `thumnail-image` -> `thumbnail-image` in listing template ([#4602](//github.com/quarto-dev/quarto-cli/pull/4602)) (Thank you, @mattspence!).
+- Add support for targeting the `#refs` divs with citations when using `natbib` or `biblatex` to generate a bibliography.
+- Warn users about Chromium installation issues in WSL ([#4596](https://github.com/quarto-dev/quarto-cli/issues/4586)).
+- Fix issue with "No inspectable targets" with Chrome Browser ([#4653](https://github.com/quarto-dev/quarto-cli/issues/4653))
+- Add `title` attribute for callouts (can be used rather than heading for defining the title)
+- Handle more varieties of raw HTML for Docusaurus output
+- Read and process DOM one-file-at-time in books and websites to reduce total memory usage ([#4350](https://github.com/quarto-dev/quarto-cli/issues/4350)).
+- Fix issue with TeX Live 2023 bin paths on Windows ([#4906](https://github.com/quarto-dev/quarto-cli/issues/4906)).
+
+## Pandoc filter changes
+
+- Quarto 1.3 introduces the notion of Custom AST nodes to Pandoc filters. If you use Lua filters for processing callouts, tabsets, or conditional blocks, consult the [pre-release documentation](https://quarto.org/docs/prerelease/1.3.html) for how to change your filters to support the new syntax.
+- Quarto 1.3 now processes HTML tables (in Markdown input) into Pandoc AST nodes, which can be processed by user filters and output into non-HTML formats. In addition, it supports "embedded Markdown content" which will be resolved by quarto's processing, including shortcode and crossref resolution. See the [prerelease documentation](https://quarto.org/docs/prerelease/1.3.html) for more.
+
+## Project
+
+- fix rendering of individual project files to stdout ([#4052](https://github.com/quarto-dev/quarto-cli/issues/4052)).
+- fix previewing docusaurus project on Windows ([#4312](https://github.com/quarto-dev/quarto-cli/issues/4312)).
+- fix performance issue in large projects ([#5002](https://github.com/quarto-dev/quarto-cli/issues/5002)).
+
+## Publishing
+
+- Fix error publishing when an `output-dir` is specified ([#4158](https://github.com/quarto-dev/quarto-cli/issues/4158)).
+- Emit error when git <2.17.0 is used ([#4575](https://github.com/quarto-dev/quarto-cli/issues/4575)).
+- Fix error regarding `--site-url` when publishing document and not website ([#4384](https://github.com/quarto-dev/quarto-cli/issues/4384)).
+
+## Other
+
+- Fix error when running the command `quarto render -h` to receive help ([#3202](https://github.com/quarto-dev/quarto-cli/issues/3202)).
+- Fix error when rendering a document with an extension which provides a directory as `format-resources` ([#4377](https://github.com/quarto-dev/quarto-cli/issues/4377)).
+- Fix incorrect copying of resource files during rendering ([#4544](https://github.com/quarto-dev/quarto-cli/issues/4544))
+- Extension authors may now force files to be included in their template by writing the file / file path in the `.quartoignore` file prefixed with a `!`. For example `!README.md` ([#4061](https://github.com/quarto-dev/quarto-cli/issues/4061)).
+- Fix issue when installing extensions on older Windows ([#4203](https://github.com/quarto-dev/quarto-cli/issues/4203)).

--- a/docs/download/changelog/1.3/index.qmd
+++ b/docs/download/changelog/1.3/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "1.3 Release Notes"
+format: html
+---
+
+{{< include _changelog.md >}}
+

--- a/docs/download/changelog/1.4/_changelog.md
+++ b/docs/download/changelog/1.4/_changelog.md
@@ -1,0 +1,445 @@
+## Fixed in this release
+
+- Update Pandoc to 3.1.12.3 to remove exposure to `polyfill.io` in Pandoc's built-in templates.
+
+## Fixed in previous releases
+
+- ([#8969](https://github.com/quarto-dev/quarto-cli/issues/8969)): Replace `polyfill.io` with `cdnjs.cloudflare.com` in MathJax usage in HTML formats.
+- ([#9927](https://github.com/quarto-dev/quarto-cli/issues/9927)): Fix a regression with explicitly sized images in layouts.
+- ([#10091](https://github.com/quarto-dev/quarto-cli/issues/10091)): Fix a regression with `fig-align` attributes in captionless images in PDF format.
+- ([#8439](https://github.com/quarto-dev/quarto-cli/issues/8439)): ensure that lack of subject line is handled
+- ([#8417](https://github.com/quarto-dev/quarto-cli/issues/8417)): Maintain a single AST element in the output cell when parsing HTML from RawBlock
+- ([#8490](https://github.com/quarto-dev/quarto-cli/issues/8490)): Properly embed `qmd` cells even when they include an explicit `echo` declaration.
+- ([#8464](https://github.com/quarto-dev/quarto-cli/issues/8464)): Fix a regression where shortcodes were not being expanded recursively.
+- ([#8485](https://github.com/quarto-dev/quarto-cli/issues/8485)): Fix a regression where shortcodes could not Unicode characters with code points above 127.
+- ([#8507](https://github.com/quarto-dev/quarto-cli/issues/8507)): Fix a regression with callout rendering in `docx`.
+- ([#8510](https://github.com/quarto-dev/quarto-cli/issues/8510)): Fix a regression on undocumented behavior with `sidebar.align` instead of `sidebar.alignment` in YAML configuration.
+- ([#8514](https://github.com/quarto-dev/quarto-cli/issues/8514)): Fix a regression where crossreferences in `number-sections: false` documents were being rendered incorrectly.
+- ([#8536](https://github.com/quarto-dev/quarto-cli/issues/8536)): Fix a regression with column specifiers in `html`.
+- ([#8552](https://github.com/quarto-dev/quarto-cli/issues/8552)): Fix incorrect behavior reading title from code cells in Dashboards.
+- ([#8555](https://github.com/quarto-dev/quarto-cli/issues/8555)): Fix malformed HTML when outputing page navigation (books and websites).
+- ([#8566](https://github.com/quarto-dev/quarto-cli/issues/8566)): Fix issues with usage of iTables in Quarto Dashboards. This includes layout issues for large or wide tables, appearance of sticky headers, as well as a hang that can occur when rendering a Dashboard using iTables 1.7.
+- ([#8567](https://github.com/quarto-dev/quarto-cli/issues/8567)): Improve website search performance for large sites with long search terms.
+- ([#8586](https://github.com/quarto-dev/quarto-cli/issues/8586)): Fix regression on rendering multiple embedded citations in LaTeX tables.
+- ([#8603](https://github.com/quarto-dev/quarto-cli/issues/8603)): Fix a regression with multiple-column layouts and code-folding.
+- ([#8630](https://github.com/quarto-dev/quarto-cli/issues/8603)): Fix a regression with latex crossref identifiers with underscores. Note that this syntax is not officially supported in Quarto, but this change reverts to the behavior in 1.3.
+- ([#8652](https://github.com/quarto-dev/quarto-cli/issues/8652)): Make code cell detection in IDE tooling consistent across editor modes.
+- ([#8662](https://github.com/quarto-dev/quarto-cli/issues/8662)): Do not incorrectly prevent previewing docusaurus websites without an index file.
+- ([#8697](https://github.com/quarto-dev/quarto-cli/issues/8697)): Ensure that lightboxed figures with margin captions properly position the caption.
+- ([#8708](https://github.com/quarto-dev/quarto-cli/issues/8708)): Resolve complex layouts in ipynbs embeds for manuscripts.
+- ([#8728](https://github.com/quarto-dev/quarto-cli/pull/8728)): Don't crash with empty floats in LaTeX format.
+- ([#8733](https://github.com/quarto-dev/quarto-cli/issues/8733)): Fix regression with image-align=right in LaTeX format.
+- ([#8741](https://github.com/quarto-dev/quarto-cli/issues/8741)): Fix issue where the MacOS installer would incorrectly report that Rosetta is required (it is not).
+- ([#8749](https://github.com/quarto-dev/quarto-cli/issues/8749)): Fix bundle creation for publishing Quarto projects to Posit Connect using `quarto publish connect`.
+- ([#8785](https://github.com/quarto-dev/quarto-cli/issues/8785)): Fix issue with noncentered, non-referenceable subfigures in LaTeX format.
+- ([#8795](https://github.com/quarto-dev/quarto-cli/issues/8795)): Fix issue with select controls appearing in Dashboard toolbar.
+- ([#8798](https://github.com/quarto-dev/quarto-cli/issues/8798)): Fix issue with duplicate level 1 headings in rendered `ipynb` notebooks.
+- ([#8818](https://github.com/quarto-dev/quarto-cli/issues/8818)): Fix alignment of `right` items in Navbars.
+- ([#8852](https://github.com/quarto-dev/quarto-cli/issues/8852)): Do not strip `index.html` from external links.
+- ([#8854](https://github.com/quarto-dev/quarto-cli/issues/8854)): Don't allow margin footnotes to break `hover-citations`
+- ([#8858](https://github.com/quarto-dev/quarto-cli/issues/8858)): Fix issue rendering markdown in bread-crumbs
+- ([#8843](https://github.com/quarto-dev/quarto-cli/issues/8843)): Fix issue in books when some R code cells emits LaTeX dependencies to be included in the LaTeX preamble.
+- ([#8857](https://github.com/quarto-dev/quarto-cli/issues/8857)): Fix issue with `format: dashboard` using Plotly in Jupyter on Windows.
+- ([#8937](https://github.com/quarto-dev/quarto-cli/pull/8937)): Fix unix `quarto` launcher in the case of paths with spaces.
+- ([#9076](https://github.com/quarto-dev/quarto-cli/issues/9076)): Fix rendering of code cells with `layout-ncol` and `column` settings in `html` format.
+- ([#9200](https://github.com/quarto-dev/quarto-cli/issues/9200)): Fix regression with `tbl-colwidths` outside of a cross-referenceable table element.
+- ([#9335](https://github.com/quarto-dev/quarto-cli/issues/9335)): Fix bad escaping of escaped inline code cells inside code blocks.
+- ([#9356](https://github.com/quarto-dev/quarto-cli/issues/9356)): Don't process column classes for figures inside the About divs.
+- ([#9535](https://github.com/quarto-dev/quarto-cli/issues/9535)): Fix `fig-alt` regression from previous 1.4 patch release.
+- ([#9550](https://github.com/quarto-dev/quarto-cli/issues/9550)): Don't crash when subcaptions are incorrectly specified with `fig-subcap: true` but no embedded subcaptions.
+- ([#9593](https://github.com/quarto-dev/quarto-cli/issues/9593)): Fix regression with `column-margin` when used in spans in a paragraph.
+- ([#9602](https://github.com/quarto-dev/quarto-cli/issues/9602)): Fix regression with parsed HTML tables not being correcty included in various format like pptx and typst.
+- ([#8258](https://github.com/quarto-dev/quarto-cli/issues/8258)): Quarto now works again with R 4.1.3 and previous versions.
+- ([#9704](https://github.com/quarto-dev/quarto-cli/issues/9704)): Fix regression with PDF export feature in Revealjs - it now works again like in 1.3.
+- ([#9734](https://github.com/quarto-dev/quarto-cli/issues/9734)): Fix issue with unlabeled tables and `tbl-cap-location` information.
+
+## Languages
+
+- Add Serbian-Latin translation (author: @n_grubor)
+- Add Slovak translation (author: @tom67)
+- Improve Italian translation of 'proof' (author: @espinielli)
+- Add Greek translation (author: @cultab)
+- Add Norwegian translation (author: @lektorodd)
+- Add Lithuanian translation (author: @GegznaV)
+- Add Traditional Chinese (Taiwan) translation (author: @bobby1030)
+- Update Catalan translation (author: @jmaspons)
+
+## Dependencies
+
+- Update to Pandoc 3.1.11
+- Update to Typst 0.10.0
+
+## Breaking Changes
+
+- In website projects, a single sidebar with a `id` property will no longer be used as a global sidebar. It will instead be used as a sidebar for only pages which specify that `id` or pages linked to from the sidebar.
+
+## HTML Format
+
+- Add support for showing cross reference contents on hover (use `crossrefs-hover: false` to disable).
+- Add support for displaying `keywords` in HTML page title block, when present.
+- ([#3473](https://github.com/quarto-dev/quarto-cli/issues/3473)): Add support for `body-right` and `body-left` layouts for Website Table of Contents.
+- ([#3895](https://github.com/quarto-dev/quarto-cli/discussions/3895)): Other format links can appear on the left (ensure that they follow the `toc-location` whether or not a toc is visible).
+- ([#4840](https://github.com/quarto-dev/quarto-cli/issues/4840)): Add support for specifying a custom Hypothesis client url using `client-url`
+- ([#4882](https://github.com/quarto-dev/quarto-cli/issues/4882)): Add support for `canonical-url`, which when provided will include a link tag with rel='canonical' which will use an explictly provided or automatically generated canonical url for the document.
+- ([#5189](https://github.com/quarto-dev/quarto-cli/issues/5189)): Ensure appendix shows even when `page-layout` is custom.
+- ([#5196](https://github.com/quarto-dev/quarto-cli/discussions/5196)): Properly support `title-prefix` for HTML output
+- ([#5210](https://github.com/quarto-dev/quarto-cli/issues/5210)): Update to Bootstrap 5.2.2
+- ([#5393](https://github.com/quarto-dev/quarto-cli/issues/5393)): Properly set color of headings without using opacity.
+- ([#5403](https://github.com/quarto-dev/quarto-cli/issues/5403)): Fix accessibility issues with the `kbd` shortcode.
+- ([#5431](https://github.com/quarto-dev/quarto-cli/issues/5431)): Properly apply column positioning to title metadata.
+- ([#5516](https://github.com/quarto-dev/quarto-cli/issues/5516)): Ensure that images which appear in the margin are properly marked as fluid.
+- ([#5663](https://github.com/quarto-dev/quarto-cli/issues/5663)): Properly forward column grid position to sub grids with margin elements.
+- ([#5700](https://github.com/quarto-dev/quarto-cli/issues/5700)): Don't show scrollbars on Windows when hovering over hover code annotations.
+- ([#5708](https://github.com/quarto-dev/quarto-cli/issues/5708)): Fix hang when viewing pages with specific query parameter
+- ([#5789](https://github.com/quarto-dev/quarto-cli/issues/5789)): Correct appearance of languageless code cells in some contexts
+- ([#5794](https://github.com/quarto-dev/quarto-cli/issues/5794)): Fix incorrect caching behavior when `import` is used in scss themes.
+- ([#5798](https://github.com/quarto-dev/quarto-cli/issues/5798)): Improve the layout consistency of HTML callouts.
+- ([#5856](https://github.com/quarto-dev/quarto-cli/issues/5856)): Always render the title block of HTML pages (previously would only render when title or subtitle was provided).
+- ([#5929](https://github.com/quarto-dev/quarto-cli/issues/5929)): Split border-bottom properties to avoid invalid `inherit` entry in resulting CSS.
+- ([#5955](https://github.com/quarto-dev/quarto-cli/issues/5955)): Correct HTML callout appearance when title isn't present.
+- ([#5957](https://github.com/quarto-dev/quarto-cli/issues/5957)): Fix layout issues when margin footnotes are contained in headings or other formatted text.
+- ([#6004](https://github.com/quarto-dev/quarto-cli/discussions/6004)): Improve appearance of Cross Talk controls in Quarto HTML documents
+- ([#6163](https://github.com/quarto-dev/quarto-cli/issues/6163)): Wrap `svg` output of `dot` cells in RawBlock `html` elements.
+- ([#6430](https://github.com/quarto-dev/quarto-cli/issues/6430)): Fix layout issue with banner style title block authors when `page-layout: full`
+- ([#6627](https://github.com/quarto-dev/quarto-cli/issues/6627)): Add a bit of margin-right to checkbox inputs.
+- ([#6693](https://github.com/quarto-dev/quarto-cli/discussions/6693)): Fine tune table appearance to improve consistency
+- ([#6714](https://github.com/quarto-dev/quarto-cli/issues/6714)): Display title block for HTML when other (non-title/author/subtitle) metadata is present.
+- ([#6833](https://github.com/quarto-dev/quarto-cli/issues/6833)): Handle partially-specified aspect ratio, width, and height attributes in `video` shortcode.
+- ([#6910](https://github.com/quarto-dev/quarto-cli/issues/6910)): Properly forward `code-summary` as a global HTML option
+- ([#7024](https://github.com/quarto-dev/quarto-cli/discussions/7024)): Ensure HTML documents can render properly even when installed Quarto files aren't writable
+- ([#7137](https://github.com/quarto-dev/quarto-cli/discussions/7137)): Automatically set `rel="noopener"` when setting a target on external links
+- ([#7183](https://github.com/quarto-dev/quarto-cli/discussions/7183)): Mark asides that appear in the margin with a `margin-aside` class
+- ([#7187](https://github.com/quarto-dev/quarto-cli/issues/7187)): Add `html-table-processing: none` to document- and project-level metadata to disable HTML table processing. Add `{html-table-processing="none"}` to a fenced div to disable HTML table processing for the elements in that div. Add `html-table-processing: none` on knitr or jupyter cell to disable HTML table processing for the cell output content.
+- ([#7441](https://github.com/quarto-dev/quarto-cli/issues/7441)): Links in hover box (e.g. links to DOI when hover for citations is opt-in) are now correctly process for external and new window processing (when `link-external-icon: true` and `link-external-newwindow: true`).
+- ([#7542](https://github.com/quarto-dev/quarto-cli/discussions/7542)): Title block will properly present author affiliations when there is a mix of authors with affiliations and authors without affiliations
+- Ensure that code annotation buttons are not selectable text.
+- ([#7364](https://github.com/quarto-dev/quarto-cli/discussions/7364)): Restore support for `layout-align` attribute in panels
+- ([#8032](https://github.com/quarto-dev/quarto-cli/issues/8032)): Fix layout issue when margin footnotes are contained on a list item inside a callout.
+- ([#7153](https://github.com/quarto-dev/quarto-cli/issues/7153)): Fix layout issue when margin footnotes are contained in a blockquote.
+
+## Appendix
+
+- ([#6783](https://github.com/quarto-dev/quarto-cli/issues/6783)): Add additional CC licenses, improve link text
+- ([#5685](https://github.com/quarto-dev/quarto-cli/issues/5685)): Provide consistent ids for appendix sections
+
+## RevealJS Format
+
+- ([#1943](https://github.com/quarto-dev/quarto-cli/issues/1943)): Allow setting `code-block-height` in presentation front matter.
+- ([#3671](https://github.com/quarto-dev/quarto-cli/issues/3671)): Remove untitled slides from the table of contents.
+- ([#5210](https://github.com/quarto-dev/quarto-cli/issues/5210)): Update to Bootstrap 5.2.2
+- ([#5546](https://github.com/quarto-dev/quarto-cli/issues/5546)): Images inside links can't be stretched, and so auto-stretch feature now ignores them.
+- ([#5783](https://github.com/quarto-dev/quarto-cli/issues/5783)): Ensure fenced code blocks work with line numbers.
+- ([#6120](https://github.com/quarto-dev/quarto-cli/issues/6120)): `pdf-max-pages-per-slide` is now correctly setting [`pdfMaxPagesPerSlide` config](https://revealjs.com/pdf-export/#page-size) for RevealJS.
+- ([#6800](https://github.com/quarto-dev/quarto-cli/issues/6800)): Move automatically-added content (slide footers, etc) to top-level of DOM when last slide is `hidden`, to avoid inadvertently removing it.
+- ([#6827](https://github.com/quarto-dev/quarto-cli/issues/6120)): Correctly layout callout in revealjs slides when changing appearance.
+- ([#6853](https://github.com/quarto-dev/quarto-cli/issues/6853), [#5208](https://github.com/quarto-dev/quarto-cli/issues/5208)): Wrap callout in div when attr is non-empty.
+- ([#7042](https://github.com/quarto-dev/quarto-cli/issues/7042)): Line highligthting now works correctly with code annotation.
+- ([#7104](https://github.com/quarto-dev/quarto-cli/issues/7104)): Line highlighting progressive reveal now correctly has code annotation anchor on the right.
+- ([#7366](https://github.com/quarto-dev/quarto-cli/issues/7366)): `smaller: true` now applies correctly on nested slides.
+- ([#7394](https://github.com/quarto-dev/quarto-cli/issues/7394)): Fix issue with mermaid diagrams in revealjs slides when `output-location: fragment`.
+- ([#4988](https://github.com/quarto-dev/quarto-cli/issues/4988)): targets for links on numbered code lines are removed, as revealjs doesn't support them because navigation is done by slide only.
+- ([#4156](https://github.com/quarto-dev/quarto-cli/issues/4156)): footer and slide number text on slide with dark background have now an adapted text muted color based on `$dark-bg-text-color`.
+- ([#7134](https://github.com/quarto-dev/quarto-cli/issues/7134)): `.nostrech` can now be applied on image directly to opt-out Revealjs' image stretching when `auto-stretch: true` (the default).
+
+## PDF Format
+
+- ([#4370](https://github.com/quarto-dev/quarto-cli/issues/4370)): Hoist code cells deep in the AST out of layout cells to avoid `\raisebox` issues with the `Shaded` environment.
+- ([#5078](https://github.com/quarto-dev/quarto-cli/issues/5078)): Ensure format-resources are copied before PDF rendering when `latex-auto-mk` is `false`
+- ([#5058](https://github.com/quarto-dev/quarto-cli/issues/5058)): Add a `before-title.tex` partial to the PDF format. This partial will appear in the document premable just before the title block, allowing further customization of the document preamble. By default, this partial is empty.
+- ([#5969](https://github.com/quarto-dev/quarto-cli/issues/5969)): Correctly detect a required rerun for biblatex when using backref link options.
+- ([#5690](https://github.com/quarto-dev/quarto-cli/issues/5690)): Improve validation of `pdf-engine`
+- ([#6077](https://github.com/quarto-dev/quarto-cli/issues/6077)): Make sure proof environments are tight around contents.
+- ([#6907](https://github.com/quarto-dev/quarto-cli/issues/6907)): Fix issue with footnote mark line processor not triggering.
+- ([#6990](https://github.com/quarto-dev/quarto-cli/issues/6990)): Fix an issue where underscore in `filename` code cell attribute were not escaped.
+- ([#7175](https://github.com/quarto-dev/quarto-cli/issues/7175)): Fix an issue with code annotations when more than one digit is used for annotation number.
+- ([#7267](https://github.com/quarto-dev/quarto-cli/issues/7267)): Fix issue with longtable environments interfering with the `table` counter.
+- ([#7434](https://github.com/quarto-dev/quarto-cli/issues/7434)): Support `resource-path` when resolving images in PDF
+- ([#7534](https://github.com/quarto-dev/quarto-cli/issues/7534)): Fix issue with multiple paragraph footnotes when using `reference-location: margin`.
+- ([#7568](https://github.com/quarto-dev/quarto-cli/issues/7568)): Code annotation now works in LaTeX document when having other comments on same line.
+- ([#6716](https://github.com/quarto-dev/quarto-cli/issues/6716)): Fix `marginpar` error when placing citations in the margin
+
+## Docusaurus Format
+
+- ([#5152](https://github.com/quarto-dev/quarto-cli/issues/5152)): Support for `code-line-numbers: true` in Docusaurus output.
+- ([#6046](https://github.com/quarto-dev/quarto-cli/issues/6046)): Fix citation regression in Docusaurus output.
+- ([#6310](https://github.com/quarto-dev/quarto-cli/issues/6310)): Support Docusaurus 3.0 by rendering to `.mdx` by default.
+- ([#7201](https://github.com/quarto-dev/quarto-cli/issues/7201)): Support for [line highlighting](https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-metadata-string) using `code-line-numbers`, as raw block attributes or code cell options.
+
+## Beamer Format
+
+- ([#3650](https://github.com/quarto-dev/quarto-cli/issues/3650)): Use `classoption=notheorems` to not conflict with Quarto's own theorem environments.
+- ([#5536](https://github.com/quarto-dev/quarto-cli/issues/5536)): Correctly support Code Filename feature for Beamer output by fixing issue with float environment.
+- ([#6041](https://github.com/quarto-dev/quarto-cli/issues/6041)): Correctly support code block appearance options (`code-block-bg` and `code-block-border-left`).
+- ([#6226](https://github.com/quarto-dev/quarto-cli/issues/6226)): Correctly detect the need for an additional compilation for TOC layout when using `lualatex`
+- ([#6956](https://github.com/quarto-dev/quarto-cli/issues/6956)): Add support `number-section` to `format: beamer` to control whether sections are numbered.
+
+## Asciidoc Format
+
+- ([#6589](https://github.com/quarto-dev/quarto-cli/issues/6589)): Don't crash when `format: asciidoc` with a missing title.
+- ([#7632](https://github.com/quarto-dev/quarto-cli/issues/7632)): Render citations properly inside callouts
+
+## Confluence Format
+
+- ([#5151](https://github.com/quarto-dev/quarto-cli/issues/5151)): Provide an informational message about attachment delays when publishing.
+- ([#7256](https://github.com/quarto-dev/quarto-cli/issues/7256)): No undesired newline are created anymore in Callouts.
+
+## Website Listings
+
+- ([#3933](https://github.com/quarto-dev/quarto-cli/issues/3933)): Don't emit base Quarto CSS or theme highlighting CSS when `minimal` is selected.
+- ([#4800](https://github.com/quarto-dev/quarto-cli/issues/4800)): Add support for including an `xml-stylesheet` in listings. Use the `xml-stylesheet: example.xsl` under `feed:` to provide a path to an XSL style sheet to style your RSS feed.
+- ([#5371](https://github.com/quarto-dev/quarto-cli/issues/5371)): Properly compute the trimmed length of descriptions included in listings.
+- ([#5463](https://github.com/quarto-dev/quarto-cli/issues/5463)): Error if the `contents` of a listing match no items.
+- ([#5742](https://github.com/quarto-dev/quarto-cli/issues/5742)): Use any element to compute a description for the listing, even when there are no paragraphs.
+- ([#5802](https://github.com/quarto-dev/quarto-cli/issues/5802)): Don't display the string `undefined` for date values if a listing table displays items without a date.
+- ([#5805](https://github.com/quarto-dev/quarto-cli/issues/5805)): Update the inherited `word-break: break-word` style (Bootstrap) to `word-break: keep-all` to prevent hyphenation of words in listings.
+- ([#6029](https://github.com/quarto-dev/quarto-cli/issues/6029)): Only use the `image-placeholder` for a listing if no other image is available.
+- ([#6091](https://github.com/quarto-dev/quarto-cli/issues/6091)): Don't use remote / absolutes images when auto-discovering images.
+- ([#6268](https://github.com/quarto-dev/quarto-cli/issues/6268)): Enable listings even when `theme: none`
+- ([#6407](https://github.com/quarto-dev/quarto-cli/issues/6407)): Add supporting for the field `word-count` for listing items. It is not displayed by default.
+- ([#6408](https://github.com/quarto-dev/quarto-cli/issues/6408)): Fix error on Windows when using yaml to create a listing with an external (e.g. `path: https://www.quarto.org`)
+- ([#6447](https://github.com/quarto-dev/quarto-cli/issues/6447)): Fix image placholder for pages with more than one listing (or a single listing passed as an array item in yaml)
+- ([#6777](https://github.com/quarto-dev/quarto-cli/issues/6777)): Add support for complex fields like `citation.container-title` when includes custom fields in listings.
+- ([#6903](https://github.com/quarto-dev/quarto-cli/issues/6903)): Don't display the `path` field for external paths provided in metadata files.
+- ([#6904](https://github.com/quarto-dev/quarto-cli/issues/6904)): Within feeds, remove `index.html` from urls which shouldn't include it.
+- ([#7088](https://github.com/quarto-dev/quarto-cli/issues/7088)): Don't emit extraneous link or whitespace in default listing template.
+- ([#7184](https://github.com/quarto-dev/quarto-cli/issues/7184)): Properly use the boostrap variable `pagination-active-color` for coloring pagination controls.
+- ([#7634](https://github.com/quarto-dev/quarto-cli/issues/7634)): Use an explicit width to ensure default listing layout doesn't grow outside its desired boundss
+- ([#7345](https://github.com/quarto-dev/quarto-cli/issues/7345)): Improve display of categories in a table style listing
+- ([#7699](https://github.com/quarto-dev/quarto-cli/issues/7699)): Properly ignore non-HTML output for listings when project level renders render HTML and other formats (for example, a book of both HTML and PDF format)
+- ([#7290](https://github.com/quarto-dev/quarto-cli/issues/7290)): Add support for `feed:type` of `metadata`, which will use only explicitly provided description metadata when generating an RSS feed. Additionally, note that `partial` feed types will prefer to use an explicit description over the first paragraph, when a description is available.
+- Add support for programmatically filtering content from a listing using `include` or `exclude` with glob syntax to include or exclude specific items from the listing. See <https://github.com/quarto-dev/quarto-cli/commit/d415d9ca5b7cb59a8a4750dd3eeb60116b931bd6s>
+- ([#8197](https://github.com/quarto-dev/quarto-cli/issues/8197)): Custom `field-types` are now correctly merged with default values for website listings.
+
+## Websites
+
+- Add support for `navbar > toggle-position` to control whether the responsive navbar toggle appears on the right or the left.
+- Add support for setting `page-navigation: true|false` in either a page or in `_metadata.yml`. This allows individual pages or sections of a website to control whether `page-navigaation` appears.
+- Add support for `bread-crumbs: true|false` to control whether bread crumbs are displayed. Add support for display of breadcrumbs on full width (non-mobile) pages when `bread-crumbs` is true. Default value is true.
+- Add support for `show-item-context` key within the `search` key to control whether page parents are display next to items in search results. Pass `tree`, `parent`, `root`, or boolean (if you pass true, `tree` is the default).
+- ([#3493](https://github.com/quarto-dev/quarto-cli/issues/3493)): Fix issue with website about pages complaining about missing citation when using an `@` in hrefs.
+- ([#4668](https://github.com/quarto-dev/quarto-cli/issues/4668)): Allow per page metadata (front matter or a `_metadata.yml` file) to overide the `repo-url` for a page by providing a `repo-url`
+- ([#4739](https://github.com/quarto-dev/quarto-cli/issues/4739)): Improve handling of reader mode at mobile responsive sizes
+- ([#5204](https://github.com/quarto-dev/quarto-cli/issues/5204)): About pages rely upon TOC being positioned right, so force that to be true
+- ([#5212](https://github.com/quarto-dev/quarto-cli/issues/5212)): Ensure navbar search button respects `collapse-below` and remains aligned properly
+- ([#5251](https://github.com/quarto-dev/quarto-cli/issues/5251)): Allow individual pages to specify `image: false` to prevent image discover for Twitter and Open Graph metadata.
+- ([#5283](https://github.com/quarto-dev/quarto-cli/issues/5283)): Add support for setting `repo-actions: false` in a document to prevent the display of repository actions on a specific page.
+- ([#5389](https://github.com/quarto-dev/quarto-cli/issues/5389)): Allow a website project to provide a default image used in social metadata tags.
+- ([#5503](https://github.com/quarto-dev/quarto-cli/issues/5503)): Fix issue with markdown rendering of href text converting dashes to en/em dashes.
+- ([#5604](https://github.com/quarto-dev/quarto-cli/issues/5604)): Process footer content as blocks.
+- ([#5624](https://github.com/quarto-dev/quarto-cli/issues/5624)): Add support for localized Cookie Consent (using either the document's language or by specifying the language explicitly under the cookie consent key).
+- ([#5625](https://github.com/quarto-dev/quarto-cli/issues/5625)): Prefer the website image (if specified) over undecorated images that appear in the page.
+- ([#5689](https://github.com/quarto-dev/quarto-cli/issues/5689)): Don't use a single sidebar with an id as a global sidebar (the id explicitly means that the sidbar will match pages specifying that id or pages which the sidebar contains).
+- ([#5756](https://github.com/quarto-dev/quarto-cli/issues/5756)): Add `rel="..."` resolution to navbar tools.
+- ([#5763](https://github.com/quarto-dev/quarto-cli/issues/5763)): Add support for a keyboard shortcut to launch search (defaults to `f` or `/`). Use `search` > `keyboard-shortcut` to override with your own key(s).
+- ([#5818](https://github.com/quarto-dev/quarto-cli/issues/5818)): Ensure that `repo-actions` for websites (and books) appear responsively in the footer if the TOC isn't visible.
+- ([#5932](https://github.com/quarto-dev/quarto-cli/issues/5932)): Correct Open Graph metadata key name for `og:site_name`
+- ([#5964](https://github.com/quarto-dev/quarto-cli/issues/5964)): Add support for `repo-link-target` and `repo-link-rel` to control the corresponding attributes of repo-action links.
+- ([#6432](https://github.com/quarto-dev/quarto-cli/issues/6432)): Don't decorate navigation tools with external link icon (we generally don't decorate navigation chrome in this way)
+- ([#6703](https://github.com/quarto-dev/quarto-cli/issues/6703)): Warn users when a `theme` key in a document is being ignored.
+- ([#6704](https://github.com/quarto-dev/quarto-cli/issues/6704)): Use the correct title when there are duplicate sidebar `href` targets
+- ([#6708](https://github.com/quarto-dev/quarto-cli/issues/6708)): Prevent duplication of footnotes within the abstract or description within websites and books.
+- ([#6732](https://github.com/quarto-dev/quarto-cli/issues/6732)): Allow specifying global alt text for social metadata
+- ([#7447](https://github.com/quarto-dev/quarto-cli/issues/7447)): Changing the `$primary` color in a SCSS theme will now properly change the navigation bar background color.
+- ([#7754](https://github.com/quarto-dev/quarto-cli/issues/7754)): Use the site title as the html `title` for a page if no other title is available.
+- ([#8083](https://github.com/quarto-dev/quarto-cli/issues/8083)): Improve About Page layouts when a sidebar is present
+- ([#8150](https://github.com/quarto-dev/quarto-cli/issues/8150)): Correctly support sidebar alignment. Default sidebar text alignment to left.
+- ([#8166](https://github.com/quarto-dev/quarto-cli/issues/8166)): Properly discover 'image' property as a resource when using a project path.
+
+## Website Search
+
+- ([#4531](https://github.com/quarto-dev/quarto-cli/issues/4531)): Section cross references are now properly searchable
+- ([#7105](https://github.com/quarto-dev/quarto-cli/issues/7105)): Improve search results by raising default limit and fixing and removing warning that would appear for Algolia when limit was more than 20.
+- ([#7150](https://github.com/quarto-dev/quarto-cli/issues/7150)): Search keyboard shortcut will not intercept keys directed at inputs.
+- ([#7117](https://github.com/quarto-dev/quarto-cli/issues/7117)): Ensure that search works properly in mobile layouts when not scrolled to top of page (don't close search when scroll occurs because of keyboard being shown).
+- ([#7796](https://github.com/quarto-dev/quarto-cli/issues/7796)): Allow providing placeholder text using the language key `search-text-placeholder`
+
+## Books
+
+- ([#5454](https://github.com/quarto-dev/quarto-cli/issues/5454)): Fix errors previewing with formats such as `asciidoc` are added to book projects.
+- ([#5630](https://github.com/quarto-dev/quarto-cli/issues/5630)): Properly form sharing URL for books
+- ([#6708](https://github.com/quarto-dev/quarto-cli/issues/6708)): Prevent duplication of footnotes within the abstract or description within websites and books.
+- ([#7206](https://github.com/quarto-dev/quarto-cli/issues/7206)): Properly enabled `issue-url` for books
+- ([#8011](https://github.com/quarto-dev/quarto-cli/issues/8011)): Improve support for unsectioned chapters in search.
+- ([#8145](https://github.com/quarto-dev/quarto-cli/issues/8145)): Support localization of book tools (Download, Share, Source Code)
+
+## Publishing
+
+- ([#5436](https://github.com/quarto-dev/quarto-cli/issues/5436)): Add support for publishing to Posit Cloud.
+- ([#5220](https://github.com/quarto-dev/quarto-cli/issues/5220)): Properly respect `output-dir` when publishin individual files in a default Quarto project
+- ([#4498](https://github.com/quarto-dev/quarto-cli/issues/4498)): Better error when `quarto publish gh-pages` fails because `gh-pages` branch does not exist on `origin` remote.
+
+## Video (and Audio)
+
+- ([#5496](https://github.com/quarto-dev/quarto-cli/issues/5496), [#5847](https://github.com/quarto-dev/quarto-cli/issues/5847), [#5268](https://github.com/quarto-dev/quarto-cli/issues/5268)): Properly display local audio and video files with website projects (properly discover the `src` as a resource)
+
+## Preview
+
+- Display render output/progress for previews that take longer than 2 seconds
+- Ability to cancel an executing preview from within the progress UI
+- Automatically render missing formats (e.g. PDF, MS Word) on the fly
+- Correct detection of Hugo project type from `hugo.toml` (in addition to already supported `config.toml`)
+- Only re-use Jupyter kernels for languages that explicitly opt into it
+- ([#4801](https://github.com/quarto-dev/quarto-cli/issues/4801)): Provide a more specific error upon a directory preview of a default project type without a root index file
+- ([#5882](https://github.com/quarto-dev/quarto-cli/issues/5882)): Disable browser cache using `Cache-Control` header config in the viewer redirect for PDF preview, correctly allowing a HTML preview later on same port.
+
+## Jupyter
+
+- Support for executing inline expressions (e.g. `` `{python} x` ``)
+- Improved detection/exclusion of spurious matplotlib plain text output
+- Correctly exclude `id` fields when converting Colab notebooks to qmd.
+- More thorough cleaning out of text artifacts created by matplotlib intermediate statements.
+- Added `ipynb-shell-interactivity` option (enables specification of IPython [`InteractiveShell.ast_node_interactivity`](https://ipython.readthedocs.io/en/stable/config/options/terminal.html#configtrait-InteractiveShell.ast_node_interactivity) option)
+- Only search for Julia conda installation when the engine language is Julia
+- Support for `plotly-connected` option to determine where Plotly is embedded or loaded from CDN
+- Reduce default margins for Plotly figures (t=30,r=0,b=0,l=0)
+- Restart kernel daemon when non-package Python modules change
+- ([#5051](https://github.com/quarto-dev/quarto-cli/issues/5051)): Don't emit strong tag with trailing spaces to not confuse Jupyter MD reader.
+- ([#6344](https://github.com/quarto-dev/quarto-cli/issues/6344)): Somewhat improve the error message in case of YAML parsing errors in metadata of Python code cells.
+- ([#6367](https://github.com/quarto-dev/quarto-cli/issues/6367)): Fix bug with nested code cells in the generation of Jupyter notebook from .qmd files.
+- ([#6393](https://github.com/quarto-dev/quarto-cli/pull/6393)): Search `JULIA_HOME` for Julia-specific Python installations.
+- ([#7016](https://github.com/quarto-dev/quarto-cli/pull/7016)): Ignore directories for which we don't have permissions when searching for unactivated environments.
+- ([#7302](https://github.com/quarto-dev/quarto-cli/issues/7302)): Avoid name collisions when embedding output from multiple notebooks in a Quarto document
+- ([#7512](https://github.com/quarto-dev/quarto-cli/issues/7512)): Improved error message listing known kernels, when a kernel set with `jupyter` key in YAML is not found.
+- ([#7548](https://github.com/quarto-dev/quarto-cli/issues/7548)): Don't use `fig_format="png"` in Julia's CairoMakie because of interaction with `display()`
+- ([#7607](https://github.com/quarto-dev/quarto-cli/issues/7607)): Make `output: asis` behave the same way as the `knitr` engine, emitting div enclosures when necessary.
+- ([#5363](https://github.com/quarto-dev/quarto-cli/issues/5363)): Fix issue caused by Quarto incorrectly using some headings as a title when reading notebooks.
+- ([#6411](https://github.com/quarto-dev/quarto-cli/issues/6411)): Don't perform notebook title fixup if the project is providing a title.
+
+## Knitr
+
+- ([#4735](https://github.com/quarto-dev/quarto-cli/pull/4735)): Special `verbatim` and `embed` language engine for knitr's chunk are now better supported, including with special quarto cell option like `echo: fenced`.
+- ([#5506](https://github.com/quarto-dev/quarto-cli/issues/5506)): Fix error in if-statement when `knitr::asis_output(x)` is used with `length(x) != 1` (author: @rcannood).
+- ([#6775](https://github.com/quarto-dev/quarto-cli/pull/6775)): Avoid duplicating special internal `tools:quarto` R environment used for making `ojs_define()` accessible during knitting.
+- ([#6792](https://github.com/quarto-dev/quarto-cli/issues/6792)): `fig-asp` provided at YAML config level now correctly work to set `fig.asp` chunk option in **knitr**.
+- ([#7002](https://github.com/quarto-dev/quarto-cli/issues/7002)): `layout-valign` is correctly forwarded to HTML to tweak vertical figure layout alignment for computational figures.
+- ([#5994](https://github.com/quarto-dev/quarto-cli/issues/5994)): Options like `include` or `echo` for `ojs` or `mermaid` cells are now correctly handled with knitr engine.
+- ([#4869](https://github.com/quarto-dev/quarto-cli/issues/4869)): `sql` cell output has now correct Quarto treatment so that specific features like `column: margin` works.
+- ([#7600](https://github.com/quarto-dev/quarto-cli/issues/7600)): `output: asis` now correctly don't emit `.cell-output-display` div around cell outputs of class `knit_asis`.
+- ([#7877](https://github.com/quarto-dev/quarto-cli/issues/7877)): `crop: false` chunk options allows to opt out (per chunk or globally) automatic cropping in PDF when `pdfcrop` and `ghostscript` are detected. This complements knitr's way `crop: null`.
+- ([#7943](https://github.com/quarto-dev/quarto-cli/issues/7943)): Internal Quarto R function should not leak to user's global environment.
+- ([#7029](https://github.com/quarto-dev/quarto-cli/issues/7029)): Fix issue with some encoding while reading configuration in R.
+
+## OJS engine
+
+- Update observablehq's runtime to version 5.6.0.
+- ([#4927](https://github.com/quarto-dev/quarto-cli/issues/4927)): Add support for `code-summary` option in OJS code cells.
+- ([#5215](https://github.com/quarto-dev/quarto-cli/issues/5215)): Report CORS requests as plain text when serving single-file previews.
+- ([#6267](https://github.com/quarto-dev/quarto-cli/issues/6267)): Fix error message when running in `file://`.
+- ([#7537](https://github.com/quarto-dev/quarto-cli/issues/7537)): Code annotations works better with OJS cells.
+- ([#7747](https://github.com/quarto-dev/quarto-cli/issues/7747)): Fix `FileAttachment` path resolution to work with `revealjs` format (and more generally, URLs that have a non-empty hash).
+- ([#8071](https://github.com/quarto-dev/quarto-cli/issues/8071)): Add support to `hugo-md` as an output format.
+
+## Mermaid diagrams
+
+- Upgrade to 10.2.0-rc.2
+- ([#5426](https://github.com/quarto-dev/quarto-cli/issues/5426)): Don't escape mermaid output in markdown formats (author: @rcannood).
+
+## Code Annotations
+
+- ([#5339](https://github.com/quarto-dev/quarto-cli/issues/5339)): Improve behavior of code annotations when present on scrollable slides
+- ([#6016](https://github.com/quarto-dev/quarto-cli/issues/6016)): Ensure that annotations are on the correct line in Safari
+- ([#6385](https://github.com/quarto-dev/quarto-cli/issues/6385)): Add support for code annotation in fenced code cells
+- ([#7056](https://github.com/quarto-dev/quarto-cli/issues/7056)): Only make content of the hover annotation scrollable if it necessary
+- ([#7435](https://github.com/quarto-dev/quarto-cli/issues/7435)): Use `#` as a fallback comment character for unknown languages
+- Add support for OCaml code annotations
+
+## Author and Affiliations
+
+- Add support for specifying author `roles`, with optional support for degree of contribution and automatic normalization of CreDiT roles, when applicable.
+- Improved support for affiliation metadata, including `ringgold`, `isni`, `ror`
+- Add support for `funding`, including support for simple strings or funding including `source`, `recipient`, and `investigator`. `source` and `recipient` may
+  -be one or more simple strings, `ref`s to an author or affiliation id, or an object following the `institution` schema.
+- ([#5764](https://github.com/quarto-dev/quarto-cli/issues/5764)): Add support for affiliations to include a `group` property to represent the team or research group within the affiliation
+- ([#6068](https://github.com/quarto-dev/quarto-cli/issues/6068)): Properly display author names in default commonmark and gfm output
+- ([#6138](https://github.com/quarto-dev/quarto-cli/issues/6138)): Add support for `degrees` to specify academic titles or professional certifications displayed following a personal name (for example, "MD", "PhD").
+- ([#6139](https://github.com/quarto-dev/quarto-cli/issues/6139)): For markdown output that will not include yaml front matter, still perform author normalization. When `yaml_metadata_block` is enabled (or for pandoc markdown) do not normalize author front matter since that will result in extraneous author keys.
+
+## Lua filters
+
+- Add support for relative paths in `require()` calls.
+- Add support `quarto.doc.add_resource` and `quarto.doc.add_supporting`. `add_resource` will add a resource file to the current render, copying that file to the same relative location in the output directory. `add_supporting` will add a supporting file to the current render, moving that file file to the same relative location in the output directory.
+- ([#5242](https://github.com/quarto-dev/quarto-cli/issues/5242)): Add line numbers to error messages.
+- ([#5461](https://github.com/quarto-dev/quarto-cli/issues/5461)): ensure return type of `stripTrailingSpace` is always `pandoc.List`.
+- ([#5466](https://github.com/quarto-dev/quarto-cli/issues/5466)): Provide global environment `_G` to user filters.
+- ([#6211](https://github.com/quarto-dev/quarto-cli/pull/6211)): Improve error message when a JSON filter (or a potentially misspelled Lua filter from an extension) is not found.
+- ([#6215](https://github.com/quarto-dev/quarto-cli/issues/6215)): Add `quarto.utils.string_to_inlines` and `quarto.utils.string_to_blocks` to Lua API to convert a string to a list of inlines or blocks taking into account quarto's AST structure.
+- ([#6289](https://github.com/quarto-dev/quarto-cli/issues/6289)): allow `markdownToInlines` to take empty string.
+- ([#6935](https://github.com/quarto-dev/quarto-cli/issues/6935)): Add isGithubMarkdownOutput() to quarto.format API.
+- ([#6935](https://github.com/quarto-dev/quarto-cli/issues/6935)): render callouts to `gfm` using GitHub's syntax.
+- ([#7067](https://github.com/quarto-dev/quarto-cli/issues/7067)): Add new entry points to user Lua filters. See <https://quarto.org/docs/prerelease/1.4/lua_changes.html>.
+- ([#7083](https://github.com/quarto-dev/quarto-cli/issues/7083)): Separate custom node handlers for Span and Div nodes, enabling conditional content spans (author: @knuesel)
+
+## Debian Installer
+
+- ([#3785](https://github.com/quarto-dev/quarto-cli/issues/3785)): Recommend installation of `unzip`, which is used when installed extensions.
+- ([#5167](https://github.com/quarto-dev/quarto-cli/issues/5167)): Don't fail installation if symlink cannot be created in path.
+
+## Citable Articles
+
+- ([#6766](https://github.com/quarto-dev/quarto-cli/issues/6766)): Add `id` as valid CSL property when specifying a documents citation metadata.
+
+## Crossrefs
+
+- ([#2551](https://github.com/quarto-dev/quarto-cli/issues/2551)): Support crossreferenceable figures without captions.
+- ([#6620](https://github.com/quarto-dev/quarto-cli/issues/6620)): Introduce `FloatRefTarget` AST nodes that generalize crossref targets to include figures, tables, and custom floating elements.
+- ([#7200](https://github.com/quarto-dev/quarto-cli/issues/7200)): Support Unicode in subref labels.
+
+## Input format
+
+- ([#7905](https://github.com/quarto-dev/quarto-cli/issues/7905)): Use `html+raw_html` as input format when processing HTML rawblocks for tables to avoid Pandoc converting SVG elements to images.
+
+## Extensions
+
+- When installing an extension, offer to open documentation explaining usage.
+- ([#4889](https://github.com/quarto-dev/quarto-cli/issues/4889)): Improve error message when attempting to create a duplicate extension
+- ([#6759](https://github.com/quarto-dev/quarto-cli/issues/6759)): Properly support format extensions controlling the order of filters that they use
+- ([#7375](https://github.com/quarto-dev/quarto-cli/issues/7375)): Updating extensions will now remove files that are not present in newer versions of an extension.
+- ([#7886](https://github.com/quarto-dev/quarto-cli/issues/7886)): Better support installation of extensions and usage of templates from repos which have been renamed.
+- ([#7909](https://github.com/quarto-dev/quarto-cli/issues/7909)): Properly resolve filter extensions even when a directory of the same name exists.
+
+## Other Fixes and Improvements
+
+- Exit if project pre or post render script fails
+- Support `--output-dir` for rendering individual files.
+- Use InternalError in typescript code, and offer a more helpful error message when an internal error happens.
+- ([#1173](https://github.com/quarto-dev/quarto-cli/issues/1173)): Allow specifying margin caption location on a per cell basis
+- ([#1237](https://github.com/quarto-dev/quarto-cli/issues/1237)): Allow `include` shortcodes to be resolved from inside non-executable code cells and metadata blocks.
+- ([#1392](https://github.com/quarto-dev/quarto-cli/issues/1392)): Add tools and LaTeX information to `quarto check` output.
+- ([#2214](https://github.com/quarto-dev/quarto-cli/issues/2214), reopened): don't report a non-existing version of Google Chrome in macOS.
+- ([#3599](https://github.com/quarto-dev/quarto-cli/issues/3599), [#5870](https://github.com/quarto-dev/quarto-cli/issues/5870)): Fix hash issue causing unexpected render when `freeze` is activated on Windows but re-rendered on Linux (e.g. in Github Action).
+- ([#4614](https://github.com/quarto-dev/quarto-cli/issues/4614)): Correctly remove empty mediabag directory in remote drives.
+- ([#4673](https://github.com/quarto-dev/quarto-cli/issues/4673)): Quarto now report in check and error message if **rmarkdown** R package minimal requirement (>= 2.3) is not fullfilled, and it will ask to update the package.
+- ([#4820](https://github.com/quarto-dev/quarto-cli/issues/4820)): Add support for setting the Giscus light/dark themes.
+- ([#5377](https://github.com/quarto-dev/quarto-cli/issues/5377)): support `from: ` formats correctly.
+- ([#5421](https://github.com/quarto-dev/quarto-cli/pull/5421)): Correct `quarto --help` command to provide correct commands and descriptions
+- ([#5444](https://github.com/quarto-dev/quarto-cli/issues/5444)): Introduce a build command `make-installer-dir` to better support third party packaging without dependencies. Fine tuning of code/patch provided in https://github.com/conda-forge/quarto-feedstock/pull/7.
+- ([#5748](https://github.com/quarto-dev/quarto-cli/issues/5748)): Don't cleanup shared lib_dir files when using `embed-resources` within a project
+- ([#5755](https://github.com/quarto-dev/quarto-cli/pull/5755)): Allow document metadata to control conditional content.
+- ([#5785](https://github.com/quarto-dev/quarto-cli/issues/5785)): Don't process juptyer notebook markdown into metadata when embedding notebooks into documents.
+- ([#5902](https://github.com/quarto-dev/quarto-cli/issues/5902)): Support paired shortcode syntax.
+- ([#6013](https://github.com/quarto-dev/quarto-cli/issues/6013)): Don't error if citation is passed as a boolean value in metadata via flags
+- ([#6042](https://github.com/quarto-dev/quarto-cli/issues/6042)): Correctly support empty lines in YAML blocks.
+- ([#6142](https://github.com/quarto-dev/quarto-cli/issues/6142)): Properly respect `DENO_DIR` when set
+- ([#6154](https://github.com/quarto-dev/quarto-cli/issues/6154)): `quarto check knitr` does not fail anymore when user's `.Rprofile` contains `cat()` calls.
+- ([#6178](https://github.com/quarto-dev/quarto-cli/pull/6178)): When `QUARTO_LOG_LEVEL=DEBUG`, information about search for a R binary will be shown.
+- ([#6207](https://github.com/quarto-dev/quarto-cli/issues/6207)): When QUARTO_R is set to a non-existing path, a warning is now thrown like with QUARTO_PYTHON. Quarto still fallback to search a working R version.
+- ([#6244](https://github.com/quarto-dev/quarto-cli/issues/6244)): Code annotation now works for executable code cells using `echo: fenced`. Also it now supports HTML and Markdown code cells.
+- ([#6269](https://github.com/quarto-dev/quarto-cli/issues/6259)): Fix issue with YAML validation where the annotated value was incorrectly built.
+- ([#6487](https://github.com/quarto-dev/quarto-cli/discussions/6487)): Fix `serviceworkers` check in `htmlDependency` to look at the correct key.
+- ([#6568](https://github.com/quarto-dev/quarto-cli/issues/6568)): Trim file extension in data URI that might have been inadvertently added by Pandoc.
+- ([#6620](https://github.com/quarto-dev/quarto-cli/pull/6620)): Rewrite Crossreferenceable figure support. See the [prerelease documentation](https://quarto.org/docs/prerelease/1.4/) for more information.
+- ([#6697](https://github.com/quarto-dev/quarto-cli/pull/6697)): Fix issue with outputing to stdout (`quarto render <file> -o -`) on Windows.
+- ([#6705](https://github.com/quarto-dev/quarto-cli/pull/6705)): Fix issue with gfm output being removed when rendered with other formats.
+- ([#6746](https://github.com/quarto-dev/quarto-cli/issues/6746)): Let stdout and stderr finish independently to avoid deadlock.
+- ([#6807](https://github.com/quarto-dev/quarto-cli/pull/6807)): Improve sourcemapping reference cleanup in generated CSS files.
+- ([#6825](https://github.com/quarto-dev/quarto-cli/issues/6825)): Show filename when YAML parsing error occurs.
+- ([#6836](https://github.com/quarto-dev/quarto-cli/issues/6836)): Fix missing `docx` format for `abstract` key in reference schema.
+- ([#7013](https://github.com/quarto-dev/quarto-cli/issues/7013)): Improve error message when there is an issue finding or running R and add more verbosity in [verbose mode](https://quarto.org/docs/troubleshooting/#verbose-mode).
+- ([#7032](https://github.com/quarto-dev/quarto-cli/issues/7032)): `quarto` is now correctly working when installed in a folder with spaces in path.
+- ([#7131](https://github.com/quarto-dev/quarto-cli/issues/7131)): Fix typo in ISBN entry for JATS subarticle template (author: @jasonaris).
+- ([#7252](https://github.com/quarto-dev/quarto-cli/issues/7252)): Improve handling with `tlmgr` of some mismatched LaTeX support files, associated with `expl3.sty` loading.
+- ([#7502](https://github.com/quarto-dev/quarto-cli/pull/7502)): Correct `execute-debug` help text
+- ([#7674](https://github.com/quarto-dev/quarto-cli/pull/7674)): Configure font paths for TinyTeX after installation so that `xetex` can find custom fonts correctly.
+- ([#7675](https://github.com/quarto-dev/quarto-cli/pull/7675)): On Windows, `quarto install tinytex` will install TinyTeX to the directory defined by the environment variable `ProgramData` when `APPDATA` is not a suitable location for TeX Live.
+- ([#8086](https://github.com/quarto-dev/quarto-cli/issues/8086)): Add support for indexing array metadata in `meta` shortcode.
+- ([#8245](https://github.com/quarto-dev/quarto-cli/issues/8245)): On Windows, prevent Quarto error due to access issue when trying to read codepage from registry.

--- a/docs/download/changelog/1.4/index.qmd
+++ b/docs/download/changelog/1.4/index.qmd
@@ -1,0 +1,7 @@
+---
+title: "1.4 Release Notes"
+format: html
+---
+
+{{< include _changelog.md >}}
+

--- a/docs/download/index.qmd
+++ b/docs/download/index.qmd
@@ -25,28 +25,34 @@ listing:
       title: v1.4.557
       date: 2024/06/27
       path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.4.557
+      changelog: "[Release Notes](changelog/1.4/)"
     - id: version13
       title: v1.3.450
       date: 2023/08/23
       path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.3.450
+      changelog: "[Release Notes](changelog/1.3/)"
     - id: version12
       title: v1.2.475
       date: 2023/03/22
       path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.2.475
+      changelog: "[Release Notes](changelog/1.2/)"
     - id: version11
       title: v1.1.189
       date: 2022/09/04
       path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.1.189
+      changelog: "[Release Notes](changelog/1.1/)"
     - id: version10
       title: v1.0.38
       date: 2022/08/04
       path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.0.38
   fields: 
     - title
+    - changelog
     - date
     - path
   field-display-names: 
     path: "Url"
+    changelog: "Release Notes"
   field-links: 
     - path
     - title

--- a/docs/download/prerelease.qmd
+++ b/docs/download/prerelease.qmd
@@ -17,6 +17,8 @@ toc: false
 anchor-sections: false
 editor: source
 image: /images/hero_right.png
+aliases:
+  - changelog/1.6/
 ---
 
 ::: {.content-visible when-profile="prerelease"}

--- a/docs/download/release.qmd
+++ b/docs/download/release.qmd
@@ -16,6 +16,8 @@ toc: false
 anchor-sections: false
 editor: source
 image: /images/hero_right.png
+aliases:
+  - changelog/1.5/
 ---
 
 {{< include _download.md >}}


### PR DESCRIPTION
A rather manual take on having release notes in permanent locations on quarto.org of the form `quarto.org/docs/download/changelog/1.*/` (e.g. [1.4](https://deploy-preview-1250.quarto.org/docs/download/changelog/1.4/)). 

Available via links from "Older Releases" tab. Current and prerelease are aliased to their respective pages.

We would have to add the following tasks to the release checklist:

* Copy `changelog` from old release to `_changelog.md` in `docs/download/changelog/1.x`

* Copy `docs/download/changelog/1.*/index.qmd` and increment versions

* Add new item to `download-older` listing in `docs/download/index.qmd` 
  
* Increment version in `aliases` of:
   - `docs/download/release.qmd`
   - `docs/download/prerelease.qmd`


Would close https://github.com/quarto-dev/quarto-cli/issues/5396