### PR TITLE
Promote Typst

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -227,19 +227,19 @@ website:
                     - docs/output-formats/html-lightbox-figures.qmd
                     - docs/output-formats/html-publishing.qmd
                     - docs/output-formats/html-accessibility.qmd
-                - section: "PDF"
+                - section: "PDF with LaTeX"
                   contents:
                     - docs/output-formats/pdf-basics.qmd
                     - docs/output-formats/pdf-engine.qmd
-                - section: "MS Word"
-                  contents:
-                    - docs/output-formats/ms-word.qmd
-                    - docs/output-formats/ms-word-templates.qmd
-                - section: "Typst"
+                - section: "PDF with Typst"
                   contents:
                     - docs/output-formats/typst.qmd
                     - text: "Custom Formats"
                       href: docs/output-formats/typst-custom.qmd
+                - section: "MS Word"
+                  contents:
+                    - docs/output-formats/ms-word.qmd
+                    - docs/output-formats/ms-word-templates.qmd
                 - section: "Markdown"
                   contents:
                     - docs/output-formats/gfm.qmd

--- a/docs/output-formats/pdf-basics.qmd
+++ b/docs/output-formats/pdf-basics.qmd
@@ -8,6 +8,14 @@ doc-type:
 
 ## Overview
 
+::: callout-tip
+## Other paths to PDF
+
+[Typst](/docs/output-formats/typst.qmd) is an alternative way to produce PDFs that comes bundled with Quarto—no separate TeX installation required. If you're new to PDF generation, Typst may offer a quicker start.
+
+Pandoc also supports creating PDFs using ConTeXt, roff ms, or HTML (via wkhtmltopdf). See the Pandoc documentation on [Creating a PDF](https://pandoc.org/MANUAL.html#creating-a-pdf) for details.
+:::
+
 Use the `pdf` format to create PDF output. For example:
 
 ``` yaml
@@ -24,10 +32,6 @@ format:
 This example highlights a few of the options available for PDF output. This article covers these and other options in detail. See the PDF [format reference](/docs/reference/formats/pdf.qmd) for a complete list of all available options.
 
 If you want to produce raw LaTeX output (a .tex file) rather than a PDF, all of the options documented here are still available (see the [LaTeX Output] section below for additional details).
-
-::: callout-note
-Note that while we will focus here exclusively on the use of LaTeX to create PDFs, Pandoc also has support for creating PDFs using ConTeXt, roff ms, or HTML (via wkhtmltopdf). See the Pandoc documentation on [Creating a PDF](https://pandoc.org/MANUAL.html#creating-a-pdf) for additional details.
-:::
 
 ### Prerequisites
 

--- a/docs/output-formats/pdf-engine.qmd
+++ b/docs/output-formats/pdf-engine.qmd
@@ -5,6 +5,12 @@ format: html
 
 ## Overview
 
+::: callout-tip
+## Looking for a simpler path to PDF?
+
+[Typst](/docs/output-formats/typst.qmd) is an alternative way to produce PDFs that comes bundled with Quarto—no separate TeX installation required. If you're new to PDF generation, Typst may offer a quicker start.
+:::
+
 Pandoc supports the use of a wide range of TeX distributions and PDF compilation engines including pdflatex, xelatex, lualatex, tectonic, and latexmk.
 
 While you can employ whatever toolchain you like for LaTeX compilation, we strongly recommend the use of [TinyTeX](https://yihui.org/tinytex/), which is a distribution of [TeX Live](https://tug.org/texlive/) that provides a reasonably sized initial download (\~100 MB) that includes the 200 or so most commonly used TeX packages for Pandoc documents.


### PR DESCRIPTION
## Summary

- Rename sidebar headings to clarify that both LaTeX and Typst produce PDFs
- Move "PDF with Typst" directly below "PDF with LaTeX" in the sidebar so the two PDF options are adjacent
- Add callout to LaTeX PDF pages mentioning Typst as an alternative (bundled, no TeX install required)

Closes quarto-dev/quarto-cli#14088
Closes quarto-dev/quarto-cli#12999

## Naming options

Currently using "PDF with LaTeX" / "PDF with Typst", but open to alternatives:

| Style | LaTeX | Typst |
|-------|-------|-------|
| with | PDF with LaTeX | PDF with Typst |
| via | PDF via LaTeX | PDF via Typst |
| parenthetical | PDF (LaTeX) | PDF (Typst) |
| colon | PDF: LaTeX | PDF: Typst |
