### PR TITLE
Environment variable is set in Quarto 1.6 only

### DIFF
--- a/docs/projects/scripts.qmd
+++ b/docs/projects/scripts.qmd
@@ -134,7 +134,7 @@ Quarto 1.6 ships with a version of Deno that has an unfortunate interaction betw
 As a result, Quarto 1.6 might download some files (once, and then cache them) when the standard library is invoked.
 Future versions of Quarto will ship with Deno 2, which does not suffer from this issue.
 
-If you want to enforce the behavior from Quarto 1.5, you can set the [environment variable](/docs/advanced/environment-vars.qmd) `QUARTO_RUN_NO_NETWORK` to `true`.
+If you want to enforce the behavior from Quarto 1.6, you can set the [environment variable](/docs/advanced/environment-vars.qmd) `QUARTO_RUN_NO_NETWORK` to `true`.
 Note that this means that the imports from `stdlib/` will not work in general.
 
 You may come across example code that embeds versions directly in Deno library imports. For example:


### PR DESCRIPTION
I believe this is wrong version right ? 