### PR TITLE
Add all hosts used for math method

### DIFF
--- a/docs/advanced/html/external-sources.qmd
+++ b/docs/advanced/html/external-sources.qmd
@@ -12,8 +12,13 @@ The following is a list of such situations:
 - If Google analytics support is enabled in websites:
   - `www.googletagmanager.com`
   - `www.google-analytics.com`
-- If `webtex` is chosen to be the default math rendering method:
-  - `latex.codecogs.com`
+- For math rendering method: 
+  - If `mathjax` is chosen (used by default):
+    - `cdn.jsdelivr.net`
+  - If `webtex` is chosen:
+    - `latex.codecogs.com`
+  - If `katex` is chosen:
+    - `cdn.jsdelivr.net`
 - If multiplex mode in `revealjs` is enabled:
   - `reveal-multiplex.glitch.me`
 - For a number of revealjs and bootswatch themes:


### PR DESCRIPTION
Companion PR to revealjs update https://github.com/quarto-dev/quarto-cli/pull/13101

And document missing host we use for mathjax and katex