### PR TITLE
Fix YAML key from 'editors' to 'editor'

### DIFF
--- a/docs/authoring/create-citeable-articles.qmd
+++ b/docs/authoring/create-citeable-articles.qmd
@@ -253,13 +253,13 @@ Quarto's approach to emitting scholarly metadata is to take the standard CSL fie
 [^2]: Specify one or more editors using one of the following:
 
     ``` yaml
-    editors: Norah Jones
+    editor: Norah Jones
     ```
 
     or multiple values like:
 
     ``` yaml
-    editors:
+    editor:
     -   Norah Jones
     -   Nick Fury
     ```


### PR DESCRIPTION
There's no key called 'editors', change it to 'editor'