### PR TITLE
Correct link for template

### DIFF
--- a/docs/gallery/gallery.yml
+++ b/docs/gallery/gallery.yml
@@ -391,7 +391,7 @@
       code: https://github.com/geocompx/py
       thumbnail: books/geocompy.png      
     - title: utilitR documentation (French)
-      href: https://www.book.utilitr.org/
+      href: https://book.utilitr.org/
       code: https://github.com/InseeFrLab/utilitR
       thumbnail: books/utilitr.png      
     - title: Analyse et conception de logiciels (French)


### PR DESCRIPTION
- took off `www.` since the url is actually `https://book.utilitr.org/`