### PR TITLE
Script to automate release notes

### DIFF
--- a/docs/download/_download-older.yml
+++ b/docs/download/_download-older.yml
@@ -1,6 +1,26 @@
 # Generate tags for a specific prefix like so
 # git tag -l 'v1\.0\.*' --sort version:refname
+- id: version14
+  title: v1.4.557
+  date: 2024/06/27
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.4.557
+  changelog: "[Release Notes](changelog/1.4/)"
+- id: version13
+  title: v1.3.450
+  date: 2023/08/23
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.3.450
+  changelog: "[Release Notes](changelog/1.3/)"
+- id: version12
+  title: v1.2.475
+  date: 2023/03/22
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.2.475
+  changelog: "[Release Notes](changelog/1.2/)"
+- id: version11
+  title: v1.1.189
+  date: 2022/09/04
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.1.189
+  changelog: "[Release Notes](changelog/1.1/)"
 - id: version10
   title: v1.0.38
   date: 2022/08/04
-  url: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.0.38
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.0.38

--- a/docs/download/_download-older.yml
+++ b/docs/download/_download-older.yml
@@ -1,26 +1,27 @@
 # Generate tags for a specific prefix like so
 # git tag -l 'v1\.0\.*' --sort version:refname
-- id: version14
-  title: v1.4.557
-  date: 2024/06/27
-  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.4.557
-  changelog: "[Release Notes](changelog/1.4/)"
-- id: version13
-  title: v1.3.450
-  date: 2023/08/23
-  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.3.450
-  changelog: "[Release Notes](changelog/1.3/)"
-- id: version12
-  title: v1.2.475
-  date: 2023/03/22
-  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.2.475
-  changelog: "[Release Notes](changelog/1.2/)"
+- id: version10
+  title: v1.0.38
+  date: 2022/08/04
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.0.38
 - id: version11
   title: v1.1.189
   date: 2022/09/04
   path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.1.189
   changelog: "[Release Notes](changelog/1.1/)"
-- id: version10
-  title: v1.0.38
-  date: 2022/08/04
-  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.0.38
+- id: version12
+  title: v1.2.475
+  date: 2023/03/22
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.2.475
+  changelog: "[Release Notes](changelog/1.2/)"
+- id: version13
+  title: v1.3.450
+  date: 2023/08/23
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.3.450
+  changelog: "[Release Notes](changelog/1.3/)"
+- id: version14
+  title: v1.4.557
+  date: 2024/06/27
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.4.557
+  changelog: "[Release Notes](changelog/1.4/)"
+  

--- a/docs/download/index.qmd
+++ b/docs/download/index.qmd
@@ -21,6 +21,7 @@ image: /images/hero_right.png
 listing:
   id: download-older
   contents: /_download-older.yml
+  sort: "date desc"
   fields: 
     - title
     - changelog

--- a/docs/download/index.qmd
+++ b/docs/download/index.qmd
@@ -20,31 +20,7 @@ editor: source
 image: /images/hero_right.png
 listing:
   id: download-older
-  contents: 
-    - id: version14
-      title: v1.4.557
-      date: 2024/06/27
-      path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.4.557
-      changelog: "[Release Notes](changelog/1.4/)"
-    - id: version13
-      title: v1.3.450
-      date: 2023/08/23
-      path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.3.450
-      changelog: "[Release Notes](changelog/1.3/)"
-    - id: version12
-      title: v1.2.475
-      date: 2023/03/22
-      path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.2.475
-      changelog: "[Release Notes](changelog/1.2/)"
-    - id: version11
-      title: v1.1.189
-      date: 2022/09/04
-      path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.1.189
-      changelog: "[Release Notes](changelog/1.1/)"
-    - id: version10
-      title: v1.0.38
-      date: 2022/08/04
-      path: https://github.com/quarto-dev/quarto-cli/releases/tag/v1.0.38
+  contents: /_download-older.yml
   fields: 
     - title
     - changelog

--- a/tools/release-notes.R
+++ b/tools/release-notes.R
@@ -81,18 +81,18 @@ readLines(prerelease_page) |>
   str_replace(aliases[2], aliases[3]) |> 
   writeLines(prerelease_page)
 
