### PR TITLE
Switch to `engine: julia` in prominent examples

### DIFF
--- a/docs/computations/julia.qmd
+++ b/docs/computations/julia.qmd
@@ -48,7 +48,7 @@ date: "5/22/2021"
 format:
   html:
     code-fold: true
-jupyter: julia-1.8
+engine: julia
 ---
 
 ### Parametric Plots

--- a/index.qmd
+++ b/index.qmd
@@ -165,7 +165,7 @@ ggplot(airquality, aes(Temp, Ozone)) +
 <div class="tab-pane fade" id="julia" role="tabpanel" aria-labelledby="julia-tab">
 ::: {.grid}
 ::: {.g-col-md-11 .g-col-12}
-Combine markdown and Julia code to create dynamic documents that are fully reproducible. Quarto executes Julia code via the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel, enabling you to author in plain text (as shown below) or render existing Jupyter notebooks.
+Combine markdown and Julia code to create dynamic documents that are fully reproducible. Quarto executes Julia code either via the [`julia` engine](#using-the-julia-engine) using [QuartoNotebookRunner.jl](https://github.com/PumasAI/QuartoNotebookRunner.jl/) or via the [`jupyter` engine](#using-the-jupyter-engine) using the [IJulia](https://github.com/JuliaLang/IJulia.jl) Jupyter kernel, enabling you to author in plain text (as shown below) or render existing Jupyter notebooks.
 
 :::
 ::: {.g-col-md-6 .g-col-12}
@@ -177,7 +177,7 @@ date: "5/22/2021"
 format:
   html:
     code-fold: true
-jupyter: julia-1.8
+engine: julia
 ---
 
 ## Parametric Plots


### PR DESCRIPTION
The docs already recommend the `julia` engine over `jupyter` in the julia section, so it makes sense to adjust these copy-paste-able examples to that engine as well so users are put on the right track from the start.