### PR TITLE
docs: make bracketed inline code the default syntax

### DIFF
--- a/docs/get-started/computations/rstudio.qmd
+++ b/docs/get-started/computations/rstudio.qmd
@@ -262,15 +262,10 @@ mean_hwy <- round(mean(mpg$hwy), 2)
 
 Then, add the following markdown text to your Quarto document.
 
-```{=html}
-<div class="sourceCode">
-<pre class="sourceCode markdown">
-<code class="sourceCode markdown">
-The average city mileage of the cars in our data is &#96;r mean_cty&#96 and the average highway mileage is &#96;r mean_hwy&#96. 
-</code>
-</pre>
-</div>
+```markdown
+The average city mileage of the cars in our data is `{r} mean_cty` and the average highway mileage is `{r} mean_hwy`. 
 ```
+
 Save your document and inspect the rendered output.
 
 ::: border
@@ -303,7 +298,7 @@ If you followed along step-by-step with this tutorial, you should now have a Qua
 Otherwise, you can download a completed version of `computations.qmd` below.
 
 ::: {.callout-note appearance="minimal"}
-<i class="bi bi-download"></i> [Download computations-complete.qmd](_computations-complete.qmd){download="computations-complete.qmd"}
+`<i class="bi bi-download"></i>`{=html} [Download computations-complete.qmd](_computations-complete.qmd){download="computations-complete.qmd"}
 :::
 
 {{< include _footer.md >}}

--- a/docs/manuscripts/authoring/_inline-computations.qmd
+++ b/docs/manuscripts/authoring/_inline-computations.qmd
@@ -213,10 +213,10 @@ You can also use computed values directly in your article text by using inline c
 :::
 
 ::: {.content-visible when-meta="tool.is_rstudio"}
-You can use computed values directly in your article text using the syntax `` `r expr` ``. For example, consider this line in `index.qmd`:
+You can use computed values directly in your article text using the syntax `` `{r} expr` ``. For example, consider this line in `index.qmd`:
 
 ``` markdown
-Based on data up to and including 1971, eruptions on La Palma happen every `r round(avg_years_between_eruptions, 1)` years on average.
+Based on data up to and including 1971, eruptions on La Palma happen every `{r} round(avg_years_between_eruptions, 1)` years on average.
 ```
 
 When rendered, it displays as:

--- a/docs/manuscripts/authoring/_inline-computations.qmd
+++ b/docs/manuscripts/authoring/_inline-computations.qmd
@@ -213,10 +213,10 @@ You can also use computed values directly in your article text by using inline c
 :::
 
 ::: {.content-visible when-meta="tool.is_rstudio"}
-You can use computed values directly in your article text using the syntax `` `{r} expr` ``. For example, consider this line in `index.qmd`:
+You can use computed values directly in your article text using the syntax `` `r expr` ``. For example, consider this line in `index.qmd`:
 
 ``` markdown
-Based on data up to and including 1971, eruptions on La Palma happen every `{r} round(avg_years_between_eruptions, 1)` years on average.
+Based on data up to and including 1971, eruptions on La Palma happen every `r round(avg_years_between_eruptions, 1)` years on average.
 ```
 
 When rendered, it displays as:

--- a/docs/visual-editor/technical.qmd
+++ b/docs/visual-editor/technical.qmd
@@ -82,7 +82,8 @@ To insert an executable code chunk, use the **Insert -\> Code Chunk** menu item,
 
 Then press the **Enter** key. Note that `r` could be another language supported by `knitr` (e.g., `python` or `sql`) and you can also include a chunk label and other chunk options.
 
-To include inline R code, you just create normal inline code (e.g., by using backticks or the <kbd>⌘ D</kbd> shortcut) but preface it with `{r}` (or `r`). For example, this inline code will be executed by `knitr`: `` `{r} Sys.Date()` ``.
+To include [inline R code](/docs/computations/inline-code.qmd), create normal inline code (e.g., by using backticks or the <kbd>⌘ D</kbd> shortcut) but preface it with `{r}` (or `r`). For example, to include the current date using the R function `Sys.Date()` you would use: `` `{r} Sys.Date()` ``. 
+
 Note that when the code displays in visual mode it won't have the backticks (but they will still appear in source mode).
 
 ### Running Chunks

--- a/docs/visual-editor/technical.qmd
+++ b/docs/visual-editor/technical.qmd
@@ -69,8 +69,8 @@ Source code which you include in a Quarto document can either be for display onl
 
 To display but not execute code, either use the **Insert -\> Code Block** menu item, or start a new line and type either:
 
-1.  ```` ``` ```` (for a plain code block); or
-2.  ```` ```<lang> ```` (where \<lang\> is a language) for a code block with syntax highlighting.
+1.  ` ``` ` (for a plain code block); or
+2.  ` ```<lang> ` (where `<lang>` is a language) for a code block with syntax highlighting.
 
 Then press the **Enter** key. To display code inline, simply surround text with backticks (`` `code` ``), or use the **Format -\> Code** menu item.
 
@@ -78,11 +78,12 @@ Then press the **Enter** key. To display code inline, simply surround text with 
 
 To insert an executable code chunk, use the **Insert -\> Code Chunk** menu item, or start a new line and type:
 
-```` ```{r} ````
+` ```{r} `
 
-Then press the **Enter** key. Note that `r` could be another language supported by knitr (e.g. `python` or `sql`) and you can also include a chunk label and other chunk options.
+Then press the **Enter** key. Note that `r` could be another language supported by `knitr` (e.g., `python` or `sql`) and you can also include a chunk label and other chunk options.
 
-To include inline R code, you just create normal inline code (e.g. by using backticks or the <kbd>⌘ D</kbd> shortcut) but preface it with `r` or `{r}`. For example, this inline code will be executed by knitr: `` `r Sys.Date()` ``. Note that when the code displays in visual mode it won't have the backticks (but they will still appear in source mode).
+To include inline R code, you just create normal inline code (e.g., by using backticks or the <kbd>⌘ D</kbd> shortcut) but preface it with `{r}` (or `r`). For example, this inline code will be executed by `knitr`: `` `{r} Sys.Date()` ``.
+Note that when the code displays in visual mode it won't have the backticks (but they will still appear in source mode).
 
 ### Running Chunks
 


### PR DESCRIPTION
The commits in this pull request update the syntax for inline code in the documentation. The changes include using `{r}` primarily instead of `` `r` `` to denote inline R code. These updates improve consistency in the documentation.

Related to quarto-dev/quarto-cli#10805