### PR TITLE
[revealjs] Mention `title-fancy/title-slide.html` as the partial starter to use for the title slide.

### DIFF
--- a/docs/journals/templates.qmd
+++ b/docs/journals/templates.qmd
@@ -211,7 +211,7 @@ template.html
 
 title-slide.html
 
-:   HTML used for the presentation title slide.
+:   HTML used for the presentation title slide. Quarto uses by default a fancier `title-slide.html` partial leveraging [Authors & Affiliations](/docs/journals/authors.qmd) handling that should be used as a starter if you want to tweak this partials. See [source code here](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-fancy/title-slide.html).
 
 toc-slide.html
 

--- a/docs/journals/templates.qmd
+++ b/docs/journals/templates.qmd
@@ -211,7 +211,7 @@ template.html
 
 title-slide.html
 
-:   HTML used for the presentation title slide. Quarto uses by default a fancier `title-slide.html` partial leveraging [Authors & Affiliations](/docs/journals/authors.qmd) handling that should be used as a starter if you want to tweak this partials. See [source code here](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-fancy/title-slide.html).
+:   HTML used for the presentation title slide. By default, Quarto uses a fancy `title-slide.html` partial that leverages [Authors & Affiliations](/docs/journals/authors.qmd) handling. Use the `title-slide.html` [source code](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-fancy/title-slide.html) as a starter if you want to tweak this partial.
 
 toc-slide.html
 

--- a/docs/presentations/revealjs/advanced.qmd
+++ b/docs/presentations/revealjs/advanced.qmd
@@ -37,9 +37,9 @@ format:
       - title-slide.html
 ```
 
-Quarto natively supports an improved title slide which improves handling of author and affiliations. While it is backward compatible with ‘author’ and ‘institute’, we now recommend that you use standard authors metadata, which will render properly. To provide your own partials for `title-slide.html`, you can start from the source code for this [fancier title slide template partial](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-fancy/title-slide.html). Customize this template as required, then save the results to `title-slide.html` alongside your presentation. 
+Quarto natively supports a title slide which improves the handling of authors and affiliations. While it is backward compatible with `author` and `institute`, we now recommend that you use standard [author metadata](/docs/authoring/front-matter.qmd#authors-and-affiliations). To provide your own partial for `title-slide.html`, you can start from the source code for this [fancier title slide template](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-fancy/title-slide.html). Customize this template as required, then save the results to `title-slide.html` alongside your presentation. 
 
-If you prefer the pandoc's default for revealjs (that can be opt-in without setting custom `template-partials` using `title-slide-style: pandoc`), here is the source code for this [simpler title slide template partial](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-slide.html). Though this one does not leverage our improved handling for [Authors & Affiliations](/docs/journals/authors.qmd), so we recommend using the fancy one as a starter. 
+If you prefer pandoc's default title slide you can opt-in using `title-slide-style: pandoc` in your YAML --- this uses this [simpler title slide template partial](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-slide.html). However, this simpler partial does not leverage our improved handling for [Authors & Affiliations](/docs/journals/authors.qmd), so we recommend using the fancy one as a starter for custom title slides. 
 
 ## Slide Transitions
 

--- a/docs/presentations/revealjs/advanced.qmd
+++ b/docs/presentations/revealjs/advanced.qmd
@@ -37,8 +37,9 @@ format:
       - title-slide.html
 ```
 
-Here is the source code for the [default title slide template partial](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-slide.html). Customize this template as required, then save the results to `title-slide.html` alongside your presentation. 
+Quarto natively supports an improved title slide which improves handling of author and affiliations. While it is backward compatible with ‘author’ and ‘institute’, we now recommend that you use standard authors metadata, which will render properly. To provide your own partials for `title-slide.html`, you can start from the source code for this [fancier title slide template partial](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-fancy/title-slide.html). Customize this template as required, then save the results to `title-slide.html` alongside your presentation. 
 
+If you prefer the pandoc's default for revealjs (that can be opt-in without setting custom `template-partials` using `title-slide-style: pandoc`), here is the source code for this [simpler title slide template partial](https://github.com/quarto-dev/quarto-cli/blob/main/src/resources/formats/revealjs/pandoc/title-slide.html). Though this one does not leverage our improved handling for [Authors & Affiliations](/docs/journals/authors.qmd), so we recommend using the fancy one as a starter. 
 
 ## Slide Transitions
 


### PR DESCRIPTION
This partials is the default one for Quarto using authors and affiliations normalization. This is the one to use as a starter.

Introduced initially in https://github.com/quarto-dev/quarto-cli/commit/9e280991de9cefac47d2088bae4ee620fa752e2a

Closes https://github.com/quarto-dev/quarto-cli/issues/10308

@cwickham asking for review for wording and other style and form comment. 
We can also improved all this when dealing with 
- https://github.com/quarto-dev/quarto-cli/issues/5194