### PR TITLE
Update shortcodes-and-filters.yml (Adds typst-function filter)

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -433,3 +433,9 @@
   author: "[Mickaël CANOUIL](https://github.com/mcanouil)"
   description: |
     Use GitHub short references (commits, issues, discussions, and pull request) directly into your Quarto documents.
+
+- name: typst-function
+  path: https://github.com/christopherkenny/typst-function
+  author: "[Christopher T. Kenny](https://github.com/christopherkenny)"
+  description: |
+    Output divs and spans as Typst functions.


### PR DESCRIPTION
This adds a filter for Typst functions to the filter listing. It is analogous to the `latex-environment` filter, but for Typst. Licensed under MIT, as some code is directly adapted from the `latex-environment` filter.