### PR TITLE
Add note about escaping in meta shortcode

### DIFF
--- a/docs/authoring/variables.qmd
+++ b/docs/authoring/variables.qmd
@@ -75,6 +75,13 @@ extract the first in the array of authors:
 {{< meta author.1 >}}
 ```
 
+To reference a field that contains a dot (`.`), escape the dot with a double backslash (`\\`). For example, to get `field.with.dots`:
+
+
+``` {.markdown shortcodes="false"}
+{{< meta field\\.with\\.dots >}}
+```
+
 ## env {#env}
 
 The `env` shortcode enables you to read values from environment variables. For example:


### PR DESCRIPTION
> ([#10936](https://github.com/quarto-dev/quarto-cli/issues/10936)): Use `\\` in `meta` shortcode to escape the following character, allowing keys with `.` in them.