### PR TITLE
MINOR: replace dead conda environments link

### DIFF
--- a/docs/projects/virtual-environments.qmd
+++ b/docs/projects/virtual-environments.qmd
@@ -9,7 +9,7 @@ There are several popular flavors of virtual environment, we will cover the foll
 
 1.  [venv](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) (built into Python 3)
 
-2.  [conda](https://towardsdatascience.com/managing-project-specific-environments-with-conda-406365a539ab) (built into Anaconda/Miniconda)
+2.  [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (built into Anaconda/Miniconda)
 
 3.  [renv](https://rstudio.github.io/renv/articles/renv.html) (package for managing R environments)
 


### PR DESCRIPTION
:wave: 

I just found a dead link in the docs. I think that this official conda doc link might be suitable as a replacement. 