### PR TITLE
fix: `margin-header` expects markdown

### DIFF
--- a/docs/websites/website-blog.qmd
+++ b/docs/websites/website-blog.qmd
@@ -418,16 +418,22 @@ Here are the steps required to add a subscription widget:
     The above widget HTML will not work in your blog as the subscription HTML needs to contain value specific to your blog. See your email service provider's instructions for generating a subscription widget.
     :::
 
-2.  Create the file `subscribe.html` in the root of your project.
+2.  Create the file `subscribe.md` in the root of your project.
 
-3.  Paste the HTML for your subscription widget into `subscribe.html` and save the file.
+3.  Paste the HTML for your subscription widget into `subscribe.md` as a raw HTML block and save the file.
 
-4.  Add `subscribe.html` to the `margin-header` in your `_quarto.yml` file:
+    ````{.markdown filename="subscribe.md"}
+    ```{=html}
+    Your HTML code goes here.
+    ```
+    ````
+
+4.  Add `subscribe.md` to the `margin-header` in your `_quarto.yml` file:
 
     ``` yaml
     website:
       # (additional metadata excluded for brevity)
-      margin-header: subscribe.html
+      margin-header: subscribe.md
     ```
 
 The result looks like this:


### PR DESCRIPTION
Update the documentation to reflect that the `margin-header` should reference a markdown file/text instead of an HTML file.