### PR TITLE
Add Claude context files for docs authoring

### DIFF
--- a/.claude/rules/docs-authoring.md
+++ b/.claude/rules/docs-authoring.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "docs/**/*.qmd"
+---
+
+# Docs Authoring
+
+## Prerelease shortcodes
+
+When documenting a feature introduced in a specific Quarto version, add at the top of the section:
+
+```
+{{< prerelease-callout X.Y >}}
+```
+
+Shows a pre-release callout before X.Y ships, disappears automatically after — never remove them manually. For blog posts use `type="blog"`. For URLs use `{{< prerelease-docs-url X.Y >}}`. See `_extensions/prerelease/` for details.

--- a/_extensions/prerelease/CLAUDE.md
+++ b/_extensions/prerelease/CLAUDE.md
@@ -1,0 +1,3 @@
+# Prerelease Extension
+
+See `prerelease.lua` for implementation and #1961 for design rationale.


### PR DESCRIPTION
Path-scoped Claude Code context files to help with docs workflows:

- `.claude/rules/docs-authoring.md` — prerelease shortcode usage guidance, scoped to `docs/**/*.qmd`
- `_extensions/prerelease/CLAUDE.md` — pointer to source and design PR for the extension