### PR TITLE
feat(extensions): add missing mcanouil extensions to listings

### DIFF
--- a/docs/extensions/listings/revealjs.yml
+++ b/docs/extensions/listings/revealjs.yml
@@ -1,3 +1,12 @@
+- name: a11y
+  path: https://github.com/mcanouil/quarto-revealjs-a11y
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto Reveal.js plugin providing accessibility (a11y) enhancements,
+    including skip navigation, focus indicators, reduced motion support, high
+    contrast mode, font size controls, screen reader announcements, and an
+    accessibility settings menu.
+
 - name: animate
   path: https://github.com/fradav/quarto-revealjs-animate
   author: '[François-David Collin](https://github.com/fradav/)'
@@ -37,6 +46,13 @@
   description: >
     Automatically creates agenda slides from H1 heading titles.
 
+- name: cascade
+  path: https://github.com/mcanouil/quarto-revealjs-cascade
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto filter that automatically repeats the heading chain for Reveal.js
+    slides following the DRY principle.
+
 - name: code-fullscreen
   path: https://github.com/shafayetShafee/code-fullscreen
   author: '[Shafayet Khan Shafee](https://github.com/shafayetShafee)'
@@ -48,6 +64,13 @@
   author: '[Reuning](https://github.com/reuning)'
   description: >
     A plugin that lets you step through fragments and code higlights at the same time.
+
+- name: codefrag
+  path: https://github.com/mcanouil/quarto-revealjs-codefrag
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Reveal.js plugin that enables fragment-based keyboard navigation through
+    code annotations in Quarto presentations.
 
 - name: code-folder
   path: https://github.com/herosi/code-folder
@@ -89,6 +112,14 @@
   author: '[Sam Parmar](https://github.com/parmsam)'
   description: >
     Adds flashcards in slides that you can flip and shuffle.
+
+- name: fragmention
+  path: https://github.com/mcanouil/quarto-revealjs-fragmention
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto filter that hoists fragment attributes to list items in Reveal.js
+    presentations, making bullet markers appear and disappear with fragment
+    content.
 
 - name: fragoff
   path: https://github.com/DanChaltiel/quarto_fragoff
@@ -164,7 +195,7 @@
     Adds speech recognition for you to navigate slides.
 
 - name: spotlight
-  path: https://github.com/mcanouil/quarto-spotlight
+  path: https://github.com/mcanouil/quarto-revealjs-spotlight
   author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
   description: >
     A Quarto extension for Reveal.js allowing to highlight the current mouse position with a spotlight.
@@ -180,6 +211,13 @@
   author: '[Sam Parmar](https://github.com/parmsam)'
   description: >
     Adds live captions for spoken words to slides.
+
+- name: tabset
+  path: https://github.com/mcanouil/quarto-revealjs-tabset
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Reveal.js plugin enabling proper tabset navigation with fragment-based
+    transitions and PDF export support for Quarto presentations.
 
 - name: tts
   path: https://github.com/parmsam/quarto-tts

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -130,6 +130,14 @@
   description: >
     Directives for filtering code and stream output included within a document.
 
+- name: code-window
+  path: https://github.com/mcanouil/quarto-code-window
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto filter that styles code blocks as macOS-style windows with traffic
+    light buttons, Windows title bar buttons, or a plain filename bar. Supports
+    HTML, Reveal.js, and Typst formats.
+
 - name: codecelloptions
   path: https://github.com/coatless-quarto/codecelloptions
   author: '[James Joseph Balamuta](https://github.com/coatless/)'
@@ -335,6 +343,14 @@
   description: >
     Add a Github Corner into your HTML document.
 
+- name: gitlink
+  path: https://github.com/mcanouil/quarto-gitlink
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto filter that automatically converts Git hosting platform references
+    (issues, pull requests, commits, users) into clickable links. Supports
+    GitHub, GitLab, Codeberg, Gitea, and Bitbucket.
+
 - name: gradio
   path: https://github.com/peter-gy/quarto-gradio
   author: '[Péter Ferenc Gyarmati](https://github.com/peter-gy)'
@@ -358,7 +374,7 @@
   path: https://github.com/mcanouil/quarto-highlight-text
   author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
   description: >
-    Quarto extension that allows to highlight text in a document for various formats: HTML, LaTeX, Typst, and Docx.
+    Quarto extension that allows to highlight text in a document for various formats: HTML, LaTeX, Typst, Docx, PowerPoint, Reveal.js, and Beamer.
 
 - name: honeypot
   path: https://github.com/jmgirard/honeypot
@@ -467,6 +483,13 @@
   author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
   description: >
     A filter/shortcode extension for Quarto to provide access to LUA objects as metadata.
+
+- name: masonry
+  path: https://github.com/mcanouil/quarto-masonry
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    Quarto extension providing support for Masonry.js grid layout in HTML
+    documents.
 
 - name: material-icons
   path: https://github.com/shafayetShafee/material-icons
@@ -716,6 +739,13 @@
   description: >
     A filter that renders [PGF/TikZ](https://en.wikipedia.org/wiki/PGF/TikZ) diagrams in HTML as SVG.
 
+- name: toc-depth
+  path: https://github.com/mcanouil/quarto-toc-depth
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto filter providing fine-grained control over table of contents depth
+    at the header level using a toc-depth attribute.
+
 - name: toggle
   path: https://github.com/coatless-quarto/toggle
   author: '[James Joseph Balamuta](https://github.com/coatless/)'
@@ -732,6 +762,14 @@
   author: '[Sverrir Arnórsson](https://github.com/sverrirarnors)'
   description: >
     Changes math block syntax from LaTeX to Typst math.
+
+- name: typst-render
+  path: https://github.com/mcanouil/quarto-typst-render
+  author: '[Mickaël CANOUIL](https://github.com/mcanouil)'
+  description: >
+    A Quarto filter that compiles Typst code blocks to images (PNG, SVG, or PDF)
+    using the bundled Typst binary, making Typst usable across all output
+    formats.
 
 - name: unsplash
   path: https://github.com/dragonstyle/unsplash


### PR DESCRIPTION
Add 10 missing mcanouil extensions to `revealjs.yml` and `shortcodes-and-filters.yml`, fix the renamed `spotlight` repository URL, and update the `highlight-text` description to list all supported formats.