### PR TITLE
Typst CSS: update feature-element matrix for div colors

### DIFF
--- a/docs/advanced/typst/typst-css.qmd
+++ b/docs/advanced/typst/typst-css.qmd
@@ -34,9 +34,9 @@ Typst CSS works for the specific combinations of HTML elements and CSS propertie
 
 |                  | span | div | table | td  |
 |------------------|------|-----|-------|-----|
-| background-color |   ✓  |     |       |  ✓  |
+| background-color |   ✓  |  ✓  |       |  ✓  |
 | border[^1]       |      |     |       |  ✓  |
-| color            |   ✓  |     |       |  ✓  |
+| color            |   ✓  |  ✓  |       |  ✓  |
 | font-family      |      |  ✓  |   ✓   |     |
 | font-size        |      |  ✓  |   ✓   |     |
 | opacity          |   ✓  |     |       |  ✓  |


### PR DESCRIPTION
A couple more entries in the feature-element matrix checked off, with div supporting `color` and `background-color`.

For quarto-dev/quarto-cli#11280
