### PR TITLE
Fix typo: {.card-sidebar}

### DIFF
--- a/docs/dashboards/inputs.qmd
+++ b/docs/dashboards/inputs.qmd
@@ -259,7 +259,7 @@ Note that the `title` attribute is optional for cells with toolbars (if there is
 
 ### Card Sidebars
 
-To add a sidebar to a card, define it immediately to the left or the right of the cell that generates the output. You can do this either by adding the `content: card-sidebar` option to a cell or by creating a div with the `.card-sidebars` class. For example:
+To add a sidebar to a card, define it immediately to the left or the right of the cell that generates the output. You can do this either by adding the `content: card-sidebar` option to a cell or by creating a div with the `.card-sidebar` class. For example:
 
 ```` {.python .pymd}
 ```{{python}}


### PR DESCRIPTION
Hello, and firstly, thank you to the Quarto team.
We're using Quarto with R to rapidly build a [website](https://github.com/cmmid/gaza-response) to support an emergency situation.
The Quarto documentation is incredible - clear, comprehensive, and useful.

I caught a small typo for card sidebars, so thought I'd open a PR to fix directly. Please feel free to edit or close etc as needed.

Thanks!
Kath
