### PR TITLE
fix typos

### DIFF
--- a/docs/authoring/brand.qmd
+++ b/docs/authoring/brand.qmd
@@ -781,7 +781,7 @@ theme:
   - tweaks.scss  # a user-defined customization
 ```
 
-As a result, values set by `brand` here are potentially overriden by the `cosmo` theme or by `tweaks.scss`.
+As a result, values set by `brand` here are potentially overridden by the `cosmo` theme or by `tweaks.scss`.
 This is sometimes useful, but often you will want to make `brand` _more_ important than the theme.
 For these situations, use the following:
 

--- a/docs/authoring/create-citeable-articles.qmd
+++ b/docs/authoring/create-citeable-articles.qmd
@@ -248,7 +248,7 @@ Quarto's approach to emitting scholarly metadata is to take the standard CSL fie
     -   Nick Fury
     ```
 
-    The list of authors provded under the citation key will be used instead of the document authors when generating the html metadata.
+    The list of authors provided under the citation key will be used instead of the document authors when generating the html metadata.
 
 [^2]: Specify one or more editors using one of the following:
 

--- a/docs/authoring/diagrams.qmd
+++ b/docs/authoring/diagrams.qmd
@@ -96,7 +96,7 @@ There are a variety of tools available to improve your productivity authoring di
 
 4)  The Quarto Extension for VS Code and Positron (available on both [OpenVSX](https://open-vsx.org/extension/quarto/quarto) and [Microsoft's marketplace](https://marketplace.visualstudio.com/items?itemName=quarto.quarto)) supports live preview of diagrams embedded in `.qmd` files and in `.mmd` and `.dot` files:
 
-    ![](images/vscode-graphviz.gif){.border fig-alt="A Quarto document being edited in Visual Studio Code, with a live preview of the currenly edited diagram shown in a pane to the right"}
+    ![](images/vscode-graphviz.gif){.border fig-alt="A Quarto document being edited in Visual Studio Code, with a live preview of the currently edited diagram shown in a pane to the right"}
 
 ## Cross-References
 

--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -324,7 +324,7 @@ You can specify `fig-scap` as an executable code block option or as an attribute
 
 ### PGF/Ti*k*Z Graphics
 
-If you are creating LaTeX output, Quarto will automatically emit the correct LaTeX for markdown images that reference `.tex` files containg [PGF/Ti*k*Z](https://en.wikipedia.org/wiki/PGF/TikZ) vector graphics. For example, the following markdown images:
+If you are creating LaTeX output, Quarto will automatically emit the correct LaTeX for markdown images that reference `.tex` files containing [PGF/Ti*k*Z](https://en.wikipedia.org/wiki/PGF/TikZ) vector graphics. For example, the following markdown images:
 
 ``` markdown
 ![](image1.tex)

--- a/docs/authoring/images/linux-kernel-diagram.dot
+++ b/docs/authoring/images/linux-kernel-diagram.dot
@@ -304,7 +304,7 @@ digraph "Linux_kernel_diagram" {
 			label = "storage devices:\nSCSI, NVMe ...",
 			row = chip]
 		block -> SD
-	}	// storge
+	}	// storage
 	subgraph HI {
 		node [color = "#cfbf57ff"]
 		edge [

--- a/docs/authoring/placeholder.qmd
+++ b/docs/authoring/placeholder.qmd
@@ -21,7 +21,7 @@ You can customize the size and format of the image by providing parameters to th
 
 ## Usage
 
-The `placeholder` shortcode can take additional arguments controling the size and format of the image:
+The `placeholder` shortcode can take additional arguments controlling the size and format of the image:
 
 ::: {layout-ncol=1}
 ```markdown

--- a/docs/blog/posts/2022-02-13-feature-callouts/index.qmd
+++ b/docs/blog/posts/2022-02-13-feature-callouts/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: Using Callouts
-subtitle: Use callouts to draw attention to important complementary content without interupting the document flow
+subtitle: Use callouts to draw attention to important complementary content without interrupting the document flow
 description: |
   Callouts are an excellent way to draw extra attention to certain concepts, or to more clearly indicate that certain content is supplemental or applicable to only some scenarios.
 categories:

--- a/docs/blog/posts/2024-01-24-1.4-release/index.qmd
+++ b/docs/blog/posts/2024-01-24-1.4-release/index.qmd
@@ -51,7 +51,7 @@ We are particularly excited about how easy it is to make templates for journal a
 
 ![IEEE](images/typst-format-ieee.png){.lightbox group="custom-formats" fig-alt="Screenshot of a page showing a article styled according IEEE standards. The title is centered with authors below in two columns."}
 
-![Poster](images/typst-format-poster.png){.lightbox group="custom-formats" fig-alt="Screenshot of a poster in landscape orientiation. The poster includes a logo in the top right, a title in the top left, and content arranged in three columns."}
+![Poster](images/typst-format-poster.png){.lightbox group="custom-formats" fig-alt="Screenshot of a poster in landscape orientation. The poster includes a logo in the top right, a title in the top left, and content arranged in three columns."}
 
 ![Letter](images/typst-format-letter.png){.lightbox group="custom-formats" fig-alt="Screenshot of a page showing a letter. A sender address is across the top of the page, followed by a recipient address left justified. The body of the letter includes a subject line in bold."}
 

--- a/docs/books/book-crossrefs.qmd
+++ b/docs/books/book-crossrefs.qmd
@@ -17,7 +17,7 @@ If you aren't already familiar with using crossrefs you may want to read the doc
 To reference a figure, table, or other cross-referenceable entity, use the `@` syntax (similar to citations) along with the ID / label of the entity you are referencing: For example:
 
 ``` markdown
-See @fig-penginus-by-island for a breakdown by island.
+See @fig-penguins-by-island for a breakdown by island.
 ```
 
 References made this way will be automatically resolved across chapters (including the requisite chapter number in the reference).

--- a/docs/computations/ojs.qmd
+++ b/docs/computations/ojs.qmd
@@ -198,7 +198,7 @@ data = FileAttachment("palmer-penguins.csv").csv({ typed: true })
 
 To learn about all of the options available, see the article on [OJS Cells](/docs/interactive/ojs/ojs-cells.qmd).
 
-In addition to OJS cells which interupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
+In addition to OJS cells which interrupt the flow of markdown, you can also include code inline. Read more about inline code in the [Inline Code](inline-code.qmd) article.
 
 ## Learning More
 

--- a/docs/computations/render-scripts.qmd
+++ b/docs/computations/render-scripts.qmd
@@ -184,7 +184,7 @@ The [Quarto VS Code Extension](https://marketplace.visualstudio.com/items?itemNa
 
 Notebook scripts can also be included within [projects](/docs/projects/quarto-projects.qmd) (e.g. websites, blogs, etc.). Scripts within projects are only rendered by Quarto when they start with the appropriate [syntax](#syntax).
 
-If for some reason you need to ignore such a script, you can create an explict render list in `_quarto.yml` that excludes individual scripts as required, for example:
+If for some reason you need to ignore such a script, you can create an explicit render list in `_quarto.yml` that excludes individual scripts as required, for example:
 
 ``` yaml
 project:

--- a/docs/dashboards/interactivity/observable.qmd
+++ b/docs/dashboards/interactivity/observable.qmd
@@ -16,7 +16,7 @@ Quarto Dashboards are a great way to present interactive OJS visualizations. Bel
 
 This example covers many of the techniques you'll use when creating dashboards with OJS, including reactive calculations and more advanced layout constructs like sidebars and tabsets. Here is the interactive document we'll be building:
 
-![](../images/penguins-ojs.png){.border fig-alt="A screenshot of a Palmer Penguins dashboard. The navigation bar shows two pages: Plot (active) and Data. On the left a sidebar with an image of penguins and two inputs: a range input for Bill length; and a set of checkboxes for Islands. On the right a plot with histgrams of body mass facetted by sex and species, with bars colored by species."}
+![](../images/penguins-ojs.png){.border fig-alt="A screenshot of a Palmer Penguins dashboard. The navigation bar shows two pages: Plot (active) and Data. On the left a sidebar with an image of penguins and two inputs: a range input for Bill length; and a set of checkboxes for Islands. On the right a plot with histgrams of body mass faceted by sex and species, with bars colored by species."}
 
 The source code for this dashboard is below. Note that we add the <br/>
 `//| output: false` option to the first cell: this is to designate the cell as having only intermediate computations (so it should not be turned into a card in the dashboard layout).

--- a/docs/dashboards/interactivity/shiny-python/_shiny-deployment.md
+++ b/docs/dashboards/interactivity/shiny-python/_shiny-deployment.md
@@ -20,7 +20,7 @@ See the following documentation for information on deploying Shiny applications 
 | [shinyapps.io](https://docs.posit.co/shinyapps.io/getting-started.html#working-with-shiny-for-python) | Cloud hosting service             |
 | [Hugging Face](https://huggingface.co/docs/hub/spaces-sdks-docker-shiny#shiny-for-python)             | Cloud hosting service             |
 | [Shiny Server](https://shiny.posit.co/py/docs/deploy.html#deploy-to-shiny-server-open-source)         | Open source application server    |
-| [Posit Connect](https://shiny.posit.co/py/docs/deploy.html#deploy-to-posit-connect-commercial)        | Commerical publishing platform    |
+| [Posit Connect](https://shiny.posit.co/py/docs/deploy.html#deploy-to-posit-connect-commercial)        | Commercial publishing platform    |
 | [Other Services](https://shiny.posit.co/py/docs/deploy.html#other-hosting-options)                    | Custom server/hosting environment |
 
 : {tbl-colwidths="\[30,70\]"}

--- a/docs/extensions/_formats-common.qmd
+++ b/docs/extensions/_formats-common.qmd
@@ -46,9 +46,9 @@ contributes:
       shortcodes:
         - quarto-ext/fancy-text
     html:
-      # html-specifc
+      # html-specific
     pdf:
-      # pdf-specifc
+      # pdf-specific
 ```
 
 ## Format Resources

--- a/docs/extensions/lua-api.qmd
+++ b/docs/extensions/lua-api.qmd
@@ -45,7 +45,7 @@ Complete documentation for the Pandoc Lua API can be found in the [Lua Filters](
 | [pandoc.path](https://pandoc.org/lua-filters.html#module-pandoc.path) | Module for file path manipulations (e.g. `is_absolute()`, `is_relative()`, `join()`, etc. |
 | [pandoc.system](https://pandoc.org/lua-filters.html#module-pandoc.system) | Access to system information and functionality (e.g. `get_working_directory()`, `list_directory()`, etc. |
 | [pandoc.mediabag](https://pandoc.org/lua-filters.html#module-pandoc.mediabag) | Access to pandoc's media storage. The "media bag" is used when pandoc is called with the `--extract-media` or (for HTML only) `--embed-resources` option. |
-| [pandoc.template](https://pandoc.org/lua-filters.html#module-pandoc.template) | Compile and access defualt pandoc templates (e.g. `compile()`) |
+| [pandoc.template](https://pandoc.org/lua-filters.html#module-pandoc.template) | Compile and access default pandoc templates (e.g. `compile()`) |
 | [pandoc.types](https://pandoc.org/lua-filters.html#module-pandoc.types) | Constructors for types which are not part of the pandoc AST (e.g. `Version()`) |
 
 : {tbl-colwidths="\[30,70\]"}

--- a/docs/extensions/revealjs.qmd
+++ b/docs/extensions/revealjs.qmd
@@ -124,7 +124,7 @@ revealjs-plugins:
 
 ## Plugin Packaging
 
-Note that the plugins listed above were not initially developed for use with Quarto. Rather, they were developed intially as native Revealjs plugins and then packaged as Quarto extensions.
+Note that the plugins listed above were not initially developed for use with Quarto. Rather, they were developed initially as native Revealjs plugins and then packaged as Quarto extensions.
 
 For example, you can find the original implementation of the attribution plugin here: <https://github.com/rschmehl/reveal-plugins/tree/main/attribution>. The plugin is implemented with a JavaScript file and a CSS file. To make the plugin available as a Quarto extension, we package these files along with an `_extension.yml` config file that registers the plugin. Here are the files in the Quarto extension:
 

--- a/docs/get-started/authoring/rstudio.qmd
+++ b/docs/get-started/authoring/rstudio.qmd
@@ -214,7 +214,7 @@ format:
 
 Here's what this document looks like when rendered to HTML.
 
-![](images/rstudio-toc-secnum.png){.border fig-alt="Rendered version of authoring.qmd as HTML with numbered sections and a table of contens on the top right. The table of contents shows three sections: Introduction, Exploratory data analysis (with subsections Data visualization and Summary statistics), and Modeling."}
+![](images/rstudio-toc-secnum.png){.border fig-alt="Rendered version of authoring.qmd as HTML with numbered sections and a table of contents on the top right. The table of contents shows three sections: Introduction, Exploratory data analysis (with subsections Data visualization and Summary statistics), and Modeling."}
 
 There are lots of options available for controlling how the table of contents and section numbering behave.
 See the output format documentation (e.g. [HTML](/docs/output-formats/html-basics.qmd), [PDF](/docs/output-formats/pdf-basics.qmd), [MS Word](/docs/output-formats/ms-word.qmd)) for additional details.

--- a/docs/journals/authors.qmd
+++ b/docs/journals/authors.qmd
@@ -206,7 +206,7 @@ Author roles can be specified with either `role` or `roles` and can be any of:
         - methodology: supporting
     ```
 
-If a role matches one of the [CRediT roles or their aliases](https://github.com/quarto-dev/quarto-cli/blob/f65180a75e1cf2996328cd51cb4fd5d02d391511/src/resources/filters/modules/authors.lua#L119-L144), the additional properties `vocab-identifier`, `vocab-term`, and `vocab-term-indentifier`, will be added to the role with the appropriate value from the CRediT specification.
+If a role matches one of the [CRediT roles or their aliases](https://github.com/quarto-dev/quarto-cli/blob/f65180a75e1cf2996328cd51cb4fd5d02d391511/src/resources/filters/modules/authors.lua#L119-L144), the additional properties `vocab-identifier`, `vocab-term`, and `vocab-term-identifier`, will be added to the role with the appropriate value from the CRediT specification.
 
 ### Arbitrary Metadata
 

--- a/docs/output-formats/html-lightbox-figures.qmd
+++ b/docs/output-formats/html-lightbox-figures.qmd
@@ -200,8 +200,8 @@ It is possible to create several plots, and group them in a lightbox gallery. Us
 #| lightbox: 
 #|   group: cars
 #|   description: 
-#|     - This is the decription for first graph
-#|     - This is the decription for second graph
+#|     - This is the description for first graph
+#|     - This is the description for second graph
 plot(mtcars)
 plot(cars)
 ```

--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -37,7 +37,7 @@ One of the highlights of Typst is the ease of creating highly customized templat
 
 ![IEEE](images/typst-format-ieee.png){.lightbox group="custom-formats" fig-alt="Screenshot of a page showing a article styled according IEEE standards. The title is centered with authors below in two columns."}
 
-![Poster](images/typst-format-poster.png){.lightbox group="custom-formats" fig-alt="Screenshot of a poster in landscape orientiation. The poster includes a logo in the top right, a title in the top left, and content arranged in three columns."}
+![Poster](images/typst-format-poster.png){.lightbox group="custom-formats" fig-alt="Screenshot of a poster in landscape orientation. The poster includes a logo in the top right, a title in the top left, and content arranged in three columns."}
 
 ![Letter](images/typst-format-letter.png){.lightbox group="custom-formats" fig-alt="Screenshot of a page showing a letter. A sender address is across the top of the page, followed by a recipient address left justified. The body of the letter includes a subject line in bold."}
 

--- a/docs/prerelease/1.4/crossref.qmd
+++ b/docs/prerelease/1.4/crossref.qmd
@@ -4,7 +4,7 @@ title: "Behind the Scenes Changes to Cross-References"
 
 ## Changes in HTML output
 
-The changes to cross-references in Quarto 1.4 also introduce some changes to the underlying HTML output of figures and other cross-referencable elements. For most users, these changes will be invisible. However, if you are operating on Quarto HTML output, you may be impacted. In particular:
+The changes to cross-references in Quarto 1.4 also introduce some changes to the underlying HTML output of figures and other cross-referenceable elements. For most users, these changes will be invisible. However, if you are operating on Quarto HTML output, you may be impacted. In particular:
 
 - The DOM structure for HTML figures used to be such that the following CSS selector would work:
   

--- a/docs/publishing/hugging-face.qmd
+++ b/docs/publishing/hugging-face.qmd
@@ -75,7 +75,7 @@ These are installed when the Dockerfile builds.
 
 - `src/_quarto.yml` defines the navigation for your website. If you want to add new pages or reorganize the existing ones, you'll need to change this file.
 
-You can edit these files directly in the Hugging Face UI but we reccommend cloning your space, and making and previewing changes locally, then using the publish command as described in the next section.
+You can edit these files directly in the Hugging Face UI but we recommend cloning your space, and making and previewing changes locally, then using the publish command as described in the next section.
 
 ## Publish Command
 

--- a/docs/websites/website-listings-custom.qmd
+++ b/docs/websites/website-listings-custom.qmd
@@ -26,7 +26,7 @@ listing:
   template: gallery.ejs
 ```
 
-A simple template for outputing a list of documents might look like:
+A simple template for outputting a list of documents might look like:
 
 ``` html
 <ul>


### PR DESCRIPTION
@cscheid 

dismissable is considered a non-standard form of dismissible

```
$ sed -n '50p' quarto-web/docs/blog/posts/2024-07-11-1.5-release/index.qmd
You can now use an `announcement` option to add a customizable banner at the top of your website. You can set an icon, make it dismissable, and include markdown formatted content like bold text:
$ sed -n '38p; 47p; 54p' quarto-web/docs/websites/website-tools.qmd
You can set an icon, make it dismissable, and even include formatted content like bold text.
    dismissable: true # <2>
2. `dismissable` - Whether the announcement bar can be dismissed by the user. It can be `true` or `false`.
$ sed -n '7p' quarto-web/docs/reference/projects/announcement.json
    "name": "dismissable",
$ sed -n '10p' quarto-web/_quarto-prerelease-docs.yml
    dismissable: false
$
```

the line with `tournamentand` was also left unmodified as authorship of the file is unknown

```
$ sed -n '1347p' quarto-web/docs/interactive/ojs/athletes.csv
594052376,Bartosz Kurek,POL,male,1988-08-29,2.05,87,volleyball,0,0,0,"An extremely powerful server and spiker, Bartosz Kurek is the idol of Poland's passionate volleyball fans. This opposite spiker helped his country to the 2012 World League, when he was elected the player of the tournamentand the 2009 European championship"
$
```

docs/reference/projects/book.json

`citation key` would be more typical in documentation on that file format

in any event `BiTeX` is a typo and `entrykey` should be written as two words

```diff

-     "description": "Identifier of the item in the input data file (analogous to BiTeX entrykey);\n\nUse this variable to facilitate conversion between word-processor and plain-text writing systems;\nFor an identifier intended as formatted output label for a citation \n(e.g. “Ferr78”), use `citation-label` instead\n"
+     "description": "Identifier of the item in the input data file (analogous to BibTeX entry key);\n\nUse this variable to facilitate conversion between word-processor and plain-text writing systems;\nFor an identifier intended as formatted output label for a citation \n(e.g. “Ferr78”), use `citation-label` instead\n"
```