### PR TITLE
Add `group-html-cell-outputs` filter extension

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -282,6 +282,12 @@
   description: >
     Embed fully serverless, browser-based Gradio applications and Python coding playgrounds into your Quarto documents.
 
+- name: group-html-cell-outputs
+  path: https://github.com/dixslyf/quarto-group-html-cell-outputs
+  author: '[Dixon Sean Low Yan Feng](https://github.com/dixslyf)'
+  description: >
+    Group cell outputs by wrapping them with a parent container when rendering to HTML.
+
 - name: hide-comment
   path: https://github.com/shafayetShafee/hide-comment
   author: '[Shafayet Khan Shafee](https://github.com/shafayetShafee)'


### PR DESCRIPTION
Adds [`group-html-cell-outputs`](https://github.com/dixslyf/quarto-group-html-cell-outputs) to the extensions listing.