### PR TITLE
Add AAAI2026 template

### DIFF
--- a/docs/extensions/listings/journal-articles.yml
+++ b/docs/extensions/listings/journal-articles.yml
@@ -105,3 +105,9 @@
   path: https://github.com/mikemahoney218/quarto-tandf
   author: '[mikemahoney218](https://github.com/mikemahoney218)'
   description: Taylor and Francis style.
+
+- name: aaai2016
+  path: https://github.com/Selbosh/aaai2026-quarto
+  author: '[Selbosh](https://github.com/Selbosh)'
+  description: >
+    Quarto template for submissions to the Association for Advancement of Artificial Intelligence (AAAI)


### PR DESCRIPTION
Added a template for the AAAI-2026 conference.

As with journals, the template can change slightly from year to year. Can handle with updates to this template or by making new versions, whichever seems best.

Currently just setup for anonymous submissions; the organizers provide separate templates for camera-ready, which we might be able to handle with template options.