### PR TITLE
docs: add "version" shortcode

### DIFF
--- a/docs/authoring/_shortcodes.qmd
+++ b/docs/authoring/_shortcodes.qmd
@@ -14,6 +14,7 @@ Quarto supports several shortcodes natively:
 
 | Shortcode                                                     | Description                              |
 |---------------------------------------------------------------|------------------------------------------|
+| [version](/docs/authoring/version.qmd)                        | Print Quarto CLI version                 |
 | [var](/docs/authoring/variables.qmd#var)                      | Print value from `_variables.yml` file   |
 | [meta](/docs/authoring/variables.qmd#meta)                    | Print value from document metadata       |
 | [env](/docs/authoring/variables.qmd#url)                      | Print system environment variable        |

--- a/docs/authoring/version.qmd
+++ b/docs/authoring/version.qmd
@@ -8,7 +8,7 @@ The `version` shortcode prints the version of the Quarto CLI that is being used 
 
 ## Example
 
-Here's an example of the `version` shortcode in action:
+Here's an example of the `{{{< version >}}}` shortcode in action:
 
 > Quarto CLI {{< version >}} is being used to build this document.
 

--- a/docs/authoring/version.qmd
+++ b/docs/authoring/version.qmd
@@ -1,0 +1,24 @@
+---
+title: Displaying Quarto CLI Version
+---
+
+## Overview
+
+The `version` shortcode prints the version of the Quarto CLI that is being used to build the document as part of the document content.
+
+## Example
+
+Here's an example of the `version` shortcode in action:
+
+> Quarto CLI {{< version >}} is being used to build this document.
+
+## Usage
+
+::: {layout-ncol=2}
+```markdown
+Quarto CLI {{{< version >}}} is amazing.
+```
+:::: {.border}
+Quarto CLI {{< version >}} is amazing.
+::::
+:::


### PR DESCRIPTION
Follow-up on the implementation of the "version" shortcode from:

- quarto-dev/quarto-cli#12006

Fixes quarto-dev/quarto-cli#11379