### PR TITLE
doc: Fix environment variable name

### DIFF
--- a/docs/projects/code-execution.qmd
+++ b/docs/projects/code-execution.qmd
@@ -95,4 +95,4 @@ project:
   execute-dir: project
 ```
 
-Note that from within your code you can always determine the location of the currently executing Quarto project using the `QUARTO_PROJECT_DIR` environment variable.
+Note that from within your code you can always determine the location of the currently executing Quarto project using the `QUARTO_PROJECT_ROOT` environment variable.


### PR DESCRIPTION
Super minor patch: I updated an environment variable name.

`QUARTO_PROJECT_ROOT` is now the correct variable for both Python and R, and `QUARTO_PROJECT_DIR` is no longer set. This is true for `quarto v1.8.23` at least. I can change the patch to mention both, if that's better.  

I checked the repo for other occurrences—only `./docs/blog/posts/2025-07-28-R-package-release-1.5/index.qmd` still refers to `QUARTO_PROJECT_ROOT` (mentions both variables).