### PR TITLE
Add section about changing titles

### DIFF
--- a/docs/authoring/callouts.qmd
+++ b/docs/authoring/callouts.qmd
@@ -68,14 +68,6 @@ This is an example of a 'folded' caution callout that can be expanded by the use
 :::
 ```
 
-Note that above callout titles are defined by using a heading at the top of the callout. If you prefer, you can also specify the title using the `title` attribute. For example:
-
-```markdown
-::: {.callout-tip title="Tip with Title"}
-This is a callout with a title.
-:::
-```
-
 ## Customizing Appearance
 
 ### Collapse
@@ -117,6 +109,26 @@ which appears as:
 
 Using callouts is an effective way to highlight content that your reader give special consideration or attention.
 :::
+
+### Title
+
+Note that above callout titles are defined by using a heading at the top of the callout. If you prefer, you can also specify the title using the `title` attribute. For example:
+
+```markdown
+::: {.callout-tip title="Tip with Title"}
+This is a callout with a title.
+:::
+```
+You can also change the default title of callout blocks for one page or the whole project, by adding the following lines to your documents yaml-header or your `_quarto.yaml` document respectively.
+
+```markdown
+language:
+  callout-note-title: "New note title"
+  callout-warning-title: "New warning title"
+  callout-important-title: "New important title"
+  callout-tip-title: "New tip title"
+  callout-caution-title: "New caution title"
+```
 
 ### Icons
 


### PR DESCRIPTION
The page only explained how to set the title of one specific callout block. I suggest adding a new section about changing titles in general, also explaining how to change the default titles, as I suspect other users will find that very useful too.