### PR TITLE
Spelling Edit - Missing Word

### DIFF
--- a/docs/output-formats/page-layout.qmd
+++ b/docs/output-formats/page-layout.qmd
@@ -52,7 +52,7 @@ Full layout uses the article grid system, but automatically expands the content 
 page-layout: custom
 ```
 
-Custom layout provides a simple HTML content container with no default grid system, padding, or margins. The default HTML framing provided will look this:
+Custom layout provides a simple HTML content container with no default grid system, padding, or margins. The default HTML framing provided will look like this:
 
 ``` html
 <div class="page-layout-custom">


### PR DESCRIPTION
The word "like" was missing from the sentence on the following example.