### PR TITLE
fix: use code blocks for copy button

### DIFF
--- a/docs/troubleshooting/index.qmd
+++ b/docs/troubleshooting/index.qmd
@@ -85,6 +85,26 @@ export QUARTO_PRINT_STACK=true
 
 Quarto will print more information about its internal state if you set `QUARTO_LOG_LEVEL=DEBUG` in your environment.
 
+::: panel-tabset
+
+## Windows
+
+On PowerShell:
+
+```powershell
+$env:QUARTO_LOG_LEVEL = "DEBUG"
+```
+
+## Unix
+
+On bash-like shells:
+
+```bash
+export QUARTO_LOG_LEVEL=DEBUG
+```
+
+:::
+
 ### Inspect log files {#log-files}
 
 Quarto creates log files that can help you diagnose problems. These are stored in different locations depending on your operating system:


### PR DESCRIPTION
This pull request enhances the `docs/troubleshooting/index.qmd` file by adding platform-specific instructions for setting the `QUARTO_LOG_LEVEL` environment variable.