### PR TITLE
Promote Typst v2

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -228,18 +228,21 @@ website:
                     - docs/output-formats/html-publishing.qmd
                     - docs/output-formats/html-accessibility.qmd
                 - section: "PDF"
+                  href: docs/output-formats/pdf.qmd
                   contents:
-                    - docs/output-formats/pdf-basics.qmd
-                    - docs/output-formats/pdf-engine.qmd
+                    - section: "LaTeX"
+                      contents:
+                        - docs/output-formats/pdf-basics.qmd
+                        - docs/output-formats/pdf-engine.qmd
+                    - section: "Typst"
+                      contents:
+                        - docs/output-formats/typst.qmd
+                        - text: "Custom Formats"
+                          href: docs/output-formats/typst-custom.qmd
                 - section: "MS Word"
                   contents:
                     - docs/output-formats/ms-word.qmd
                     - docs/output-formats/ms-word-templates.qmd
-                - section: "Typst"
-                  contents:
-                    - docs/output-formats/typst.qmd
-                    - text: "Custom Formats"
-                      href: docs/output-formats/typst-custom.qmd
                 - section: "Markdown"
                   contents:
                     - docs/output-formats/gfm.qmd

--- a/docs/output-formats/pdf-basics.qmd
+++ b/docs/output-formats/pdf-basics.qmd
@@ -25,8 +25,12 @@ This example highlights a few of the options available for PDF output. This arti
 
 If you want to produce raw LaTeX output (a .tex file) rather than a PDF, all of the options documented here are still available (see the [LaTeX Output] section below for additional details).
 
-::: callout-note
-Note that while we will focus here exclusively on the use of LaTeX to create PDFs, Pandoc also has support for creating PDFs using ConTeXt, roff ms, or HTML (via wkhtmltopdf). See the Pandoc documentation on [Creating a PDF](https://pandoc.org/MANUAL.html#creating-a-pdf) for additional details.
+::: callout-tip
+## Other paths to PDF
+
+[Typst](/docs/output-formats/typst.qmd) is an alternative way to produce PDFs that comes bundled with Quarto—no separate TeX installation required. If you're new to PDF generation, Typst may offer a quicker start.
+
+Pandoc also supports creating PDFs using ConTeXt, roff ms, or HTML (via wkhtmltopdf). See the Pandoc documentation on [Creating a PDF](https://pandoc.org/MANUAL.html#creating-a-pdf) for details.
 :::
 
 ### Prerequisites

--- a/docs/output-formats/pdf-basics.qmd
+++ b/docs/output-formats/pdf-basics.qmd
@@ -1,5 +1,5 @@
 ---
-title: PDF Basics
+title: LaTeX Basics
 format: html
 pdf-standard-latex-examples: true
 doc-type:

--- a/docs/output-formats/pdf-engine.qmd
+++ b/docs/output-formats/pdf-engine.qmd
@@ -5,6 +5,12 @@ format: html
 
 ## Overview
 
+::: callout-tip
+## Looking for a simpler path to PDF?
+
+[Typst](/docs/output-formats/typst.qmd) is an alternative way to produce PDFs that comes bundled with Quarto—no separate TeX installation required. If you're new to PDF generation, Typst may offer a quicker start.
+:::
+
 Pandoc supports the use of a wide range of TeX distributions and PDF compilation engines including pdflatex, xelatex, lualatex, tectonic, and latexmk.
 
 While you can employ whatever toolchain you like for LaTeX compilation, we strongly recommend the use of [TinyTeX](https://yihui.org/tinytex/), which is a distribution of [TeX Live](https://tug.org/texlive/) that provides a reasonably sized initial download (\~100 MB) that includes the 200 or so most commonly used TeX packages for Pandoc documents.

--- a/docs/output-formats/pdf-engine.qmd
+++ b/docs/output-formats/pdf-engine.qmd
@@ -1,5 +1,5 @@
 ---
-title: "PDF Engines"
+title: "LaTeX Engines"
 format: html
 ---
 

--- a/docs/output-formats/pdf.qmd
+++ b/docs/output-formats/pdf.qmd
@@ -1,0 +1,30 @@
+---
+title: PDF Documents
+format: html
+---
+
+## Overview
+
+Quarto supports two paths to PDF output:
+
+-   `typst` --- [Typst](#typst) (bundled with Quarto)
+
+-   `pdf` --- [LaTeX](#latex) via TeX (e.g., TinyTeX, TeX Live)
+
+Both produce high-quality documents but differ in setup, speed, and customization.
+
+## Typst
+
+Use `format: typst` for the fastest path to PDF. Typst is bundled with Quarto—no additional installation required. It offers fast compilation, simpler customization syntax, and a gentler learning curve.
+
+Choose Typst if you're new to PDF generation, want quick results, or are working from Typst templates.
+
+See [Typst Basics](typst.qmd) to get started.
+
+## LaTeX
+
+Use `format: pdf` to generate PDFs via LaTeX. This requires a TeX distribution (e.g., TinyTeX, TeX Live), but gives you access to the vast ecosystem of LaTeX packages and templates.
+
+Choose LaTeX if you need specific LaTeX packages, are working with journal or publisher templates, or have existing LaTeX workflows.
+
+See [LaTeX Basics](pdf-basics.qmd) to get started.


### PR DESCRIPTION
An alternative approach to quarto-dev/quarto-web#1917 (the "PDF with LaTeX" / "PDF with Typst" naming approach).

This PR nests both LaTeX and Typst under a single "PDF" section in the sidebar, with a new landing page that helps users choose between the two paths.

**Changes:**

- Add new `pdf.qmd` landing page describing both PDF paths
- Nest "LaTeX" and "Typst" as subsections under "PDF" in sidebar
- Rename "PDF Basics" → "LaTeX Basics" and "PDF Engines" → "LaTeX Engines"

**Sidebar structure:**

```
- PDF (landing page)
  - LaTeX
    - LaTeX Basics
    - LaTeX Engines
  - Typst
    - Typst Basics
    - Custom Formats
```

Closes quarto-dev/quarto-cli#14088
Closes quarto-dev/quarto-cli#12999
