### PR TITLE
Add typst-math to shortcodes-and-filters.ym

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -475,6 +475,12 @@
   description: >
     Output divs and spans as Typst functions.
 
+- name: typst-math
+  path: https://github.com/sverrirarnors/typst-math
+  author: '[Sverrir Arnórsson](https://github.com/sverrirarnors)'
+  description: >
+    Changes math block syntax from LaTeX to Typst math.
+
 - name: unsplash
   path: https://github.com/dragonstyle/unsplash
   author: '[dragonstyle](https://github.com/dragonstyle)'


### PR DESCRIPTION
Adds the `typst-math` filter to the filter listing.