### PR TITLE
feat: add Quarto extensions

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -60,6 +60,12 @@
   description: >
     Automatic dark mode for Quarto websites and slides.
 
+- name: badge
+  path: https://github.com/mcanouil/quarto-badge
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    Badge is an extension for Quarto to provide a shortcode to display software version or anything as a badge.
+
 - name: base64
   path: https://github.com/gadenbuie/quarto-base64
   author: '[Garrick Aden-Buie](https://github.com/gadenbuie)'
@@ -183,6 +189,12 @@
     Generate diagrams from embedded code;
     supports Mermaid, Dot/GraphViz, PlantUML, Asymptote, and TikZ.
 
+- name: div-reuse
+  path: https://github.com/mcanouil/quarto-div-reuse
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    The power of “code/content reuse” for seamless and efficient content creation.
+
 - name: docx-horizontal-rule
   path: https://github.com/ttalVlatt/Quarto-Docx-Horizontal-Rule
   author: '[Matt Capaldi](https://github.com/ttalVlatt/)'
@@ -213,6 +225,12 @@
   author: '[Jeffrey Girard](https://github.com/jmgirard/)'
   description: >
     Easily embed PDF files within HTML documents.
+
+- name: external
+  path: https://github.com/mcanouil/quarto-external
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    Quarto extension to include content or partial content from external file.
 
 - name: fancy-epigraphs
   path: https://github.com/andrewheiss/fancy-epigraphs-quarto
@@ -404,18 +422,18 @@
   description: >
     A filter/shortcode extension for Quarto to provide access to LUA objects as metadata.
 
-- name: open-social-comments
-  path: https://github.com/AndreasThinks/quarto-open-social-comments
-  author: '[AndreasThinks](https://github.com/AndreasThinks/)'
-  description: >
-    Enables adding Bluesky or Mastodon/Fediverse powered comments to posts and articles.
-
 - name: material-icons
   path: https://github.com/shafayetShafee/material-icons
   author: '[Shafayet Khan Shafee](https://github.com/shafayetShafee)'
   description: >
     Use [Material Design Icons](https://fonts.google.com/icons?icon.set=Material+Icons&icon.query=chart) in HTML documents and
     Revealjs presentations.
+
+- name: modal
+  path: https://github.com/mcanouil/quarto-modal
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto extension providing a simple way to create Bootstrap modals in your HTML documents.
 
 - name: molstar
   path: https://github.com/jmbuhr/quarto-molstar
@@ -436,6 +454,12 @@
   description: >
     Embed [Nutshell](https://ncase.me/nutshell/) expandable explanations in HTML documents.
 
+- name: open-social-comments
+  path: https://github.com/AndreasThinks/quarto-open-social-comments
+  author: '[AndreasThinks](https://github.com/AndreasThinks/)'
+  description: >
+    Enables adding Bluesky or Mastodon/Fediverse powered comments to posts and articles.
+
 - name: options
   path: https://github.com/coatless-quarto/options
   author: '[James Joseph Balamuta](https://github.com/coatless/)'
@@ -453,6 +477,12 @@
   author: '[Garrick Aden-Buie](https://github.com/gadenbuie)'
   description: A shortcode to include partial content templates using the mustache
     templating syntax.
+
+- name: preview-colour
+  path: https://github.com/mcanouil/quarto-preview-colour
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto extension to add preview colour as a coloured symbol next to colour code in HTML, PDF, Typst, Docx, Reveal.js, Beamer, and PowerPoint.
 
 - name: pseudocode
   path: https://github.com/leovan/quarto-pseudocode

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -372,6 +372,12 @@
     Render [Kroki](https://kroki.io/) diagrams in Quarto websites — including HTML and PDF output.
     This extension uses the Kroki API via HTTP GET requests. The Kroki service URL is customizable, and the output format (e.g. SVG, PNG, etc.) can be specified per diagram.
 
+- name: language-cell-decorator
+  path: https://github.com/mcanouil/quarto-language-cell-decorator
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    Quarto extension to add a decorator to the code cells to display the language name.
+
 - name: language-name
   path: https://github.com/andrewheiss/language-name
   author: '[Andrew Heiss](https://github.com/andrewheiss/)'


### PR DESCRIPTION
This pull request updates the `docs/extensions/listings/shortcodes-and-filters.yml` file by adding several Quarto extensions.

* Added the `badge` extension, which provides a shortcode to display software versions or other information as badges.
* Added the `div-reuse` extension, enabling seamless and efficient content reuse in Quarto.
* Added the `external` extension, allowing inclusion of content or partial content from external files.
* Added the `language-cell-decorator` extension, allowing to automatically add the code block/cell language as header via the `filename` feature.
* Added the `modal` extension for creating Bootstrap modals in HTML documents.
* Added the `preview-colour` extension, which displays a coloured symbol next to colour codes across multiple formats.


* Moved the `open-social-comments` extension to be properly alphabetically ordered.