### PR TITLE
Remove link to Twitter account

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,9 +43,6 @@ website:
       - text: "Trademark"
         href: trademark.qmd
     right:
-      - icon: twitter
-        href: https://twitter.com/quarto_pub
-        aria-label: Quarto Twitter
       - icon: github
         href: https://github.com/quarto-dev/quarto-cli
         aria-label: Quarto GitHub


### PR DESCRIPTION
The quarto account at formerly-known-as-Twitter is not beeing updated anymore, so it should not be linked prominently.