### PR TITLE
Add `quarto-gradio` to extension listings

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -258,6 +258,12 @@
   description: >
     Add a Github Corner into your HTML document.
 
+- name: gradio
+  path: https://github.com/peter-gy/quarto-gradio
+  author: '[Péter Ferenc Gyarmati](https://github.com/peter-gy)'
+  description: >
+    Embed fully serverless, browser-based Gradio applications and Python coding playgrounds into your Quarto documents.
+
 - name: hide-comment
   path: https://github.com/shafayetShafee/hide-comment
   author: '[Shafayet Khan Shafee](https://github.com/shafayetShafee)'


### PR DESCRIPTION
Enlists https://github.com/peter-gy/quarto-gradio as a new Quarto extension.