### PR TITLE
fix: incorrect repository name for bluesky-comments extension

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -68,7 +68,7 @@
     Format the codes in python code-chunk using [black](https://black.readthedocs.io/en/stable/index.html) formatter.
 
 - name: bluesky-comments
-  path: https://github.com/quarto-ext/quarto-bluesky-comments
+  path: https://github.com/quarto-ext/bluesky-comments
   author: 
   - '[Garrick Aden-Buie](https://github.com/gadenbuie)'
   - '[James Joseph Balamuta](https://github.com/coatless/)'


### PR DESCRIPTION
Update the repository path for the bluesky-comments extension to the correct URL.