### PR TITLE
docs: move link outside of footnote

### DIFF
--- a/docs/get-started/computations/rstudio.qmd
+++ b/docs/get-started/computations/rstudio.qmd
@@ -232,7 +232,7 @@ See the documentation on [Article Layout](/docs/authoring/article-layout.qmd) to
 
 ## Inline Code
 
-To include executable expressions within markdown, enclose the expression in `` `{r} ` ``^[Quarto also supports the Knitr syntax `` `r ` ``, read more in [Inline Code](/docs/computations/inline-code.qmd)].
+To include executable expressions within markdown, enclose the expression in `` `{r} ` ``^[Quarto also supports the Knitr syntax `` `r ` ``.], read more in [Inline Code](/docs/computations/inline-code.qmd).
 For example, we can use inline code to state the number of observations in our data.
 Try adding the following markdown text to your Quarto document.
 

--- a/docs/get-started/computations/rstudio.qmd
+++ b/docs/get-started/computations/rstudio.qmd
@@ -232,7 +232,9 @@ See the documentation on [Article Layout](/docs/authoring/article-layout.qmd) to
 
 ## Inline Code
 
-To include executable expressions within markdown, enclose the expression in `` `{r} ` ``^[Quarto also supports the Knitr syntax `` `r ` ``.], read more in [Inline Code](/docs/computations/inline-code.qmd).
+To include executable expressions within markdown, enclose the expression in `` `{r} ` ``^[Quarto also supports the Knitr syntax `` `r ` ``, read more in [Inline Code](/docs/computations/inline-code.qmd)].
+For additional details on inline code expressions, please visit the [Inline Code](/docs/computations/inline-code.qmd) documentation.
+
 For example, we can use inline code to state the number of observations in our data.
 Try adding the following markdown text to your Quarto document.
 


### PR DESCRIPTION
Currently the link to the full documentation on inline code is "hidden" inside the footnote.
It would be better for it to be clearly visible.
The footnote is mostly there to say the `knitr` syntax is supported.