### PR TITLE
docs: grid can be set per page

### DIFF
--- a/docs/output-formats/page-layout.qmd
+++ b/docs/output-formats/page-layout.qmd
@@ -100,9 +100,9 @@ You can control the width of the layout components in HTML documents with YAML o
 ![Wider Sidebar](images/grid-wide-sidebar.png){fig-alt="Screenshot of a Quarto website with altered layout, devoting more space to the sidebar."}
 :::
 
-This change can be made by adding the `grid` option to the `_quarto.yml` file, increasing the `sidebar-width` from its default of 250px:
+This change can be made by adding the `grid` option, increasing the `sidebar-width` from its default of 250px:
 
-```{.yaml filename="_quarto.yml"}
+```{.yaml}
 format:
   html:
     grid:

--- a/docs/output-formats/page-layout.qmd
+++ b/docs/output-formats/page-layout.qmd
@@ -138,7 +138,7 @@ The values of these variables don't directly specify the display width of the co
 
 You can control the component width variables using YAML or SCSS variables. To set these options in YAML, you may use the `grid` option :
 
-```{.yaml filename="_quarto.yml"}
+```yaml
 format:
   html: 
     grid:
@@ -147,14 +147,6 @@ format:
       margin-width: 300px
       gutter-width: 1.5rem
 ```
-
-::: {.callout-note}
-## Websites vs. Standalone HTML Pages
-
-Customizing the layout of pages that are part of a Quarto website with YAML should happen at the site level in `_quarto.yml`. For HTML documents that aren't part of a website, these options could also be set in the YAML at the top of the document.
-
-:::
-
 
 Similarly, in a [custom theme `scss` file](/docs/output-formats/html-themes.qmd#theme-options), you may set variables like:
 

--- a/docs/output-formats/page-layout.qmd
+++ b/docs/output-formats/page-layout.qmd
@@ -100,9 +100,9 @@ You can control the width of the layout components in HTML documents with YAML o
 ![Wider Sidebar](images/grid-wide-sidebar.png){fig-alt="Screenshot of a Quarto website with altered layout, devoting more space to the sidebar."}
 :::
 
-This change can be made by adding the `grid` option, increasing the `sidebar-width` from its default of 250px:
+This change can be made by adding the `grid` option to the `_quarto.yml` file, increasing the `sidebar-width` from its default of 250px:
 
-```{.yaml}
+```{.yaml filename="_quarto.yml"}
 format:
   html:
     grid:


### PR DESCRIPTION
Since https://github.com/quarto-dev/quarto-cli/pull/10611 `grid` can be set on a page of a website.

- https://github.com/quarto-dev/quarto-cli/discussions/6615
- https://github.com/quarto-dev/quarto-cli/discussions/10818