### PR TITLE
Refactor Julia page

### DIFF
--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -6,7 +6,7 @@ vscode-extension: "[Julia Extension](https://www.julia-vscode.org/docs)"
 vscode-screenshot: "![](images/julia-vscode){.border fig-alt='Screen shot of VS Code with quarto document containing Julia code on the left, the output of a plot from the Julia code on the right, and the Quarto Help pane at the bottom.'}"
 ---
 
-## Overview
+# Overview
 
 Quarto supports executable Julia code blocks within markdown. This allows you to create fully reproducible documents and reports---the Julia code required to produce your output is part of the document itself, and is automatically re-run whenever the document is rendered.
 
@@ -19,11 +19,81 @@ Juliaup installation manager, or the "manual" installation approach. Unless
 you know that you need to use the "manual" approach, use
 Juliaup since it allows you to manage multiple Julia versions on your system.
 
+first we'll cover the basics of creating and rendering documents with Julia code blocks.
+
+### Code Blocks
+
+Code blocks that use braces around the language name (e.g. ```` ```{julia} ````) are executable, and will be run by Quarto during render. Here is a simple example:
+
+```` markdown
+---
+title: "Plots Demo"
+author: "Norah Jones"
+date: "5/22/2021"
+format:
+  html:
+    code-fold: true
+jupyter: julia-1.8
+---
+
+### Parametric Plots
+
+Plot function pair (x(u), y(u)). 
+See @fig-parametric for an example.
+
+```{{julia}}
+#| label: fig-parametric
+#| fig-cap: "Parametric Plots"
+
+using Plots
+
+plot(sin, 
+     x->sin(2x), 
+     0, 
+     2π, 
+     leg=false, 
+     fill=(0,:lavender))
+```
+````
+
+You'll note that there are some special comments at the top of the code block. These are cell level options that make the figure [cross-referenceable](/docs/authoring/cross-references.qmd).
+
+This document would result in the following rendered output:
+
+![](/images/hello-julia.png){.border fig-alt="Example Plots Demo output with title, author, date published and main section on Parametric plots which contains text, a toggleable code field, and the output of the plot, with the caption Figure 1 Parametric Plots."}
+
+You can produce a wide variety of output types from executable code blocks, including plots, tabular output from data frames, and plain text output (e.g. printing the results of statistical summaries).
+
+There are many options which control the behavior of code execution and output, you can read more about them in the article on [Execution Options](execution-options.qmd).
+
+In addition to code blocks which interrupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
+
+#### Multiple Outputs
+
+By default Julia cells will automatically print the value of their last statement (as with the example above where the call to `plot()` resulted in plot output). If you want to display multiple plots (or other types of output) from a single cell you should call the `display()` function explicitly. For example, here we output two plots side-by-side with sub-captions:
+
+```{{julia}}
+#| label: fig-plots
+#| fig-cap: "Multiple Plots"
+#| fig-subcap:
+#|   - "Plot 1"
+#|   - "Plot 2"
+#| layout-ncol: 2
+
+using Plots
+display(plot(sin, x -> sin(2x), 0, 2))
+display(plot(x -> sin(4x), y -> sin(5y), 0, 2))
+```
+
+{{< include _jupyter-rendering.md >}}
+
+{{< include _jupyter-authoring-tools.md >}}
+
 # Using the `julia` engine
 
 {{< include /docs/prerelease/1.5/_pre-release-feature.qmd >}}
 
-## Installation
+## Installation {#installation-native}
 
 The `julia` engine uses the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks. When you first attempt to render a notebook with the `julia` engine, Quarto will automatically install this package into a private environment that is owned by Quarto. This means you don't have to install anything in your global Julia environment for Quarto to work and Quarto will not interfere with any other Julia environments on your system. Quarto will use the `julia` binary on your PATH by default, but you can override this using the `QUARTO_JULIA` environment variable.
 
@@ -431,75 +501,6 @@ repository.
 
 # Using the `jupyter` engine
 
-Below we'll describe how to [install](#installation) IJulia and related requirements but first we'll cover the basics of creating and rendering documents with Julia code blocks.
-
-#### Code Blocks
-
-Code blocks that use braces around the language name (e.g. ```` ```{julia} ````) are executable, and will be run by Quarto during render. Here is a simple example:
-
-```` markdown
----
-title: "Plots Demo"
-author: "Norah Jones"
-date: "5/22/2021"
-format:
-  html:
-    code-fold: true
-jupyter: julia-1.8
----
-
-### Parametric Plots
-
-Plot function pair (x(u), y(u)). 
-See @fig-parametric for an example.
-
-```{{julia}}
-#| label: fig-parametric
-#| fig-cap: "Parametric Plots"
-
-using Plots
-
-plot(sin, 
-     x->sin(2x), 
-     0, 
-     2π, 
-     leg=false, 
-     fill=(0,:lavender))
-```
-````
-
-You'll note that there are some special comments at the top of the code block. These are cell level options that make the figure [cross-referenceable](/docs/authoring/cross-references.qmd).
-
-This document would result in the following rendered output:
-
-![](/images/hello-julia.png){.border fig-alt="Example Plots Demo output with title, author, date published and main section on Parametric plots which contains text, a toggleable code field, and the output of the plot, with the caption Figure 1 Parametric Plots."}
-
-You can produce a wide variety of output types from executable code blocks, including plots, tabular output from data frames, and plain text output (e.g. printing the results of statistical summaries).
-
-There are many options which control the behavior of code execution and output, you can read more about them in the article on [Execution Options](execution-options.qmd).
-
-In addition to code blocks which interrupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
-
-#### Multiple Outputs
-
-By default Julia cells will automatically print the value of their last statement (as with the example above where the call to `plot()` resulted in plot output). If you want to display multiple plots (or other types of output) from a single cell you should call the `display()` function explicitly. For example, here we output two plots side-by-side with sub-captions:
-
-```{{julia}}
-#| label: fig-plots
-#| fig-cap: "Multiple Plots"
-#| fig-subcap:
-#|   - "Plot 1"
-#|   - "Plot 2"
-#| layout-ncol: 2
-
-using Plots
-display(plot(sin, x -> sin(2x), 0, 2))
-display(plot(x -> sin(4x), y -> sin(5y), 0, 2))
-```
-
-{{< include _jupyter-rendering.md >}}
-
-
 ### Installation {#installation}
 
 In order to render documents with embedded Julia code you'll need to install the following components:
