### PR TITLE
Add documentation for SCSS variables in revealjs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -672,6 +672,7 @@ format:
 
 filters:
   - filters/tools-tabset.lua
+  - filters/color-box.lua
 
 freeze: true
 

--- a/docs/presentations/revealjs/themes.qmd
+++ b/docs/presentations/revealjs/themes.qmd
@@ -176,6 +176,32 @@ Here's a list of all Sass variables (and their default values) used by Reveal th
 | `$presentation-slide-text-align`       | left                                     |
 | `$presentation-title-slide-text-align` | center                                   |
 
+### Callouts
+
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Variable                 | Notes                                                                                                                                                              |
++==========================+====================================================================================================================================================================+
+| `$callout-border-width`  | The left border width of callouts. Defaults to `0.3rem`.                                                                                                           |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| `$callout-border-scale`  | The border color of callouts computed by shifting the callout color by this amount. Defaults to `0%`.                                                              |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| `$callout-icon-scale`    | The color of the callout icon computed by shifting the callout color by this amount. Defaults to `10%`.                                                            |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| `$callout-margin-top`    | The amount of top margin on the callout. Defaults to `1rem`.                                                                                                       |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| `$callout-margin-bottom` | The amount of bottom margin on the callout. Defaults to `1rem`.                                                                                                    |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| `$callout-color-<type>`  | The colors for the various types of callouts. Defaults:                                                                                                            |
+|                          |                                                                                                                                                                    |
+|                          | | type        | default   |                                                                                                                                        |
+|                          | |-------------|-----------|                                                                                                                                        |
+|                          | | `note`      | `#0d6efd` |                                                                                                                                        |
+|                          | | `tip`       | `#198754` |                                                                                                                                        |
+|                          | | `caution`   | `#dc3545` |                                                                                                                                        |
+|                          | | `warning`   | `#fd7e14` |                                                                                                                                        |
+|                          | | `important` | `#ffc107` |                                                                                                                                        |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
 You'll notice that some of the Sass variables use a `presentation-` prefix and some do not. The `presentation-` prefixed variables are specific to presentations, whereas the other variables are the same as ones used for standard Quarto [HTML Themes](/docs/output-formats/html-themes.qmd).
 
 Since all Quarto themes use the same Sass format, you can use a single theme file for both HTML / website documents and presentations.

--- a/docs/presentations/revealjs/themes.qmd
+++ b/docs/presentations/revealjs/themes.qmd
@@ -200,6 +200,7 @@ Here's a list of all Sass variables (and their default values) used by Reveal th
 |                          | | `caution`   | `#dc3545` |                                                                                                                                        |
 |                          | | `warning`   | `#fd7e14` |                                                                                                                                        |
 |                          | | `important` | `#ffc107` |                                                                                                                                        |
+|                          | Note that style for callout is to have left border using type color, and header background to use a variation of this color.                                       |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 You'll notice that some of the Sass variables use a `presentation-` prefix and some do not. The `presentation-` prefixed variables are specific to presentations, whereas the other variables are the same as ones used for standard Quarto [HTML Themes](/docs/output-formats/html-themes.qmd).

--- a/docs/presentations/revealjs/themes.qmd
+++ b/docs/presentations/revealjs/themes.qmd
@@ -193,13 +193,14 @@ Here's a list of all Sass variables (and their default values) used by Reveal th
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | `$callout-color-<type>`  | The colors for the various types of callouts. Defaults:                                                                                                            |
 |                          |                                                                                                                                                                    |
-|                          | | type        | default   |                                                                                                                                        |
-|                          | |-------------|-----------|                                                                                                                                        |
-|                          | | `note`      | `#0d6efd` |                                                                                                                                        |
-|                          | | `tip`       | `#198754` |                                                                                                                                        |
-|                          | | `caution`   | `#dc3545` |                                                                                                                                        |
-|                          | | `warning`   | `#fd7e14` |                                                                                                                                        |
-|                          | | `important` | `#ffc107` |                                                                                                                                        |
+|                          | | type        | default                 |                                                                                                                          |
+|                          | |-------------|-------------------------|                                                                                                                          |
+|                          | | `note`      | [`#0d6efd`]{.color-box} |                                                                                                                          |
+|                          | | `tip`       | [`#198754`]{.color-box} |                                                                                                                          |
+|                          | | `caution`   | [`#dc3545`]{.color-box} |                                                                                                                          |
+|                          | | `warning`   | [`#fd7e14`]{.color-box} |                                                                                                                          |
+|                          | | `important` | [`#ffc107`]{.color-box} |                                                                                                                          |
+|                          |                                                                                                                                                                    |
 |                          | Note that style for callout is to have left border using type color, and header background to use a variation of this color.                                       |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 

--- a/filters/color-box.lua
+++ b/filters/color-box.lua
@@ -1,0 +1,19 @@
+Span = function(s)
+  if not quarto.format.isHtmlOutput() then
+    return nil
+  end
+  if s.classes:includes('color-box') then
+    local color
+    if  s.attributes['color'] then
+      quarto.log.output("HERE")
+      color = s.attributes['color']
+      s.attributes.color = nil
+    elseif #s.content == 1 and s.content[1] and s.content[1].t == "Code" and s.content[1].text and s.content[1].text:sub(1, 1) == '#' then
+      color = s.content[1].text
+    end
+    if color then
+      s.content:insert(1, pandoc.Span('', pandoc.Attr('', { 'color-box' }, { style ="background-color:" .. color .. ";"})))
+      return pandoc.Span( s.content , { "", { "color-box-container" } })
+    end
+  end
+end

--- a/styles.css
+++ b/styles.css
@@ -337,3 +337,16 @@ iframe.reveal-demo {
 .illustration {
   border: 1px solid #dee2e6;
 }
+
+span.color-box-container {
+  display: inline-flex;
+  align-items: center; /* Align vertically */
+}
+
+span.color-box {
+  display: inline-block;
+  width: 1em; /* Width of the color box */
+  height: 1em; /* Height of the color box */
+  margin-right: 0.2em; /* Space between box and text */
+  border: 1px solid #000; /* Border color */
+}


### PR DESCRIPTION
This is a companion PR to Revealjs callout update to be merged in
- https://github.com/quarto-dev/quarto-cli/pull/11251

It adds documentation for SCSS variable available to customize callouts. 

@cwickham this PR also adds a new feature for our doc: Adding a color box next to some part mentioning a color. 

Basically doing  ``[`<hexcolor>`]{.color-box}`` would use the hexcolor to create the box. It would work with any text using `` [any content]{.color-box color="hexcolor"} `` 

![image](https://github.com/user-attachments/assets/1714d7ce-d199-485c-bb73-3d6dc3b6a86e)

We could probably use that into the website in other places, and we could also make it a shortcode syntax if easier. 

I noticed a few changes in preview locally regarding tables in documentation. I'll check if this is happening with the preview here too. I wonder if our brand change have had side effect

