### PR TITLE
Update typst.qmd

### DIFF
--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -315,3 +315,39 @@ format:
       - text: |
           #show heading: set text(navy)
 ```
+## Custom Typst Configuration
+
+By default, Quarto uses its built-in version of Typst to ensure compatibility and stable behavior. However, for advanced users who need to use features from newer Typst versions, Quarto can be configured to use an external Typst installation through the `QUARTO_TYPST` environment variable.
+
+For example:
+
+```bash
+# Unix/macOS
+export QUARTO_TYPST=/path/to/typst
+
+# Windows PowerShell
+$env:QUARTO_TYPST = "C:\path\to\typst"
+```
+
+:::caution
+Using a custom Typst installation is considered experimental and may lead to unexpected behavior. Quarto makes no guarantees about compatibility when using versions of Typst other than the built-in version. Use this configuration at your own risk.
+:::
+
+The custom Typst binary can be installed through various package managers, including homebrew, cargo, Nix, and more.
+
+```bash
+# Homebrew (macOS/Linux)
+brew install typst
+
+# Cargo (Cross-platform)
+cargo install typst
+
+# Nix (Cross-platform)
+nix-env -iA nixpkgs.typst
+```
+
+After setting `QUARTO_TYPST` and refreshing your shell, verify the configuration by checking which version of Typst Quarto is using:
+
+```bash
+quarto typst --version
+```


### PR DESCRIPTION
From [this discussion](https://github.com/quarto-dev/quarto-cli/issues/9106) we learned of the undocumented QUARTO_TYPST env var. This got me out of a jam recently and I was able to finally compile my thesis using some of the par options in 0.12. Nothing else broke.

So this PR is just to add an explainer for advanced users as to how they can point quarto to a different typst compiler if they so choose.