### PR TITLE
11300 - clarify that section title are not scrollable

### DIFF
--- a/docs/presentations/revealjs/index.qmd
+++ b/docs/presentations/revealjs/index.qmd
@@ -55,6 +55,18 @@ format:
 ---
 ```
 
+Please note that section title slides are centered by default which prevents them from being scrollable.
+If you want to make title slides scrollable, you need to make them non-centered.
+
+``` {.yaml code-preview="examples/make-section-title-scrollable.qmd"}
+---
+format:
+  revealjs:
+    scrollable: true
+    center-title-slide: false
+---
+```
+
 {{< include _callout-auto-stretch-scrollable.qmd >}}
 
 {{< include ../_speaker-notes.md >}}

--- a/docs/presentations/revealjs/index.qmd
+++ b/docs/presentations/revealjs/index.qmd
@@ -58,7 +58,7 @@ format:
 Please note that section title slides are centered by default which prevents them from being scrollable.
 If you want to make title slides scrollable, you need to make them non-centered.
 
-``` {.yaml code-preview="examples/make-section-title-scrollable.qmd"}
+``` {.yaml}
 ---
 format:
   revealjs:


### PR DESCRIPTION
Related https://github.com/quarto-dev/quarto-cli/issues/11300

Update documentation to clarify:

- that section title slides are not scrollable by default,
- how to modify them to make them scrollable.