### PR TITLE
docs: Update Python GitHub Action version to v5

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -198,7 +198,7 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -163,7 +163,7 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/docs/publishing/posit-cloud.qmd
+++ b/docs/publishing/posit-cloud.qmd
@@ -250,7 +250,7 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/docs/publishing/quarto-pub.qmd
+++ b/docs/publishing/quarto-pub.qmd
@@ -177,7 +177,7 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -310,7 +310,7 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'


### PR DESCRIPTION
Replace the usage of actions/setup-python@v4 with actions/setup-python@v5.

Fixes quarto-dev/quarto-cli#11259