### PR TITLE
docs: avoid confusion with column/columns

### DIFF
--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -53,7 +53,7 @@ Since Typst is under active development, there are still some limitations to Qua
 
 -   The default size of images may not reflect the behavior you are used to in other output formats. This is a problem that Typst, pandoc and Quarto are actively working to fix. In the meantime, you can manually [specify image widths](/docs/authoring/figures.qmd#figure-sizing).
 
--   Advanced page layout (e.g. using the `.column` classes as explained in [Article Layout](/docs/authoring/article-layout.qmd)) is not implemented.
+-   Advanced page layout (e.g. using the `.column-*` classes as explained in [Article Layout](/docs/authoring/article-layout.qmd)) is not implemented.
 
 -   Various other small things might not yet be implemented. Please [let us know](https://github.com/quarto-dev/quarto-cli/issues/new/choose) if you see things that could use improvement!
 


### PR DESCRIPTION
This pull request includes a minor update to the documentation for Typst output formats. Updated the description of advanced page layout to specify the use of `.column-*` classes instead of `.column` classes to avoid confusion with multiple columns layout classes `.column` and `.columns`.