### PR TITLE
docs: add data import code cell and download link to CSV file

### DIFF
--- a/docs/computations/ojs.qmd
+++ b/docs/computations/ojs.qmd
@@ -18,6 +18,10 @@ OJS works in any Quarto document (plain markdown as well as Jupyter and Knitr do
 We'll start with a simple example based on Allison Horst's [Palmer Penguins](https://allisonhorst.github.io/palmerpenguins/) dataset. Here we look at how penguin body mass varies across both sex and species (use the provided inputs to filter the dataset by bill length and island):
 
 ```{ojs}
+data = FileAttachment("palmer-penguins.csv").csv({ typed: true })
+```
+
+```{ojs}
 filtered = data.filter(function(penguin) {
   return bill_length_min < penguin.bill_length_mm &&
          islands.includes(penguin.island);
@@ -57,9 +61,9 @@ Plot.rectY(filtered,
 )
 ```
 
-Let's take a look at the source code for this example. First we create an `{ojs}` cell that reads in some data from a CSV file using a [FileAttachment](https://observablehq.com/@observablehq/file-attachments):
+Let's take a look at the source code for this example. First we create an `{ojs}` cell that reads in some data from a CSV file (*e.g.*, [`palmer-penguins.csv`](palmer-penguins.csv){target="_blank" download="palmer-penguins.csv"}) using a [FileAttachment](https://observablehq.com/@observablehq/file-attachments):
 
-```{ojs}
+```{{ojs}}
 data = FileAttachment("palmer-penguins.csv").csv({ typed: true })
 ```
 


### PR DESCRIPTION
This pull request includes updates to the documentation for using OJS in Quarto documents, specifically in the `docs/computations/ojs.qmd` file. The changes focus on improving the clarity and functionality of the example provided.

Documentation improvements:

* Added an `{ojs}` code cell to read data from a CSV file using `FileAttachment` in the introductory example.
* Updated the description to include a downloadable link to the `palmer-penguins.csv` file and corrected the code cell format to `{{ojs}}` for consistency.