### PR TITLE
fix: update language key for search box placeholder

### DIFF
--- a/docs/websites/website-search.qmd
+++ b/docs/websites/website-search.qmd
@@ -34,12 +34,12 @@ The `textbox` option displays search like this:
 
 ![](images/navbar-textbox.png){.border .column-page-outset-right fig-alt="Algolia search with textbox in navbar. The search dialog opens as a dropdown in the right-hand side of the screen as an expansion of the textbox."}
 
-When the search is displayed as a textbox, by default, there is no placeholder text. You can specify placeholder text using the `search-box-placeholder` key of the `language` option (note that this is at the top-level, not inside the `website` option):
+When the search is displayed as a textbox, by default, there is no placeholder text. You can specify placeholder text using the `search-text-placeholder` key of the `language` option (note that this is at the top-level, not inside the `website` option):
 
 ::: {layout-ncol="2"}
 ``` yaml
 language: 
-  search-box-placeholder: Search
+  search-text-placeholder: Search
 ```
 
 ![](images/search-placeholder-text.png){fig-alt="Search box showing the placeholder text 'Search'."}


### PR DESCRIPTION
The language key for the search box placeholder has been updated from `search-box-placeholder` to `search-text-placeholder`. This ensures that the correct language key is documented.

Fixes quarto-dev/quarto-cli#10485