### PR TITLE
bump to latest Rstudio IDE version

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -1,3 +1,2 @@
 rstudio:
   min_version: "v2022.07"
-  current_release: "v2024.09"

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,3 +1,3 @@
 rstudio:
   min_version: "v2022.07"
-  current_release: "v2023.12"
+  current_release: "v2024.09"

--- a/docs/faq/rmarkdown.qmd
+++ b/docs/faq/rmarkdown.qmd
@@ -94,7 +94,7 @@ Quarto v1.0 was [announced at rstudio::conf(2022)](https://www.rstudio.com/blog/
 
 Yes! You need to use RStudio {{< var rstudio.min_version >}} or a later version, which includes support for [editing and preview of Quarto documents](/docs/tools/rstudio.qmd).
 
-You can download the latest release ({{< var rstudio.current_release >}}) of RStudio from <https://posit.co/download/rstudio-desktop/>.
+You can download the latest release of RStudio from <https://posit.co/download/rstudio-desktop/>.
 
 ### Does Posit Connect support Quarto?
 

--- a/docs/get-started/authoring/rstudio.qmd
+++ b/docs/get-started/authoring/rstudio.qmd
@@ -14,7 +14,7 @@ In this tutorial we'll show you how to author Quarto documents in RStudio.
 In particular, we'll discuss the various document formats you can produce with the same source code and show you how to add components like table of contents, equations, citations, etc.
 The [visual markdown editor](/docs/visual-editor/index.qmd) in RStudio makes many of these tasks easier so we'll highlight its use in this tutorial, but note that it's possible to accomplish these tasks in the source editor as well.
 
-If you would like to follow along step-by-step in your own environment, make sure that you have the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio ({{< var rstudio.current_release >}}), which you can download [here](https://posit.co/download/rstudio-desktop/), installed.
+If you would like to follow along step-by-step in your own environment, install the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio.
 
 ## Output Formats
 

--- a/docs/get-started/hello/rstudio.qmd
+++ b/docs/get-started/hello/rstudio.qmd
@@ -28,10 +28,10 @@ If you would like a video introduction to Quarto before you dive into the tutori
 
 If you would like to follow along with this tutorial in your own environment, follow the steps outlined below.
 
-1.  Download and install the latest release of RStudio ({{< var rstudio.current_release >}}):
+1.  Download and install the latest release of RStudio:
 
     ::: {.callout appearance="minimal"}
-    <i class="bi bi-download"></i> [Download RStudio {{< var rstudio.current_release >}}](https://posit.co/download/rstudio-desktop/)
+    <i class="bi bi-download"></i> [Download RStudio](https://posit.co/download/rstudio-desktop/)
     :::
 
 2.  Be sure that you have installed the `tidyverse` and `palmerpenguins` packages:

--- a/docs/interactive/shiny/running.qmd
+++ b/docs/interactive/shiny/running.qmd
@@ -20,7 +20,7 @@ install.packages("rmarkdown")
 
 While you are developing an interactive document it will likely be most convenient to run within RStudio.
 
-Note that you need RStudio {{< var rstudio.min_version >}} or a later version in order to run Quarto interactive documents. You can download the latest release ({{< var rstudio.current_release >}}) here <https://posit.co/download/rstudio-desktop/>.
+Note that you need RStudio {{< var rstudio.min_version >}} or a later version in order to run Quarto interactive documents. You can download the latest release at <https://posit.co/download/rstudio-desktop/>.
 
 Click the **Run Document** button while editing a Shiny interactive document to render and view the document within the IDE:
 

--- a/docs/tools/_rstudio.md
+++ b/docs/tools/_rstudio.md
@@ -1,8 +1,8 @@
 RStudio {{< var rstudio.min_version >}} and later includes support for editing and preview of Quarto documents (the documentation below assumes you are using this build or a later version). 
 
-If you are using Quarto within RStudio it is **strongly** recommended that you use the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio ({{< var rstudio.current_release >}}).
+If you are using Quarto within RStudio it is **strongly** recommended that you use the [latest release](https://posit.co/download/rstudio-desktop/) of RStudio.
 
-You can download RStudio {{< var rstudio.current_release >}} from <https://posit.co/download/rstudio-desktop/>.
+You can download RStudio from <https://posit.co/download/rstudio-desktop/>.
 
 ### Creating Documents
 

--- a/docs/visual-editor/index.qmd
+++ b/docs/visual-editor/index.qmd
@@ -22,7 +22,7 @@ Note that you can switch between source and visual mode at any time (editing loc
 
 The Quarto visual editor is currently available as a feature of the [RStudio IDE](https://posit.co/download/rstudio-desktop/). The visual editor will eventually also be made available in standalone form.
 
-To get started with the visual editor, download the latest release of RStudio ({{< var rstudio.current_release >}}) for your platform from:
+To get started with the visual editor, download the latest release of RStudio for your platform from:
 
 <https://posit.co/download/rstudio-desktop/>
 


### PR DESCRIPTION
closes quarto-dev/quarto-cli#11298

@cwickham do you want to still keep track on version number and update this variable regularly ? 

or should we just say "latest" with a link to https://posit.co/download/rstudio-desktop/ and stop showing the version. 

We don't update our doc at each release on it... 

Otherwise, we could come up with a pre-render script that would query the API at https://posit.co/wp-content/uploads/downloads.json
