### PR TITLE
Update version info and links in licences

### DIFF
--- a/license.qmd
+++ b/license.qmd
@@ -20,3 +20,4 @@ Quarto also makes use of several other open-source projects, the distribution of
 | [Dart Sass](https://sass-lang.com/dart-sass)                  | [MIT](https://github.com/sass/dart-sass/blob/main/LICENSE)               |
 | [Observable Runtime](https://github.com/observablehq/runtime) | [ISC](https://github.com/observablehq/runtime/blob/main/LICENSE)         |
 | [Typst](https://typst.app/docs/)                              | [Apache License 2.0](https://github.com/typst/typst/blob/main/LICENSE)   |
+| [Juice](https://github.com/Automattic/juice)                  | [MIT](https://github.com/Automattic/juice/blob/master/LICENSE.md)        |

--- a/license.qmd
+++ b/license.qmd
@@ -10,12 +10,13 @@ Quarto is a registered trademark of Posit. Please see our [trademark policy](tra
 
 Quarto also makes use of several other open-source projects, the distribution of which is subject to their respective licenses. Major components and their licenses include:
 
-| Project                                                       | License                                                            |
-|---------------------------------------------------------------|--------------------------------------------------------------------|
-| [Pandoc](https://pandoc.org/)                                 | [GNU GPL v2](https://github.com/jgm/pandoc/blob/master/COPYING.md) |
-| [Bootstrap 5](https://getbootstrap.com/)                      | [MIT](https://github.com/twbs/bootstrap/blob/main/LICENSE)         |
-| [Bootswatch 5](https://bootswatch.com/)                       | [MIT](https://github.com/thomaspark/bootswatch/blob/v5/LICENSE)    |
-| [Deno](https://deno.land/)                                    | [MIT](https://github.com/denoland/deno/blob/main/LICENSE.md)       |
-| [esbuild](https://esbuild.github.io/)                         | [MIT](https://github.com/evanw/esbuild/blob/master/LICENSE.md)     |
-| [Dart Sass](https://sass-lang.com/dart-sass)                  | [MIT](https://github.com/sass/dart-sass/blob/main/LICENSE)         |
-| [Observable Runtime](https://github.com/observablehq/runtime) | [ISC](https://github.com/observablehq/runtime/blob/main/LICENSE)   |
+| Project                                                       | License                                                                  |
+|---------------------------------------------------------------|--------------------------------------------------------------------------|
+| [Pandoc](https://pandoc.org/)                                 | [GNU GPL v2](https://github.com/jgm/pandoc/blob/master/COPYING.md)       |
+| [Bootstrap 5](https://getbootstrap.com/)                      | [MIT](https://github.com/twbs/bootstrap/blob/main/LICENSE)               |
+| [Bootswatch 5](https://bootswatch.com/)                       | [MIT](https://github.com/thomaspark/bootswatch/blob/v5/LICENSE)          |
+| [Deno](https://deno.land/)                                    | [MIT](https://github.com/denoland/deno/blob/main/LICENSE.md)             |
+| [esbuild](https://esbuild.github.io/)                         | [MIT](https://github.com/evanw/esbuild/blob/master/LICENSE.md)           |
+| [Dart Sass](https://sass-lang.com/dart-sass)                  | [MIT](https://github.com/sass/dart-sass/blob/main/LICENSE)               |
+| [Observable Runtime](https://github.com/observablehq/runtime) | [ISC](https://github.com/observablehq/runtime/blob/main/LICENSE)         |
+| [Typst](https://typst.app/docs/)                              | [Apache License 2.0](https://github.com/typst/typst/blob/main/LICENSE)   |

--- a/license.qmd
+++ b/license.qmd
@@ -13,8 +13,8 @@ Quarto also makes use of several other open-source projects, the distribution of
 | Project                                                       | License                                                            |
 |---------------------------------------------------------------|--------------------------------------------------------------------|
 | [Pandoc](https://pandoc.org/)                                 | [GNU GPL v2](https://github.com/jgm/pandoc/blob/master/COPYING.md) |
-| [Bootstrap 5.1](https://getbootstrap.com/docs/5.1/)           | [MIT](https://github.com/twbs/bootstrap/blob/v5.1.3/LICENSE)       |
-| [Bootswatch 5.1](https://bootswatch.com/)                     | [MIT](https://github.com/thomaspark/bootswatch/blob/v5/LICENSE)    |
+| [Bootstrap 5](https://getbootstrap.com/)                      | [MIT](https://github.com/twbs/bootstrap/blob/main/LICENSE)         |
+| [Bootswatch 5](https://bootswatch.com/)                       | [MIT](https://github.com/thomaspark/bootswatch/blob/v5/LICENSE)    |
 | [Deno](https://deno.land/)                                    | [MIT](https://github.com/denoland/deno/blob/main/LICENSE.md)       |
 | [esbuild](https://esbuild.github.io/)                         | [MIT](https://github.com/evanw/esbuild/blob/master/LICENSE.md)     |
 | [Dart Sass](https://sass-lang.com/dart-sass)                  | [MIT](https://github.com/sass/dart-sass/blob/main/LICENSE)         |


### PR DESCRIPTION
Following discussion at https://github.com/quarto-dev/quarto-cli/discussions/10319#discussioncomment-10084294, we noticed this page was outdated regarding some version information. 

This PR update it, and add two more entries of tools we ship and use as external tooling 
- Typst for PDF generation
- Juice that we call from Pandoc Lua directly. 

Opening this PR to confirm we want to mentioned them like this. 

Preview: https://deploy-preview-1269.quarto.org/license.html