### PR TITLE
replace "OpenOffice" with "OpenDocument"

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -474,7 +474,7 @@ website:
                   href: docs/reference/formats/docx.qmd
                 - text: Typst
                   href: docs/reference/formats/typst.qmd
-                - text: "OpenOffice"
+                - text: "OpenDocument"
                   href: docs/reference/formats/odt.qmd
                 - text: "ePub"
                   href: docs/reference/formats/epub.qmd

--- a/docs/output-formats/all-formats.qmd
+++ b/docs/output-formats/all-formats.qmd
@@ -35,7 +35,7 @@ See below for a list of all output formats by type along with links to their ref
 | [HTML](/docs/reference/formats/html.qmd) | HTML is a markup language used for structuring and presenting content on the web. |
 | [PDF](/docs/reference/formats/pdf.qmd) | PDF is a file format for creating print-ready paged documents. |
 | [MS Word](/docs/reference/formats/docx.qmd) | MS Word is the word processor included with Microsoft Office. |
-| [OpenOffice](/docs/reference/formats/odt.qmd) | OpenDocument is an open standard file format for word processing documents. |
+| [OpenDocument](/docs/reference/formats/odt.qmd) | ODT is an open standard file format for word processing documents. |
 | [ePub](/docs/reference/formats/epub.qmd) | ePub is an e-book file format that is supported by many e-readers. |
 
 ## Presentations


### PR DESCRIPTION
ODF (and its subset ODT) is not tied to one software project. And in any case, Apache OpenOffice is rather on life support, whereas most contributions to the OpenOffice.org descendants are currently going to LibreOffice.
MS Office also opens ODF and recently announced support for version 1.4.