### PR TITLE
docs: add tip about absolute path in include shortcode important callout

### DIFF
--- a/docs/authoring/includes.qmd
+++ b/docs/authoring/includes.qmd
@@ -17,7 +17,7 @@ To include a file, add the `{{{< include >}}}` shortcode at the location in your
 Include shortcodes are equivalent to copying and pasting the text from the included file into the main file.
 This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.
 
-::: {.callout-tip icon="false"}
+::: {.callout-tip}
 Use absolute (to the project root) paths for links and images in included files to ensure they resolve correctly, *e.g.*, `{{< include /path/to/file.qmd >}}`.
 :::
 

--- a/docs/authoring/includes.qmd
+++ b/docs/authoring/includes.qmd
@@ -14,7 +14,12 @@ To include a file, add the `{{{< include >}}}` shortcode at the location in your
 
 ::: callout-important
 
-Include shortcodes are equivalent to copying and pasting the text from the included file into the main file. This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.
+Include shortcodes are equivalent to copying and pasting the text from the included file into the main file.
+This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.
+
+::: {.callout-tip icon="false"}
+Use absolute (to the project root) paths for links and images in included files to ensure they resolve correctly, *e.g.*, `{{< include /path/to/file.qmd >}}`.
+:::
 
 It also means that if the included file has a metadata block, that block will take effect in all included files. In most cases, having metadata blocks in an included file will cause unexpected behavior.
 

--- a/docs/authoring/includes.qmd
+++ b/docs/authoring/includes.qmd
@@ -16,7 +16,7 @@ To include a file, add the `{{{< include >}}}` shortcode at the location in your
 
 Include shortcodes are equivalent to copying and pasting the text from the included file into the main file.
 This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.  
-Use absolute (to the project root) paths for links and images in included files to ensure they resolve correctly, *e.g.*, `{{< include /path/to/file.qmd >}}`.
+Use absolute (to the project root) paths for links and images in included files to ensure they resolve correctly, *e.g.*, `[A Figure Reused](/path/to/image.png)` or `{{< include /path/to/file.qmd >}}`.
 
 It also means that if the included file has a metadata block, that block will take effect in all included files. In most cases, having metadata blocks in an included file will cause unexpected behavior.
 

--- a/docs/authoring/includes.qmd
+++ b/docs/authoring/includes.qmd
@@ -15,8 +15,8 @@ To include a file, add the `{{{< include >}}}` shortcode at the location in your
 ::: callout-important
 
 Include shortcodes are equivalent to copying and pasting the text from the included file into the main file.
-This means that relative references (links, images, other includes, etc.) inside the included file resolve based on the directory of the main file not the included file.  
-Use absolute (to the project root) paths for links, images, or other includes, in included files to ensure they resolve correctly, *e.g.*, `[A Figure Reused](/path/to/image.png)` or `{{< include /path/to/file.qmd >}}`.
+This means that relative references (links, images, other includes, etc.) inside the included file resolve based on the directory of the main file not the included file.
+Use absolute (to the project root) paths for links, images, or other includes, in included files to ensure they resolve correctly, *e.g.*, `[A Figure Reused](/path/to/image.png)` or `{{< include /path/to/_file.qmd >}}`.
 
 It also means that if the included file has a metadata block, that block will take effect in all included files. In most cases, having metadata blocks in an included file will cause unexpected behavior.
 

--- a/docs/authoring/includes.qmd
+++ b/docs/authoring/includes.qmd
@@ -15,11 +15,8 @@ To include a file, add the `{{{< include >}}}` shortcode at the location in your
 ::: callout-important
 
 Include shortcodes are equivalent to copying and pasting the text from the included file into the main file.
-This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.
-
-::: {.callout-tip}
+This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.  
 Use absolute (to the project root) paths for links and images in included files to ensure they resolve correctly, *e.g.*, `{{< include /path/to/file.qmd >}}`.
-:::
 
 It also means that if the included file has a metadata block, that block will take effect in all included files. In most cases, having metadata blocks in an included file will cause unexpected behavior.
 

--- a/docs/authoring/includes.qmd
+++ b/docs/authoring/includes.qmd
@@ -15,8 +15,8 @@ To include a file, add the `{{{< include >}}}` shortcode at the location in your
 ::: callout-important
 
 Include shortcodes are equivalent to copying and pasting the text from the included file into the main file.
-This means that relative references (links, images, etc.) inside the included file resolve based on the directory of the main file not the included file.  
-Use absolute (to the project root) paths for links and images in included files to ensure they resolve correctly, *e.g.*, `[A Figure Reused](/path/to/image.png)` or `{{< include /path/to/file.qmd >}}`.
+This means that relative references (links, images, other includes, etc.) inside the included file resolve based on the directory of the main file not the included file.  
+Use absolute (to the project root) paths for links, images, or other includes, in included files to ensure they resolve correctly, *e.g.*, `[A Figure Reused](/path/to/image.png)` or `{{< include /path/to/file.qmd >}}`.
 
 It also means that if the included file has a metadata block, that block will take effect in all included files. In most cases, having metadata blocks in an included file will cause unexpected behavior.
 


### PR DESCRIPTION
This pull request adds a tip to the documentation about using absolute paths in the include shortcode. The tip explains that using absolute paths ensures that links and images in included files resolve correctly regardless of where the file is included via the shortcode.

Motivation: several users were bitten by this. The explicit tip might help avoid the issue.