### PR TITLE
Add callouty-theorem to shortcodes-and-filters.yml

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -88,6 +88,12 @@
     Use [Bootstrap Icons](https://icons.getbootstrap.com/) in HTML documents and
     Revealjs presentations.
 
+- name: callouty-theorem
+  path: https://github.com/sun123zxy/quarto-callouty-theorem
+  author: "[sun123zxy](https://github.com/sun123zxy/)"
+  description: >
+    Wraps theorems and proofs in callout blocks for better visual appeal.
+
 - name: code-fullscreen
   path: https://github.com/shafayetShafee/code-fullscreen
   author: '[Shafayet Khan Shafee](https://github.com/shafayetShafee)'


### PR DESCRIPTION
This filter wraps theorems and proofs in callout blocks for better visual appeal.