### PR TITLE
Slight "supported by Posit" badge color tweaks

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -685,8 +685,11 @@ format:
     include-in-header:
       - text: |
           <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js"
-            data-light-bg="#dee2e6"
+            data-light-bg="#E8EDF2"
             data-light-text="#404041"
+            data-light-lt="#ee6331"
+            data-light-gt="#447099"
+            data-dark-bg="#333333"
             data-dark-lt="#ffffff"
             data-dark-gt="#ffffff"></script>
     include-after-body: js.html

--- a/theme-dark.scss
+++ b/theme-dark.scss
@@ -185,3 +185,9 @@ details > summary {
 img.footer-logo {
   color: #ffffff;
 }
+
+/* Supported by Posit badge in navbar */
+
+body.quarto-dark #supported-by-posit:hover {
+   background-color: #2C2C2D;
+}

--- a/theme.scss
+++ b/theme.scss
@@ -43,3 +43,10 @@ $text-muted: #6a737b;
   color: $white;
 }
 
+/* Supported by Posit badge in navbar */
+
+#supported-by-posit:hover {
+  box-shadow: 0px 0px 2px rgba(21, 21, 21, 0.05), 0px 2px 4px rgba(21, 21, 21, 0.06);
+  background-color: #fff;
+  transition: background-color .05s ease-in-out;
+}


### PR DESCRIPTION
This is really minor stuff... Just nuancing the colors controlled by `_quarto.yml`.  More (really minor) hover behavior will come from the light and dark theme files as well

## It will go from this:

https://github.com/user-attachments/assets/4fe65da5-3568-4c1e-b14f-a11c420ba8b5

https://github.com/user-attachments/assets/fd0da527-4a32-4935-8a51-e34fd5a0ec6c


## To this:


https://github.com/user-attachments/assets/7111231e-036f-4e12-88b9-839a8dd1d271



https://github.com/user-attachments/assets/e2ff1d85-41ba-4ec6-9cf1-f1181bbe9135


