### PR TITLE
A `Lumo` to the custom format list

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -1,3 +1,9 @@
+- name: lumo
+  path: https://github.com/holtzy/lumo
+  author: "[Holtz Yan](https:www.yan-holtz.com)"
+  description: |
+    A clean and minimalist HTML custom format
+
 - name: quarto-preprint
   path: https://github.com/mvuorre/quarto-preprint
   author: "[Matti Vuorre](https://github.com/mvuorre)"


### PR DESCRIPTION
👋 Dear Quarto team,

I created a new Quarto custom format called `lumo`.

[Link](https://github.com/holtzy/lumo)

If possible, I would love to see it appearing in the list of all the Quarto custom formats.

I'm happy to apply any modification if necessary.

Thanks a lot for your excellent work! 🙏🙏🙏🙏🙏