### PR TITLE
HTML tables: add info about caption and bootstrap classes

### DIFF
--- a/docs/authoring/tables.qmd
+++ b/docs/authoring/tables.qmd
@@ -585,6 +585,41 @@ Markdown supports specification of alignment by column, but does not allow setti
 ```
 ````
 
+### Caption and Bootstrap classes
+
+If you want to add a caption to an HTML table, you can put the table in a div and assign it a label (below it's `#tbl-html`), and finally insert the caption after the table.<br>
+If you want to add a bootstrap class, just do it in the HTML itself.<br>
+Below is an example with both applied.
+
+````markdown
+:::{#tbl-html}
+
+```{=html}
+<table class="table-striped">
+  <tr>
+    <th>Name</th>
+    <th>Age</th>
+  </tr>
+  <tr>
+    <td>John Doe</td>
+    <td>30</td>
+  </tr>
+  <tr>
+    <td>Jane Smith</td>
+    <td>25</td>
+  </tr>
+  <tr>
+    <td>Emily Johnson</td>
+    <td>40</td>
+  </tr>
+</table>
+```
+
+My html table caption
+
+:::
+````
+
 ## Disabling Quarto Table Processing
 
 It's possible that Quarto's processing of HTML tables may interfere with the HTML produced computationally with table packages in R and Python (or other supported languages).


### PR DESCRIPTION
This information is not present and in my opinion is best not given as obvious. I would add them