### PR TITLE
Add special span classes

### DIFF
--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -538,6 +538,15 @@ classes `.smallcaps`, `.underline` or `.mark` respectively.
 | ```                                    |                                           |
 +----------------------------------------+-------------------------------------------+
 
+::: {.callout-note}
+
+## In supported formats only
+
+Support for these classes comes directly from Pandoc. 
+Not all formats support all of these classes. 
+In particular, `.mark` is not currently supported in `format: pptx`.
+
+:::
 
 ## Special Characters
 

--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -395,7 +395,12 @@ Videos can refer to video files (e.g. MPEG) or can be links to videos published 
 
 ## Divs and Spans {#sec-divs-and-spans}
 
-You can add classes, attributes, and other identifiers to regions of content using Divs and Spans (you'll see an example of this below in [Callout Blocks]).
+You can add classes, attributes, and other identifiers to regions of content using Divs and Spans.
+Although the terms *Div* and *Span* originate in HTML, the syntax is used in Quarto across output formats.
+For example, [Callout Blocks](#callout-blocks) are specified using the div syntax, and [Small Caps](#other-spans) are specified using the span syntax, and both work for many formats beyond HTML.
+You may also use CSS and/or a [Filter](/docs/extensions/filters.qmd) along with Divs and Spans to provide styling or other behavior within rendered documents beyond what Quarto provides.
+
+### Divs
 
 For example, here we add the "border" class to a region of content using a div (`:::`):
 
@@ -439,6 +444,8 @@ Once rendered to HTML, Quarto will translate the markdown into:
 
 Fences without attributes are always closing fences. Unlike with fenced code blocks, the number of colons in the closing fence need not match the number in the opening fence. However, it can be helpful for visual clarity to use fences of different lengths to distinguish nested divs from their parents.
 
+### Spans 
+
 A bracketed sequence of inlines, as one would use to begin a link, will be treated as a `Span` with attributes if it is followed immediately by attributes:
 
 ``` markdown
@@ -452,8 +459,6 @@ Once rendered to HTML, Quarto will translate the markdown into:
   This is <em>some text</em>
 </span>
 ```
-
-Typically, you'll use CSS and/or a [Filter](/docs/extensions/filters.qmd) along with Divs and Spans to provide styling or other behavior within rendered documents.
 
 ### Ordering of Attributes
 
@@ -511,6 +516,28 @@ Learn more in the article on [Callout Blocks](callouts.qmd).
 | |   are preserved        |                          |
 | ```                      |                          |
 +--------------------------+--------------------------+
+
+## Other Spans {#other-spans}
+
+To create text in small caps, that is underlined, or that is highlighted, use a span with one of the 
+classes `.smallcaps`, `.underline` or `.mark` respectively.
+
++----------------------------------------+-------------------------------------------+
+| Markdown Syntax                        | Output                                    |
++========================================+===========================================+
+| ``` markdown                           | [This text is smallcaps]{.smallcaps}      |
+| [This text is smallcaps]{.smallcaps}   |                                           |
+| ```                                    |                                           |
++----------------------------------------+-------------------------------------------+
+| ``` markdown                           | [This text is underlined]{.underline}     |
+| [This text is underlined]{.underline}  |                                           |
+| ```                                    |                                           |
++----------------------------------------+-------------------------------------------+
+| ``` markdown                           | [This text is highlighted]{.mark}         |
+| [This text is highlighted]{.mark}      |                                           |
+| ```                                    |                                           |
++----------------------------------------+-------------------------------------------+
+
 
 ## Special Characters
 


### PR DESCRIPTION
Closes https://github.com/quarto-dev/quarto-cli/issues/12073

Adds an "Other Spans" section: [Preview](https://deploy-preview-1601.quarto.org/docs/authoring/markdown-basics.html#other-spans)

