### PR TITLE
Clarify figure reference syntax in figures.qmd

### DIFF
--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -138,7 +138,7 @@ You can cross-reference figures by adding an ID with the `fig-` prefix to them, 
 ``` markdown
 ![An Elephant](elephant.png){#fig-elephant}
 
-This is illustrated well by @fig-elephant.
+This is illustrated well by @fig-elephant. (Note the space before the `@`!)
 ```
 
 For figures produced by executable code cells, include a `label` with a `fig-` prefix to make them cross-referenceable. For example:


### PR DESCRIPTION
Added a note about the space before the '@' in figure references.

No space, no reference!