### PR TITLE
add app_and_amp to shortcodes-and-filters.yml

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -28,6 +28,12 @@
   description: >
     Shortcode for animating text using [Animate.css](https://animate.style/).
 
+- name: apa_and_amp
+  path: https://github.com/gwbrck/apa_and_amp
+  author: '[Gregor Willenbrock](https://github.com/gwbrck)'
+  description: >
+    Small Quarto filter extension for valid APA narrative citation ("and" instead of ampersand)
+
 - name: assign
   path: https://github.com/coatless-quarto/assign
   author: '[James Joseph Balamuta](https://github.com/coatless/)'


### PR DESCRIPTION
This is a minimal Quarto filter extension designed to correct narrative APA citations by replacing the ampersand (`&`) with the word `and` in in-text narrative citations. Unlike the broader apaquarto extension, this filter has a focused scope: handling narrative citations for APA-style compliance. It does not include additional formatting features or broader APA-related enhancements. See https://github.com/quarto-dev/quarto-cli/discussions/11545