### PR TITLE
fix: `docs/projects/scripts.qmd` - fix typo

### DIFF
--- a/docs/projects/scripts.qmd
+++ b/docs/projects/scripts.qmd
@@ -54,12 +54,12 @@ Pre and post render scripts are run with the main project directory.
 
 The following environment variables are passed to pre and post-render scripts (note that all paths are *relative* to the main project directory):
 
-| Variable                      | Description                                                                                                                                                                |
+| Variable                      | Description                                                                                                                                                                   |
 |-----------------|-------------------------------------------------------|
-| `QUARTO_PROJECT_RENDER_ALL`   | Set to "1" if this is a render of all files in the project (as opposed to an incremental render or a render for preview). This unset if Quarto is not rendering all files. |
-| `QUARTO_PROJECT_OUTPUT_DIR`   | Output directory                                                                                                                                                           |
-| `QUARTO_PROJECT_INPUT_FILES`  | Newline separated list of all input files being rendered (passed only to `pre-render`)                                                                                     |
-| `QUARTO_PROJECT_OUTPUT_FILES` | Newline separated list of all output files rendered (passed only to `post-render`).                                                                                        |
+| `QUARTO_PROJECT_RENDER_ALL`   | Set to "1" if this is a render of all files in the project (as opposed to an incremental render or a render for preview). This is unset if Quarto is not rendering all files. |
+| `QUARTO_PROJECT_OUTPUT_DIR`   | Output directory                                                                                                                                                              |
+| `QUARTO_PROJECT_INPUT_FILES`  | Newline separated list of all input files being rendered (passed only to `pre-render`)                                                                                        |
+| `QUARTO_PROJECT_OUTPUT_FILES` | Newline separated list of all output files rendered (passed only to `post-render`).                                                                                           |
 
 The project metadata and render list will be re-computed after any pre-render scripts have executed, allowing them to modify this project data.
 For example, a pre-render script might generate additional `qmd` files or `ipynb` files that should be rendered.


### PR DESCRIPTION
Found what I assume is a small typo in `docs/projects/scripts.qmd` - at least the previous sentence wasn't really correct 

Sidenote: 

I could not find any specific style guide reg. whitespace in raw markdown-tables, thus I took the freedom to maintain a flush right edge to the table.

~Gw