### PR TITLE
Add qdraw extension to revealjs.yml

### DIFF
--- a/docs/extensions/listings/revealjs.yml
+++ b/docs/extensions/listings/revealjs.yml
@@ -95,6 +95,12 @@
   description: >
     Switch the cursor to a 'pointer' style element.
 
+- name: qdraw
+  path: https://github.com/mahmudstat/qdraw
+  author: '[Abdullah Al Mahmud](https://github.com/mahmudstat)'
+  description: >
+    Adds drawing and erasing functionality to slides.
+
 - name: quiz
   path: https://github.com/parmsam/quarto-quiz
   author: '[Sam Parmar](https://github.com/parmsam)'


### PR DESCRIPTION
Allows drawing and erasing in a revealjs presentation rendered via quarto.

The demo can be watched [here](https://www.thinkermahmud.com/qdraw/#/video-demo)