### PR TITLE
Add `leg-cite` filter

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -421,3 +421,9 @@
   author: "[Andrew Bray](https://github.com/andrewpbray/)"
   description: |
     Publish blog posts or web pages on a schedule.
+
+- name: leg-cite
+  path: https://github.com/blackerby/leg-cite
+  author: "[William Blackerby](https://github.com/blackerby)"
+  description: |
+    US federal legislation citation macros: expands citations into links to Congress.gov


### PR DESCRIPTION
This filter implements citation macros for United States House and Senate bills, resolutions, and amendments. Given a short citation like `118hr8070` between curly brackets (a.k.a. braces &mdash; `{}`),  the rendered Quarto document will display a link to the bill, resolution, or amendment referenced by the citation on Congress.gov.