### PR TITLE
fix: typo `ref` instead of `href`

### DIFF
--- a/docs/extensions/lua-api.qmd
+++ b/docs/extensions/lua-api.qmd
@@ -154,7 +154,7 @@ The `dep` object passed to `quarto.doc.add_html_dependency()` has the following 
 | `version` | Version number (as a string). Required. |
 | `scripts` | List of scripts to include (paths can be absolute or relative to the Lua file calling the function). Scripts can be either a simple path or a [script object](#script-object). |
 | `stylesheets` | List of CSS style-sheets to include (paths can be absolute or relative to the Lua file calling the function). Stylesheets can either be a simple path or a [stylesheet object](#stylesheet-object) |
-| `links` | List of link tags to add to the document. Each tag should be a table with `rel` and `ref` (required) and optionally `type` |
+| `links` | List of link tags to add to the document. Each tag should be a table with `rel` and `href` (required) and optionally `type` |
 | `resources` | Additional files to copy to the input directory (each resource is an object with `name` (target file name in input directory) and `path` (source file name relative to Lua script). |
 | `serviceworkers` | JavaScript serviceworker files that should be copied to the root output directory (can be a simple string file name or table with \`path\` and \`name\` for renaming the file as its copied). |
 | `meta` | Table of optional `key = value` meta tags to insert into the document `<head>` |


### PR DESCRIPTION
In HTML dependencies section, the description of `link` has a typo where `ref` is written instead of `href`.