### PR TITLE
fix: remove typo from index page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -91,7 +91,7 @@ Combine Jupyter notebooks with flexible options to produce production quality ou
 
 <div class="tab-pane fade" id="knitr" role="tabpanel" aria-labelledby="knitr-tab">
 
-Quarto is a multi-language, next generation version of R Markdown from Posit, with many new new features and capabilities. Like R Markdown, Quarto uses [knitr](https://yihui.org/knitr/) to execute R code, and is therefore able to render most existing Rmd files without modification.
+Quarto is a multi-language, next generation version of R Markdown from Posit, with many new features and capabilities. Like R Markdown, Quarto uses [knitr](https://yihui.org/knitr/) to execute R code, and is therefore able to render most existing Rmd files without modification.
 
 ::: {.grid}
 ::: {.g-col-lg-6 .g-col-12}


### PR DESCRIPTION
Hi, there's a typo on the index page in the R section. It's a simple fix, so it should be ready to go.