### PR TITLE
docs: add note and example on how to reuse a sidebar for a page

### DIFF
--- a/docs/websites/website-navigation.qmd
+++ b/docs/websites/website-navigation.qmd
@@ -377,7 +377,13 @@ website:
       title: "Reference"
       contents: 
         # navigation items
-    
+```
+
+To use a specific sidebar on a page or a group of pages, specify the `sidebar` ID in the front matter of the page or in the `_metadata.yml` file.
+For example, to include the tutorials sidebar, from the above example, on a page, add the following to the page's front matter:
+
+```yaml
+sidebar: tutorials
 ```
 
 ## Breadcrumbs


### PR DESCRIPTION
This pull request adds a note and example to the documentation on how to reuse a sidebar for a page. It explains how to specify the `sidebar` ID in the front matter of a page or in the `_metadata.yml` file to include a specific sidebar. An example is provided to demonstrate how to include the tutorials sidebar on a page.

- https://github.com/quarto-dev/quarto-cli/discussions/10707
- https://github.com/quarto-dev/quarto-cli/discussions/8117