### PR TITLE
replace universal quantifier with existential in knitr compatibility claim

### DIFF
--- a/docs/tools/rstudio.qmd
+++ b/docs/tools/rstudio.qmd
@@ -17,7 +17,7 @@ To learn more, see the documentation on [Using the Visual Editor](../visual-edit
 
 ## Knitr Engine
 
-Quarto is designed to be highly compatible with existing [R Markdown](https://rmarkdown.rstudio.com/) documents. You should generally be able to use Quarto to render any existing Rmd document without changes.
+Quarto is designed to be highly compatible with existing [R Markdown](https://rmarkdown.rstudio.com/) documents. You should generally be able to use Quarto to render an existing Rmd document without changes.
 
 {{< include _chunk-options.md >}}
 


### PR DESCRIPTION
For consistency with "highly" (vs "perfectly"), "generally" (vs "always"), and "should" (vs "must"), let's use "an" (vs "any").