### PR TITLE
fix: inconsistent kernel version for julia

### DIFF
--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -152,12 +152,12 @@ Alternatively, if you are using Jupyter from within any other version of Python 
 
 ### Kernel Selection
 
-You'll note in our first example that we specified the use of the `julia-1.7` kernel explicitly in our document options (shortened for brevity):
+You'll note in our first example that we specified the use of the `julia-1.8` kernel explicitly in our document options (shortened for brevity):
 
 ``` markdown
 ---
 title: "StatsPlots Demo"
-jupyter: julia-1.7
+jupyter: julia-1.8
 ---
 ```
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/computations/julia.qmd` file. The change updates the kernel version specified in the document options from `julia-1.7` to `julia-1.8` to make it consistent as it quotes the first example which uses 1.8.
