### PR TITLE
Add new revealjs-plugin 'audio-slideshow'

### DIFF
--- a/docs/extensions/listings/revealjs.yml
+++ b/docs/extensions/listings/revealjs.yml
@@ -23,6 +23,14 @@
   description: >
     Display attribution text along the right edge of slides.
 
+- name: audio-slideshow
+  path: https://github.com/kapsner/audio-slideshow
+  author:
+  - '[Lorenz A. Kapsner](https://github.com/kapsner)'
+  - '[Asvin Goel](https://github.com/rajgoel)'
+  description: >
+    Adds the option to add/record audio playback to each slide of the presentation.
+
 - name: auto-agenda
   path: https://github.com/andrie/reveal-auto-agenda
   author: '[andrie](https://github.com/andrie)'


### PR DESCRIPTION
This PR adds the revealjs extension 'audio-slideshow' to the web-listing.
This plugin ports the option to add/record audio playback to each slide of the presentation. The plugin was originally developed by @rajgoel (https://github.com/rajgoel/reveal.js-plugins/tree/master/audio-slideshow) - he is mentioned as author as well.

Best, Lorenz