@@ -560,8 +561,6 @@ Conda.add("jupyter-cache")
 ```
 
 Alternatively, if you are using Jupyter from within any other version of Python not managed by IJulia, see the instructions below on [Installing Jupyter](#installing-jupyter) for details on installing `jupyter cache`,
-
-{{< include _jupyter-authoring-tools.md >}}
 
 {{< include _jupyter-cache.md >}}
 

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -19,196 +19,6 @@ Juliaup installation manager, or the "manual" installation approach. Unless
 you know that you need to use the "manual" approach, use
 Juliaup since it allows you to manage multiple Julia versions on your system.
 
-# Using the `jupyter` engine
-
-Below we'll describe how to [install](#installation) IJulia and related requirements but first we'll cover the basics of creating and rendering documents with Julia code blocks.
-
-#### Code Blocks
-
-Code blocks that use braces around the language name (e.g. ```` ```{julia} ````) are executable, and will be run by Quarto during render. Here is a simple example:
-
-```` markdown
----
-title: "Plots Demo"
-author: "Norah Jones"
-date: "5/22/2021"
-format:
-  html:
-    code-fold: true
-jupyter: julia-1.8
----
-
-### Parametric Plots
-
-Plot function pair (x(u), y(u)). 
-See @fig-parametric for an example.
-
-```{{julia}}
-#| label: fig-parametric
-#| fig-cap: "Parametric Plots"
-
-using Plots
-
-plot(sin, 
-     x->sin(2x), 
-     0, 
-     2π, 
-     leg=false, 
-     fill=(0,:lavender))
-```
-````
-
-You'll note that there are some special comments at the top of the code block. These are cell level options that make the figure [cross-referenceable](/docs/authoring/cross-references.qmd).
-
-This document would result in the following rendered output:
-
-![](/images/hello-julia.png){.border fig-alt="Example Plots Demo output with title, author, date published and main section on Parametric plots which contains text, a toggleable code field, and the output of the plot, with the caption Figure 1 Parametric Plots."}
-
-You can produce a wide variety of output types from executable code blocks, including plots, tabular output from data frames, and plain text output (e.g. printing the results of statistical summaries).
-
-There are many options which control the behavior of code execution and output, you can read more about them in the article on [Execution Options](execution-options.qmd).
-
-In addition to code blocks which interrupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
-
-#### Multiple Outputs
-
-By default Julia cells will automatically print the value of their last statement (as with the example above where the call to `plot()` resulted in plot output). If you want to display multiple plots (or other types of output) from a single cell you should call the `display()` function explicitly. For example, here we output two plots side-by-side with sub-captions:
-
-```{{julia}}
-#| label: fig-plots
-#| fig-cap: "Multiple Plots"
-#| fig-subcap:
-#|   - "Plot 1"
-#|   - "Plot 2"
-#| layout-ncol: 2
-
-using Plots
-display(plot(sin, x -> sin(2x), 0, 2))
-display(plot(x -> sin(4x), y -> sin(5y), 0, 2))
-```
-
-{{< include _jupyter-rendering.md >}}
-
-
-### Installation {#installation}
-
-In order to render documents with embedded Julia code you'll need to install the following components:
-
-1)  IJulia
-2)  Revise.jl
-3)  Optionally, Jupyter Cache
-
-We'll cover each of these in turn below.
-
-#### IJulia {#ijulia}
-
-[IJulia](https://julialang.github.io/IJulia.jl/stable) is a Julia-language execution kernel for Jupyter. You can install IJulia from within the Julia REPL as follows:
-
-``` julia
-using Pkg
-Pkg.add("IJulia")
-using IJulia
-notebook()
-```
-
-The first time you run `notebook()`, it will prompt you for whether it should install Jupyter. Hit enter to have it use the [Conda.jl](https://github.com/Luthaf/Conda.jl) package to install a minimal Python+Jupyter distribution (via [Miniconda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html)) that is private to Julia (not in your `PATH`). On Linux, it defaults to looking for `jupyter` in your `PATH` first, and only asks to installs the Conda Jupyter if that fails.
-
-If you choose not to use Conda.jl to install Python and Jupyter you will need to make sure that you have another installation of it on your system (see the section on [Installing Jupyter](#installing-jupyter) if you need help with this).
-
-#### Revise.jl
-
-In addition to IJulia, you'll want to install [Revise.jl](https://timholy.github.io/Revise.jl/stable) and configure it for use with IJulia. Revise.jl is a library that helps you keep your Julia sessions running longer, reducing the need to restart when you make changes to code.
-
-Quarto maintains a persistent [kernel daemon](#kernel-daemon) for each document to mitigate Jupyter start up time during iterative work. Revise.jl will make this persistent process robust in the face of package updates, git branch checkouts, etc. Install Revise.jl with:
-
-``` julia
-using Pkg
-Pkg.add("Revise")
-```
-
-To configure Revise to launch automatically within IJulia, create a `.julia/config/startup_ijulia.jl` file with the contents:
-
-``` default
-try
-  @eval using Revise
-catch e
-  @warn "Revise init" exception=(e, catch_backtrace())
-end
-```
-
-You can learn more about Revise.jl at <https://timholy.github.io/Revise.jl/stable>.
-
-#### Jupyter Cache
-
-[Jupyter Cache](https://jupyter-cache.readthedocs.io/en/latest/) enables you to cache all of the cell outputs for a notebook. If any of the cells in the notebook change then all of the cells will be re-executed.
-
-If you are using the integrated version of Jupyter installed by `IJulia.notebook()`, then you will need to add `jupyter-cache` to the Python environment managed by IJulia. You can do that as follows:
-
-``` julia
-using Conda
-Conda.add("jupyter-cache")
-```
-
-Alternatively, if you are using Jupyter from within any other version of Python not managed by IJulia, see the instructions below on [Installing Jupyter](#installing-jupyter) for details on installing `jupyter cache`,
-
-{{< include _jupyter-authoring-tools.md >}}
-
-{{< include _jupyter-cache.md >}}
-
-{{< include _caching-more.md >}}
-
-### Kernel Selection
-
-You'll note in our first example that we specified the use of the `julia-1.8` kernel explicitly in our document options (shortened for brevity):
-
-``` markdown
----
-title: "StatsPlots Demo"
-jupyter: julia-1.8
----
-```
-
-If no `jupyter` kernel is explicitly specified, then Quarto will attempt to automatically discover a kernel on the system that supports Julia.
-
-You can discover the available Jupyter kernels on your system using the `quarto check` command:
-
-``` {.bash filename="Terminal"}
-quarto check jupyter
-```
-
-{{< include _jupyter-daemon.md >}}
-
-
-### Installing Jupyter {#installing-jupyter}
-
-You can rely on the minimal version of Python and Jupyter that is installed automatically by **IJulia**, or you can choose to install Python and Jupyter separately. If you need to install another version of Jupyter this section describes how.
-
-{{< include _jupyter-install.md >}}
-
-#### Jupyter Cache
-
-[Jupyter Cache](https://jupyter-cache.readthedocs.io/en/latest/) enables you to cache all of the cell outputs for a notebook. If any of the cells in the notebook change then all of the cells will be re-executed.
-
-To use Jupyter Cache you'll want to first install the `jupyter-cache` package:
-
-+-----------+--------------------------------------+
-| Platform  | Command                              |
-+===========+======================================+
-| Mac/Linux | ```{.bash filename="Terminal"}       |
-|           | python3 -m pip install jupyter-cache |
-|           | ```                                  |
-+-----------+--------------------------------------+
-| Windows   | ```{.powershell filename="Terminal"} |
-|           | py -m pip install jupyter-cache      |
-|           | ```                                  |
-+-----------+--------------------------------------+
-| Conda     | ```{.bash filename="Terminal"}       |
-|           | conda install jupyter-cache          |
-|           | ```                                  |
-+-----------+--------------------------------------+
-
-To enable the cache for a document, add the `cache` option. For example:
-
 # Using the `julia` engine
 
 {{< include /docs/prerelease/1.5/_pre-release-feature.qmd >}}
@@ -618,3 +428,194 @@ packages that wish to extend the functionality of notebooks in other ways.
 Please direct questions and requests regarding this functionality to the
 [QuartoNotebookRunner](https://github.com/PumasAI/QuartoNotebookRunner.jl)
 repository.
+
+# Using the `jupyter` engine
+
+Below we'll describe how to [install](#installation) IJulia and related requirements but first we'll cover the basics of creating and rendering documents with Julia code blocks.
+
+#### Code Blocks
+
+Code blocks that use braces around the language name (e.g. ```` ```{julia} ````) are executable, and will be run by Quarto during render. Here is a simple example:
+
+```` markdown
+---
+title: "Plots Demo"
+author: "Norah Jones"
+date: "5/22/2021"
+format:
+  html:
+    code-fold: true
+jupyter: julia-1.8
+---
+
+### Parametric Plots
+
+Plot function pair (x(u), y(u)). 
+See @fig-parametric for an example.
+
+```{{julia}}
+#| label: fig-parametric
+#| fig-cap: "Parametric Plots"
+
+using Plots
+
+plot(sin, 
+     x->sin(2x), 
+     0, 
+     2π, 
+     leg=false, 
+     fill=(0,:lavender))
+```
+````
+
+You'll note that there are some special comments at the top of the code block. These are cell level options that make the figure [cross-referenceable](/docs/authoring/cross-references.qmd).
+
+This document would result in the following rendered output:
+
+![](/images/hello-julia.png){.border fig-alt="Example Plots Demo output with title, author, date published and main section on Parametric plots which contains text, a toggleable code field, and the output of the plot, with the caption Figure 1 Parametric Plots."}
+
+You can produce a wide variety of output types from executable code blocks, including plots, tabular output from data frames, and plain text output (e.g. printing the results of statistical summaries).
+
+There are many options which control the behavior of code execution and output, you can read more about them in the article on [Execution Options](execution-options.qmd).
+
+In addition to code blocks which interrupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
+
+#### Multiple Outputs
+
+By default Julia cells will automatically print the value of their last statement (as with the example above where the call to `plot()` resulted in plot output). If you want to display multiple plots (or other types of output) from a single cell you should call the `display()` function explicitly. For example, here we output two plots side-by-side with sub-captions:
+
+```{{julia}}
+#| label: fig-plots
+#| fig-cap: "Multiple Plots"
+#| fig-subcap:
+#|   - "Plot 1"
+#|   - "Plot 2"
+#| layout-ncol: 2
+
+using Plots
+display(plot(sin, x -> sin(2x), 0, 2))
+display(plot(x -> sin(4x), y -> sin(5y), 0, 2))
+```
+
+{{< include _jupyter-rendering.md >}}
+
+
+### Installation {#installation}
+
+In order to render documents with embedded Julia code you'll need to install the following components:
+
+1)  IJulia
+2)  Revise.jl
+3)  Optionally, Jupyter Cache
+
+We'll cover each of these in turn below.
+
+#### IJulia {#ijulia}
+
+[IJulia](https://julialang.github.io/IJulia.jl/stable) is a Julia-language execution kernel for Jupyter. You can install IJulia from within the Julia REPL as follows:
+
+``` julia
+using Pkg
+Pkg.add("IJulia")
+using IJulia
+notebook()
+```
+
+The first time you run `notebook()`, it will prompt you for whether it should install Jupyter. Hit enter to have it use the [Conda.jl](https://github.com/Luthaf/Conda.jl) package to install a minimal Python+Jupyter distribution (via [Miniconda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html)) that is private to Julia (not in your `PATH`). On Linux, it defaults to looking for `jupyter` in your `PATH` first, and only asks to installs the Conda Jupyter if that fails.
+
+If you choose not to use Conda.jl to install Python and Jupyter you will need to make sure that you have another installation of it on your system (see the section on [Installing Jupyter](#installing-jupyter) if you need help with this).
+
+#### Revise.jl
+
+In addition to IJulia, you'll want to install [Revise.jl](https://timholy.github.io/Revise.jl/stable) and configure it for use with IJulia. Revise.jl is a library that helps you keep your Julia sessions running longer, reducing the need to restart when you make changes to code.
+
+Quarto maintains a persistent [kernel daemon](#kernel-daemon) for each document to mitigate Jupyter start up time during iterative work. Revise.jl will make this persistent process robust in the face of package updates, git branch checkouts, etc. Install Revise.jl with:
+
+``` julia
+using Pkg
+Pkg.add("Revise")
+```
+
+To configure Revise to launch automatically within IJulia, create a `.julia/config/startup_ijulia.jl` file with the contents:
+
+``` default
+try
+  @eval using Revise
+catch e
+  @warn "Revise init" exception=(e, catch_backtrace())
+end
+```
+
+You can learn more about Revise.jl at <https://timholy.github.io/Revise.jl/stable>.
+
+#### Jupyter Cache
+
+[Jupyter Cache](https://jupyter-cache.readthedocs.io/en/latest/) enables you to cache all of the cell outputs for a notebook. If any of the cells in the notebook change then all of the cells will be re-executed.
+
+If you are using the integrated version of Jupyter installed by `IJulia.notebook()`, then you will need to add `jupyter-cache` to the Python environment managed by IJulia. You can do that as follows:
+
+``` julia
+using Conda
+Conda.add("jupyter-cache")
+```
+
+Alternatively, if you are using Jupyter from within any other version of Python not managed by IJulia, see the instructions below on [Installing Jupyter](#installing-jupyter) for details on installing `jupyter cache`,
+
+{{< include _jupyter-authoring-tools.md >}}
+
+{{< include _jupyter-cache.md >}}
+
+{{< include _caching-more.md >}}
+
+### Kernel Selection
+
+You'll note in our first example that we specified the use of the `julia-1.8` kernel explicitly in our document options (shortened for brevity):
+
+``` markdown
+---
+title: "StatsPlots Demo"
+jupyter: julia-1.8
+---
+```
+
+If no `jupyter` kernel is explicitly specified, then Quarto will attempt to automatically discover a kernel on the system that supports Julia.
+
+You can discover the available Jupyter kernels on your system using the `quarto check` command:
+
+``` {.bash filename="Terminal"}
+quarto check jupyter
+```
+
+{{< include _jupyter-daemon.md >}}
+
+
+### Installing Jupyter {#installing-jupyter}
+
+You can rely on the minimal version of Python and Jupyter that is installed automatically by **IJulia**, or you can choose to install Python and Jupyter separately. If you need to install another version of Jupyter this section describes how.
+
+{{< include _jupyter-install.md >}}
+
+#### Jupyter Cache
+
+[Jupyter Cache](https://jupyter-cache.readthedocs.io/en/latest/) enables you to cache all of the cell outputs for a notebook. If any of the cells in the notebook change then all of the cells will be re-executed.
+
+To use Jupyter Cache you'll want to first install the `jupyter-cache` package:
+
++-----------+--------------------------------------+
+| Platform  | Command                              |
++===========+======================================+
+| Mac/Linux | ```{.bash filename="Terminal"}       |
+|           | python3 -m pip install jupyter-cache |
+|           | ```                                  |
++-----------+--------------------------------------+
+| Windows   | ```{.powershell filename="Terminal"} |
+|           | py -m pip install jupyter-cache      |
+|           | ```                                  |
++-----------+--------------------------------------+
+| Conda     | ```{.bash filename="Terminal"}       |
+|           | conda install jupyter-cache          |
+|           | ```                                  |
++-----------+--------------------------------------+
+
+To enable the cache for a document, add the `cache` option. For example:
+

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -81,7 +81,7 @@ You can produce a wide variety of output types from executable code blocks, incl
 
 There are many options which control the behavior of code execution and output, you can read more about them in the article on [Execution Options](execution-options.qmd).
 
-In addition to code blocks which interrupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
+In addition to code blocks which interrupt the flow of Markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
 
 #### Multiple Outputs
 
@@ -445,7 +445,7 @@ Notebook caches are invalidated based on the following criteria:
 
 Changes that do not invalidate a cache:
 
-- Editing markdown content outside of executable Julia cells.
+- Editing Markdown content outside of executable Julia cells.
 
 Caches are saved to file in a `.cache` directory alongside the notebook file.
 This directory is safe to remove if you want to invalidate all caches. The

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -24,7 +24,7 @@ This table lists some of the reasons why the `julia` engine was created:
 | Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅           | ❌              |
 | "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅           | ❌              |
 
-::: {..-note}
+::: {.callout-note}
 For most users, the `julia` engine should offer the best experience.
 However, for backwards compatibility the `jupyter` engine remains the default engine for Julia code.
 The `julia` engine has to be [specifically enabled either in the frontmatter or the project file](#enabling-the-julia-engine).
@@ -146,7 +146,29 @@ engines: ['julia']
 
 ## Rendering notebooks
 
-Rendering a notebook will start a persistent server process if it hasn't already started. This server process first loads QuartoNotebookRunner from Quarto's private environment. QuartoNotebookRunner then spins up a separate Julia worker process for each notebook you want to render.
+Requesting the first render of a notebook which contains Julia code blocks and has the `julia` engine enabled will start a persistent server process that loads QuartoNotebookRunner.jl.
+This package is installed automatically in an environment private to Quarto.
+
+The server spins up a separate Julia worker process for each notebook you want to render.
+Every purple node in the following graph represents a separate Julia process which runs independently from each short-lived `quarto` process that communicates with the server.
+
+```{mermaid}
+flowchart LR
+    A[<b>quarto render ...</b>] <-.-> B[<b>Server Process</b><br/>QuartoNotebookRunner.jl]
+    B <--> C[<b>Worker Process 1</b><br/>notebook_A.qmd]
+    B <--> D[<b>Worker Process 2</b><br/>notebook_B.qmd]
+    B <--> E[<b>Worker Process 3</b><br/>notebook_C.qmd]
+
+    style A color:#333
+    style B fill:#cb9be0,color:#333
+    style C fill:#e7d0f2,color:#333
+    style D fill:#e7d0f2,color:#333
+    style E fill:#e7d0f2,color:#333
+```
+
+You can check the status of the server, request it to shut down, and more using the [`call julia engine` commands](#quarto-call-engine-julia-commands).
+The server will stay alive for five minutes after the last worker process has exited, unless it's closed manually.
+Changes to environment variables that influence the server process will only be picked up once the next new server process is started.
 
 ### Notebook environments
 

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -14,25 +14,15 @@ Quarto has two available engines for executing Julia code, the newer [native eng
 
 This table lists some of the reasons why the native engine was created:
 
-+--------------------------------------------------------------------------+---------------+----------------+
-|                                                                          | Native Engine | Jupyter Engine |
-+==========================================================================+===============+================+
-| Execute Julia code blocks                                                | ✅            | ✅              |
-+--------------------------------------------------------------------------+---------------+----------------+
-| Keep sessions alive for fast reruns                                      | ✅            | ✅              |
-+--------------------------------------------------------------------------+---------------+----------------+
-| No Python installation required                                          | ✅            | ❌              |
-+--------------------------------------------------------------------------+---------------+----------------+
-| No global package installation needed                                    | ✅            | ❌              |
-+--------------------------------------------------------------------------+---------------+----------------+
-| Automatic integration with juliaup (no kernel installation)              | ✅            | ❌              |
-+--------------------------------------------------------------------------+---------------+----------------+
-| Python & R Codeblocks                                                    | ✅            | ❌              |
-| (via PythonCall.jl and RCall.jl)                                         |               |                |
-+--------------------------------------------------------------------------+---------------+----------------+
-| "Expandable cells" or programmatic document generation                   | ✅            | ❌              |
-| (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) |               |                |
-+--------------------------------------------------------------------------+---------------+----------------+
+|                                                                                                                                 | Native Engine | Jupyter Engine |
+|---------------------------------------------------------------------------------------------------------------------------------|---------------|----------------|
+| Execute Julia code blocks                                                                                                       | ✅            | ✅              |
+| Keep sessions alive for fast reruns                                                                                             | ✅            | ✅              |
+| No Python installation required                                                                                                 | ✅            | ❌              |
+| No global package installation needed                                                                                           | ✅            | ❌              |
+| Automatic integration with juliaup (no kernel installation)                                                                     | ✅            | ❌              |
+| Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅            | ❌              |
+| "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅            | ❌              |
 
 ::: {.callout-note}
 For most users, the native engine should offer the best experience.

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -24,7 +24,7 @@ This table lists some of the reasons why the `julia` engine was created:
 | Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅           | ❌              |
 | "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅           | ❌              |
 
-::: {.callout-note}
+::: {..-note}
 For most users, the `julia` engine should offer the best experience.
 However, for backwards compatibility the `jupyter` engine remains the default engine for Julia code.
 The `julia` engine has to be [specifically enabled either in the frontmatter or the project file](#enabling-the-julia-engine).
@@ -112,11 +112,14 @@ display(plot(x -> sin(4x), y -> sin(5y), 0, 2))
 
 The `julia` engine uses the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks. When you first attempt to render a notebook with the `julia` engine, Quarto will automatically install this package into a private environment that is owned by Quarto. This means you don't have to install anything in your global Julia environment for Quarto to work and Quarto will not interfere with any other Julia environments on your system. Quarto will use the `julia` binary on your PATH by default, but you can override this using the `QUARTO_JULIA` environment variable.
 
-### Using custom versions of `QuartoNotebookRunner`
+:::{.callout-note}
+
+## Using custom versions of `QuartoNotebookRunner`
 
 In special circumstances, you may not want to use the specific `QuartoNotebookRunner` version that Quarto installs for you. For example, you might be developing `QuartoNotebookRunner` itself, or you need to use a fork or an unreleased version with a bugfix. In this case, set the [environment variable](/docs/projects/environment.qmd) `QUARTO_JULIA_PROJECT` to a directory of a julia environment that has `QuartoNotebookRunner` installed. 
 
 As an example, you could install the main branch of `QuartoNotebookRunner` into the directory `/some/dir` by executing `]activate /some/dir` in a julia REPL followed by `]add QuartoNotebookRunner#main`. As long as there is no server currently running, running a command like `QUARTO_JULIA_PROJECT=/some/dir quarto render some_notebook.qmd` in your terminal will ensure the server process is started using the custom `QuartoNotebookRunner`. You can also set `quarto`'s `--execute-debug` flag and check the output to verify that the custom environment is being used.
+:::
 
 ## Enabling the `julia` engine
 

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -14,15 +14,15 @@ Quarto has two available engines for executing Julia code, the newer [`julia` en
 
 This table lists some of the reasons why the `julia` engine was created:
 
-|                                                                                                                                 | `julia` Engine | `jupyter` Engine |
-|---------------------------------------------------------------------------------------------------------------------------------|----------------|------------------|
-| Execute Julia code blocks                                                                                                       | ✅             | ✅                |
-| Keep sessions alive for fast reruns                                                                                             | ✅             | ✅                |
-| No Python installation required                                                                                                 | ✅             | ❌                |
-| No global package installation needed                                                                                           | ✅             | ❌                |
-| Automatic integration with juliaup (no kernel installation)                                                                     | ✅             | ❌                |
-| Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅             | ❌                |
-| "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅             | ❌                |
+|                                                                                                                                 | julia Engine | jupyter Engine |
+|---------------------------------------------------------------------------------------------------------------------------------|--------------|----------------|
+| Execute Julia code blocks                                                                                                       | ✅           | ✅              |
+| Keep sessions alive for fast reruns                                                                                             | ✅           | ✅              |
+| No Python installation required                                                                                                 | ✅           | ❌              |
+| No global package installation needed                                                                                           | ✅           | ❌              |
+| Automatic integration with juliaup (no kernel installation)                                                                     | ✅           | ❌              |
+| Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅           | ❌              |
+| "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅           | ❌              |
 
 ::: {.callout-note}
 For most users, the `julia` engine should offer the best experience.

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -10,16 +10,41 @@ vscode-screenshot: "![](images/julia-vscode){.border fig-alt='Screen shot of VS 
 
 Quarto supports executable Julia code blocks within markdown. This allows you to create fully reproducible documents and reports---the Julia code required to produce your output is part of the document itself, and is automatically re-run whenever the document is rendered.
 
-Quarto has two available engines for executing Julia code. The older one is using the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel and depends on Python to run. The newer engine is using the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks and does not have any additional dependencies beyond a Julia installation.
+Quarto has two available engines for executing Julia code, the newer [native engine](#using-the-julia-engine) is using the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks, the older [jupyter engine](#using-the-jupyter-engine) is using the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel.
 
-Using either of these engines will require manually installing Julia if
-you have not done so already. You can download it from
-https://julialang.org/downloads/. There are two options for installation: the
-Juliaup installation manager, or the "manual" installation approach. Unless
-you know that you need to use the "manual" approach, use
-Juliaup since it allows you to manage multiple Julia versions on your system.
+This table lists some of the reasons why the native engine was created:
 
-first we'll cover the basics of creating and rendering documents with Julia code blocks.
++--------------------------------------------------------------------------+---------------+----------------+
+|                                                                          | Native Engine | Jupyter Engine |
++==========================================================================+===============+================+
+| Execute Julia code blocks                                                | ✅            | ✅              |
++--------------------------------------------------------------------------+---------------+----------------+
+| Keep sessions alive for fast reruns                                      | ✅            | ✅              |
++--------------------------------------------------------------------------+---------------+----------------+
+| No Python installation required                                          | ✅            | ❌              |
++--------------------------------------------------------------------------+---------------+----------------+
+| No global package installation needed                                    | ✅            | ❌              |
++--------------------------------------------------------------------------+---------------+----------------+
+| Automatic integration with juliaup (no kernel installation)              | ✅            | ❌              |
++--------------------------------------------------------------------------+---------------+----------------+
+| Python & R Codeblocks                                                    | ✅            | ❌              |
+| (via PythonCall.jl and RCall.jl)                                         |               |                |
++--------------------------------------------------------------------------+---------------+----------------+
+| "Expandable cells" or programmatic document generation                   | ✅            | ❌              |
+| (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) |               |                |
++--------------------------------------------------------------------------+---------------+----------------+
+
+::: {.callout-note}
+For most users, the native engine should offer the best experience.
+However, for backwards compatibility the Jupyter engine remains the default engine for Julia code.
+The native engine has to be [specifically enabled either in the frontmatter or the project file](#enabling-the-native-engine).
+:::
+
+Using either of the two engines will require manually installing Julia if
+you have not done so already. Installation via `juliaup` is recommended, for further
+information check the [official Julia website](https://julialang.org/install/).
+
+Now, we will cover the basics of creating and rendering documents with Julia code blocks.
 
 ### Code Blocks
 
@@ -103,7 +128,7 @@ In special circumstances, you may not want to use the specific `QuartoNotebookRu
 
 As an example, you could install the main branch of `QuartoNotebookRunner` into the directory `/some/dir` by executing `]activate /some/dir` in a julia REPL followed by `]add QuartoNotebookRunner#main`. As long as there is no server currently running, running a command like `QUARTO_JULIA_PROJECT=/some/dir quarto render some_notebook.qmd` in your terminal will ensure the server process is started using the custom `QuartoNotebookRunner`. You can also set `quarto`'s `--execute-debug` flag and check the output to verify that the custom environment is being used.
 
-## Rendering notebooks
+## Enabling the native engine
 
 To use the `julia` engine, you have to specifically enable it. For that, you have two options.
 
@@ -125,6 +150,8 @@ Or, starting with Quarto 1.7, you can prioritize the julia engine project-wide b
 ```{.yaml filename="_quarto.yml"}
 engines: ['julia']
 ```
+
+## Rendering notebooks
 
 Rendering a notebook will start a persistent server process if it hasn't already started. This server process first loads QuartoNotebookRunner from Quarto's private environment. QuartoNotebookRunner then spins up a separate Julia worker process for each notebook you want to render.
 

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -19,7 +19,7 @@ Juliaup installation manager, or the "manual" installation approach. Unless
 you know that you need to use the "manual" approach, use
 Juliaup since it allows you to manage multiple Julia versions on your system.
 
-## Using the `jupyter` engine
+# Using the `jupyter` engine
 
 Below we'll describe how to [install](#installation) IJulia and related requirements but first we'll cover the basics of creating and rendering documents with Julia code blocks.
 
@@ -209,21 +209,21 @@ To use Jupyter Cache you'll want to first install the `jupyter-cache` package:
 
 To enable the cache for a document, add the `cache` option. For example:
 
-## Using the `julia` engine
+# Using the `julia` engine
 
 {{< include /docs/prerelease/1.5/_pre-release-feature.qmd >}}
 
-### Installation
+## Installation
 
 The `julia` engine uses the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks. When you first attempt to render a notebook with the `julia` engine, Quarto will automatically install this package into a private environment that is owned by Quarto. This means you don't have to install anything in your global Julia environment for Quarto to work and Quarto will not interfere with any other Julia environments on your system. Quarto will use the `julia` binary on your PATH by default, but you can override this using the `QUARTO_JULIA` environment variable.
 
-#### Using custom versions of `QuartoNotebookRunner`
+### Using custom versions of `QuartoNotebookRunner`
 
 In special circumstances, you may not want to use the specific `QuartoNotebookRunner` version that Quarto installs for you. For example, you might be developing `QuartoNotebookRunner` itself, or you need to use a fork or an unreleased version with a bugfix. In this case, set the [environment variable](/docs/projects/environment.qmd) `QUARTO_JULIA_PROJECT` to a directory of a julia environment that has `QuartoNotebookRunner` installed. 
 
 As an example, you could install the main branch of `QuartoNotebookRunner` into the directory `/some/dir` by executing `]activate /some/dir` in a julia REPL followed by `]add QuartoNotebookRunner#main`. As long as there is no server currently running, running a command like `QUARTO_JULIA_PROJECT=/some/dir quarto render some_notebook.qmd` in your terminal will ensure the server process is started using the custom `QuartoNotebookRunner`. You can also set `quarto`'s `--execute-debug` flag and check the output to verify that the custom environment is being used.
 
-### Rendering notebooks
+## Rendering notebooks
 
 To use the `julia` engine, you have to specifically enable it. For that, you have two options.
 
@@ -248,7 +248,7 @@ engines: ['julia']
 
 Rendering a notebook will start a persistent server process if it hasn't already started. This server process first loads QuartoNotebookRunner from Quarto's private environment. QuartoNotebookRunner then spins up a separate Julia worker process for each notebook you want to render.
 
-#### Notebook environments
+### Notebook environments
 
 By default, QuartoNotebookRunner will use the `--project=@.` flag when starting a worker. This makes Julia search for an environment (a `Project.toml` or `JuliaProject.toml` file) starting in the directory where the quarto notebook is stored and walking up the directory tree from there.
 
@@ -287,7 +287,7 @@ julia:
 ---
 ````
 
-#### Worker process reuse
+### Worker process reuse
 
 An idle worker process will be kept alive for 5 minutes by default, this can be changed by passing the desired number of seconds to the `daemon` key:
 
@@ -315,7 +315,7 @@ execute:
 
 The server process itself will time out after five minutes if no more worker processes exist.
 
-### Engine options
+## Engine options
 
 Engine options can be passed under the `julia` top-level key:
 
@@ -333,11 +333,11 @@ The currently available options are:
 - `exeflags`: An array of strings which are appended to the `julia` command that starts the worker process. For example, a notebook is run with `--project=@.` by default (the environment in the directory where the notebook is stored) but this could be overridden by setting `exeflags: ["--project=/some/directory/"]`.
 - `env`: An array of strings where each string specifies one environment variable that is passed to the worker process. For example, `env: ["SOMEVAR=SOMEVALUE"]`.
 
-### `quarto call engine julia` commands
+## `quarto call engine julia` commands
 
 Starting with Quarto 1.7, The julia engine offers CLI commands for configuration and monitoring via the `quarto call engine julia` entrypoint.
 
-#### `status`
+### `status`
 
 The `status` command prints out information about the currently running server process as well as potential worker processes. For example:
 
@@ -363,7 +363,7 @@ QuartoNotebookRunner server status:
       env: ["JULIA_PROJECT=@."]
 ```
 
-#### `close`
+### `close`
 
 The `close` command allows shutting down notebook worker processes.
 By default, only closing of idle worker processes is allowed.
@@ -446,7 +446,7 @@ QuartoNotebookRunner server status:
   workers active: 0
 ```
 
-#### `stop`
+### `stop`
 
 The `stop` command shuts down the server process gracefully. Note that you will get an error if any workers are currently busy:
 
@@ -469,15 +469,15 @@ $ quarto call engine julia status
 Julia control server is not running.
 ```
 
-#### `kill`
+### `kill`
 
 The `kill` command shuts the server process down forcefully. This command is intended as a last resort when the server is in a bad state and unresponsive. Note that all worker processes will be killed as well, so you will lose all progress.
 
-#### `log`
+### `log`
 
 The `log` command prints the output of the internal log file of the server process. If the server process fails to start or unexpectedly quits, this log file might contain useful information.
 
-### `juliaup` integration
+## `juliaup` integration
 
 [`juliaup`](https://github.com/JuliaLang/juliaup) is the recommended way to
 install and manage Julia versions. The `julia` engine supports using
@@ -506,7 +506,7 @@ VERSION
 `QuartoNotebookRunner` currently supports running Julia versions from 1.6
 onwards. Support for earlier versions is not planned.
 
-### Revise.jl integration
+## Revise.jl integration
 
 [Revise](https://github.com/timholy/Revise.jl) allows for automatically
 updating function definitions in Julia sessions. It is an essential tool in the
@@ -520,7 +520,7 @@ Ensure that `Revise` is installed in the project environment that the notebook
 is using, since the global environment is not included in the load path
 provided to Julia, unlike the behaviour of a Julia REPL session.
 
-### Caching {#caching-julia}
+## Caching {#caching-julia}
 
 The engine has built-in support for caching notebook results. This feature is disabled by
 default but can be enabled by setting the `execute.cache` option to `true` in a notebook's
@@ -559,7 +559,7 @@ These caches are safe to save in CI via such tools as GitHub Actions
 `action/cache` to help improve the render time of long-running notebooks that
 do not often change.
 
-### R and Python support
+## R and Python support
 
 `{{r}}` and `{{python}}` executable code blocks are supported in the `julia`
 engine via integrations with the
@@ -600,7 +600,7 @@ len($data)
 ```
 ````
 
-### Engine "extensions"
+## Engine "extensions"
 
 The implementation of `QuartoNotebookRunner` allows for extending the behaviour
 of notebooks via external Julia packages.

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -556,7 +556,7 @@ Pkg.add("Revise")
 
 To configure Revise to launch automatically within IJulia, create a `.julia/config/startup_ijulia.jl` file with the contents:
 
-``` default
+``` julia
 try
   @eval using Revise
 catch e

--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -10,24 +10,24 @@ vscode-screenshot: "![](images/julia-vscode){.border fig-alt='Screen shot of VS 
 
 Quarto supports executable Julia code blocks within markdown. This allows you to create fully reproducible documents and reports---the Julia code required to produce your output is part of the document itself, and is automatically re-run whenever the document is rendered.
 
-Quarto has two available engines for executing Julia code, the newer [native engine](#using-the-julia-engine) is using the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks, the older [jupyter engine](#using-the-jupyter-engine) is using the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel.
+Quarto has two available engines for executing Julia code, the newer [`julia` engine](#using-the-julia-engine) is using the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks, the older [`jupyter` engine](#using-the-jupyter-engine) is using the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel.
 
-This table lists some of the reasons why the native engine was created:
+This table lists some of the reasons why the `julia` engine was created:
 
-|                                                                                                                                 | Native Engine | Jupyter Engine |
-|---------------------------------------------------------------------------------------------------------------------------------|---------------|----------------|
-| Execute Julia code blocks                                                                                                       | ✅            | ✅              |
-| Keep sessions alive for fast reruns                                                                                             | ✅            | ✅              |
-| No Python installation required                                                                                                 | ✅            | ❌              |
-| No global package installation needed                                                                                           | ✅            | ❌              |
-| Automatic integration with juliaup (no kernel installation)                                                                     | ✅            | ❌              |
-| Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅            | ❌              |
-| "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅            | ❌              |
+|                                                                                                                                 | `julia` Engine | `jupyter` Engine |
+|---------------------------------------------------------------------------------------------------------------------------------|----------------|------------------|
+| Execute Julia code blocks                                                                                                       | ✅             | ✅                |
+| Keep sessions alive for fast reruns                                                                                             | ✅             | ✅                |
+| No Python installation required                                                                                                 | ✅             | ❌                |
+| No global package installation needed                                                                                           | ✅             | ❌                |
+| Automatic integration with juliaup (no kernel installation)                                                                     | ✅             | ❌                |
+| Python & R Codeblocks (via PythonCall.jl and RCall.jl)                                                                          | ✅             | ❌                |
+| "Expandable cells" or programmatic document generation (via [QuartoTools.jl](https://pumasai.github.io/QuartoTools.jl/stable/)) | ✅             | ❌                |
 
 ::: {.callout-note}
-For most users, the native engine should offer the best experience.
-However, for backwards compatibility the Jupyter engine remains the default engine for Julia code.
-The native engine has to be [specifically enabled either in the frontmatter or the project file](#enabling-the-native-engine).
+For most users, the `julia` engine should offer the best experience.
+However, for backwards compatibility the `jupyter` engine remains the default engine for Julia code.
+The `julia` engine has to be [specifically enabled either in the frontmatter or the project file](#enabling-the-julia-engine).
 :::
 
 Using either of the two engines will require manually installing Julia if
@@ -108,7 +108,7 @@ display(plot(x -> sin(4x), y -> sin(5y), 0, 2))
 
 {{< include /docs/prerelease/1.5/_pre-release-feature.qmd >}}
 
-## Installation {#installation-native}
+## Installation {#installation-julia-engine}
 
 The `julia` engine uses the [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) package to render notebooks. When you first attempt to render a notebook with the `julia` engine, Quarto will automatically install this package into a private environment that is owned by Quarto. This means you don't have to install anything in your global Julia environment for Quarto to work and Quarto will not interfere with any other Julia environments on your system. Quarto will use the `julia` binary on your PATH by default, but you can override this using the `QUARTO_JULIA` environment variable.
 
@@ -118,7 +118,7 @@ In special circumstances, you may not want to use the specific `QuartoNotebookRu
 
 As an example, you could install the main branch of `QuartoNotebookRunner` into the directory `/some/dir` by executing `]activate /some/dir` in a julia REPL followed by `]add QuartoNotebookRunner#main`. As long as there is no server currently running, running a command like `QUARTO_JULIA_PROJECT=/some/dir quarto render some_notebook.qmd` in your terminal will ensure the server process is started using the custom `QuartoNotebookRunner`. You can also set `quarto`'s `--execute-debug` flag and check the output to verify that the custom environment is being used.
 
-## Enabling the native engine
+## Enabling the `julia` engine
 
 To use the `julia` engine, you have to specifically enable it. For that, you have two options.
 
@@ -135,7 +135,7 @@ engine: julia
 ```
 ````
 
-Or, starting with Quarto 1.7, you can prioritize the julia engine project-wide by adding `julia` to the `engines` array in your project file, giving it priority over all unlisted engines (more under [Engine prioritization](#engine-prioritization)). Note that the project file approach is the only option in order to use the native Julia engine with percent-script files.
+Or, starting with Quarto 1.7, you can prioritize the julia engine project-wide by adding `julia` to the `engines` array in your project file, giving it priority over all unlisted engines (more under [Engine prioritization](#engine-prioritization)). Note that the project file approach is the only option in order to use the `julia` engine with percent-script files.
 
 ```{.yaml filename="_quarto.yml"}
 engines: ['julia']


### PR DESCRIPTION
By now, the docs for the native engine are nicely fleshed out, however there's still somewhat of a discoverability problem, due to the way that the docs page is structured. Visitors will currently see this table of contents:

<img width="221" alt="image" src="https://github.com/user-attachments/assets/782e3b37-9814-4431-92dd-ee050d8063b1" />

The native engine section, while far longer than the rest, is squeezed into one entry at the bottom, appearing like an afterthought. Also, some parts that thematically belong to both engines look like they belong only to the jupyter engine.

In this PR, I've moved the native engine before the Jupyter engine and added a table that clarifies why the native engine should be preferable for most users (this is not to criticize previous efforts, I just think we need to be really clear here as the older engine is still the default, which carries some weight for new users). If someone can think of something that the Jupyter engine has but the native one doesn't, I'll be happy to add that, too.

<img width="874" alt="image" src="https://github.com/user-attachments/assets/42212601-cb1c-41d9-9eb6-5e21e7908e6c" />

I've also changed heading levels such that the grouping now appears like this, with both engines appearing directly next to each other, and common content moved under Overview:

<img width="204" alt="image" src="https://github.com/user-attachments/assets/949212c5-1213-4e93-b0c6-ec07bb3e34eb" />

The headings are a bit unusual in that there are multiple H1's on the same page, but due to the spliced in markdown documents that are reused in other sections, it was easier to resolve the hierarchy problems like this, rather than refactoring all pages that splice in the markdown snippets.