-# MANUALLY update listing ------------------------------------------------
+# Update listing ------------------------------------------------
 
 old_abbr <- str_split(major_version, "\\.")[[1]] |> paste0(collapse = "")
 
 # Add new item to download-older listing in docs/download/index.qmd
 
-cat("Please manually add a new item to the `download-older` listing in `docs/download/index.qmd`:\n")
 glue('
 - id: version{ old_abbr }
   title: { old_release }
-  date: <RELEASE DATE>
+  date: { format(as.Date(old_release_date), "%Y/%m/%d") }
   path: https://github.com/quarto-dev/quarto-cli/releases/tag/{ old_release }
   changelog: "[Release Notes](changelog/{ major_version }/)"
-')
+') |> 
+  cat(file = path(downloads, "_download-older.yml"), append = TRUE)
 

--- a/tools/release-notes.R
+++ b/tools/release-notes.R
@@ -88,10 +88,10 @@ old_abbr <- str_split(major_version, "\\.")[[1]] |> paste0(collapse = "")
 # Add new item to download-older listing in docs/download/index.qmd
 
 glue('
-- id: version{ old_abbr }
+\n- id: version{ old_abbr }
   title: { old_release }
   date: { format(as.Date(old_release_date), "%Y/%m/%d") }
-  path: https://github.com/quarto-dev/quarto-cli/releases/tag/{ old_release }
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/v{ old_release }
   changelog: "[Release Notes](changelog/{ major_version }/)"
 ') |> 
   cat(file = path(downloads, "_download-older.yml"), append = TRUE)

--- a/tools/release-notes.R
+++ b/tools/release-notes.R
@@ -1,0 +1,65 @@
+library(fs)
+library(stringr)
+library(glue)
+
+# Version numbers
+old_release <- "v1.5.57"
+new_release_major <- "1.6"
+new_prerelease_major <- "1.7"
+
+major_version <- str_extract(old_release, "(\\d+)\\.(\\d+)")
+
+downloads <- path("docs", "download")
+
+# Create new changelog content -------------------------------------------
+
+changelog_url <- paste0("https://github.com/quarto-dev/quarto-cli/releases/download/", 
+  old_release, "/changelog.md")
+changelog_dir <- dir_create(path(downloads, "changelog", major_version))
+
+download_status <- download.file(changelog_url, path(changelog_dir, 
+  "_changelog", ext = "md"))
+stopifnot(!download_status)
+
+glue("
+---
+title: {major_version} Release Notes
+format: html
+---
+
+{{{{< include _changelog.md >}}}}
+") |> 
+  writeLines(path(changelog_dir, "index", ext = "qmd"))
+
+# Increment versions of aliases ------------------------------------------
+
+release_page <- path(downloads, "release", ext = "qmd")
+prerelease_page <- path(downloads, "prerelease", ext = "qmd")
+
+aliases <- paste0("changelog/", 
+  c(major_version, new_release_major, new_prerelease_major), 
+  "/") 
+
+readLines(release_page) |> 
+  str_replace(aliases[1], aliases[2]) |> 
+  writeLines(release_page)
+
+readLines(prerelease_page) |> 
+  str_replace(aliases[2], aliases[3]) |> 
+  writeLines(prerelease_page)
+
+# MANUALLY update listing ------------------------------------------------
+
+old_abbr <- str_split(major_version, "\\.")[[1]] |> paste0(collapse = "")
+
+# Add new item to download-older listing in docs/download/index.qmd
+
+cat("Please manually add a new item to the `download-older` listing in `docs/download/index.qmd`:\n")
+glue('
+- id: version{ old_abbr }
+  title: { old_release }
+  date: <RELEASE DATE>
+  path: https://github.com/quarto-dev/quarto-cli/releases/tag/{ old_release }
+  changelog: "[Release Notes](changelog/{ major_version }/)"
+')
+


### PR DESCRIPTION
Adds a script to automate the steps of adding release notes for the old release.

Closes https://github.com/quarto-dev/quarto-cli/issues/10277

In addition, we'd need to change this step in the release checklist:

https://github.com/quarto-dev/quarto-cli/blob/a2026c8b7c775665472b73f30b84d8da7a94c178/dev-docs/checklist-make-a-new-quarto-release.md?plain=1#L24

to:
```markdown
  - run `quarto run tools/release-notes.R`
```
