### PR TITLE
Move giscus comments to quarto-cli repo discussion board

### DIFF
--- a/docs/blog/posts/_metadata.yml
+++ b/docs/blog/posts/_metadata.yml
@@ -1,6 +1,6 @@
 comments:
   giscus:
-    repo: quarto-dev/quarto-web
+    repo: quarto-dev/quarto-cli
     category: Blog
 title-block-banner: "#EDF3F9"
 title-block-banner-color: body


### PR DESCRIPTION
This should be enough to move discussion from quarto-web to quarto-cli

I created the category there 
https://github.com/quarto-dev/quarto-cli/discussions/categories/blog

I just need to move every post from here to there so that current comments will work. 

I'll try to make a script for that so that we can sync up the merge of this PR with the move. Maybe do it before merging. 

I'll update when done