### PR TITLE
fix: update issue URL to use documentation template

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -21,7 +21,7 @@ website:
   twitter-card: true
   site-url: https://quarto.org
   repo-url: https://github.com/quarto-dev/quarto-web
-  issue-url: https://github.com/quarto-dev/quarto-cli/issues/new/choose
+  issue-url: https://github.com/quarto-dev/quarto-cli/issues/new?template=documentation.yml
   repo-actions: [edit, issue]
   page-navigation: true
   bread-crumbs: true


### PR DESCRIPTION
Update the issue URL in the configuration to direct users to the documentation issue template, enhancing guidance for reporting issues.

There is no reason to ask users to choose which template to use (including "blank issue") when they click on "report an issue" from https://quarto.org.
Let's guide them directly to the right one.