### PR TITLE
Remove space in powershell command in troubleshooting page

### DIFF
--- a/docs/troubleshooting/index.qmd
+++ b/docs/troubleshooting/index.qmd
@@ -68,7 +68,7 @@ Setting `QUARTO_PRINT_STACK=true` in your environment will cause Quarto to print
 On PowerShell:
 
 ```powershell
-$env:QUARTO_PRINT_STACK = "true"
+$env:QUARTO_PRINT_STACK="true"
 ```
 
 ## Unix
@@ -92,7 +92,7 @@ Quarto will print more information about its internal state if you set `QUARTO_L
 On PowerShell:
 
 ```powershell
-$env:QUARTO_LOG_LEVEL = "DEBUG"
+$env:QUARTO_LOG_LEVEL="DEBUG"
 ```
 
 ## Unix
@@ -138,7 +138,7 @@ In this example, we're setting the maximum amount of memory to be allocated by D
 On PowerShell:
 
 ```powershell
-$env:QUARTO_DENO_V8_OPTIONS = "--max-old-space-size=8192"
+$env:QUARTO_DENO_V8_OPTIONS="--max-old-space-size=8192"
 ```
 
 ## Unix


### PR DESCRIPTION
Better not have them just in case, even if both with or without spaces work.