### PR TITLE
Add Reference sidebar landing pages to fix breadcrumb navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -493,6 +493,7 @@ website:
           href: docs/reference/index.qmd
           contents:
             - section: "Formats"
+              href: docs/reference/formats/index.qmd
               contents:
                 - text: "HTML"
                   href: docs/reference/formats/html.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -597,7 +597,8 @@ website:
                   href: docs/reference/projects/books.qmd
                 - text: "Manuscripts"
                   href: docs/reference/projects/manuscripts.qmd
-            - section: "More"
+            - section: "Metadata"
+              href: docs/reference/metadata/index.qmd
               contents:
                 - text: "Dates"
                   href: docs/reference/dates.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -587,6 +587,7 @@ website:
                 - text: "Observable"
                   href: docs/reference/cells/cells-ojs.qmd
             - section: "Projects"
+              href: docs/reference/projects/index.qmd
               contents:
                 - text: "Options"
                   href: docs/reference/projects/options.qmd

--- a/docs/reference/formats/index.qmd
+++ b/docs/reference/formats/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Formats
+toc: false
+anchor-sections: false
+listing:
+  id: reference-links
+  template: ../../../ejs/links.ejs
+  contents: ./reference.yml
+---
+
+Reference for the document, presentation, markdown, wiki, and other output formats Quarto can produce. Each link points to the YAML option reference for that format.
+
+::: {#reference-links .column-screen-inset-right style="max-width: 850px;"}
+:::

--- a/docs/reference/formats/reference.yml
+++ b/docs/reference/formats/reference.yml
@@ -1,0 +1,88 @@
+- title: "Documents"
+  links:
+    - text: HTML
+      href: html.qmd
+    - text: PDF
+      href: pdf.qmd
+    - text: MS Word
+      href: docx.qmd
+    - text: Typst
+      href: typst.qmd
+    - text: OpenDocument
+      href: odt.qmd
+    - text: ePub
+      href: epub.qmd
+
+- title: "Presentations"
+  links:
+    - text: Revealjs
+      href: presentations/revealjs.qmd
+    - text: PowerPoint
+      href: presentations/pptx.qmd
+    - text: Beamer
+      href: presentations/beamer.qmd
+
+- title: "Markdown"
+  links:
+    - text: GitHub
+      href: markdown/gfm.qmd
+    - text: CommonMark
+      href: markdown/commonmark.qmd
+    - text: Hugo
+      href: markdown/hugo.qmd
+    - text: Markua
+      href: markdown/markua.qmd
+
+- title: "Wikis"
+  links:
+    - text: MediaWiki
+      href: wiki/mediawiki.qmd
+    - text: DokuWiki
+      href: wiki/dokuwiki.qmd
+    - text: ZimWiki
+      href: wiki/zimwiki.qmd
+    - text: Jira Wiki
+      href: wiki/jira.qmd
+    - text: XWiki
+      href: wiki/xwiki.qmd
+
+- title: "More Formats"
+  links:
+    - text: JATS
+      href: jats.qmd
+    - text: Jupyter
+      href: ipynb.qmd
+    - text: Dashboards
+      href: dashboard.qmd
+    - text: ConTeXt
+      href: context.qmd
+    - text: RTF
+      href: rtf.qmd
+    - text: reST
+      href: rst.qmd
+    - text: AsciiDoc
+      href: asciidoc.qmd
+    - text: Org-Mode
+      href: org.qmd
+    - text: Muse
+      href: muse.qmd
+    - text: GNU TexInfo
+      href: texinfo.qmd
+    - text: Groff Man Page
+      href: man.qmd
+    - text: Groff Manuscript
+      href: ms.qmd
+    - text: Haddock markup
+      href: haddock.qmd
+    - text: OPML
+      href: opml.qmd
+    - text: Textile
+      href: textile.qmd
+    - text: DocBook
+      href: docbook.qmd
+    - text: InDesign
+      href: icml.qmd
+    - text: TEI Simple
+      href: tei.qmd
+    - text: FictionBook
+      href: fb2.qmd

--- a/docs/reference/metadata/index.qmd
+++ b/docs/reference/metadata/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Metadata
+toc: false
+anchor-sections: false
+listing:
+  id: reference-links
+  template: ../../../ejs/links.ejs
+  contents: ./reference.yml
+---
+
+Reference for document- and project-level metadata: dates, glob patterns, citations, cross-references, and brand configuration.
+
+::: {#reference-links .column-screen-inset-right style="max-width: 850px;"}
+:::

--- a/docs/reference/metadata/reference.yml
+++ b/docs/reference/metadata/reference.yml
@@ -1,0 +1,12 @@
+- title: "Metadata"
+  links:
+    - text: Dates
+      href: ../dates.qmd
+    - text: Globs
+      href: ../globs.qmd
+    - text: Citations
+      href: citation.qmd
+    - text: Cross-References
+      href: crossref.qmd
+    - text: Brand
+      href: brand.qmd

--- a/docs/reference/projects/index.qmd
+++ b/docs/reference/projects/index.qmd
@@ -1,0 +1,14 @@
+---
+title: Projects
+toc: false
+anchor-sections: false
+listing:
+  id: reference-links
+  template: ../../../ejs/links.ejs
+  contents: ./reference.yml
+---
+
+Reference for Quarto project types and their YAML options. Project types include websites, books, and manuscripts; the Options page covers settings shared across all project types.
+
+::: {#reference-links .column-screen-inset-right style="max-width: 850px;"}
+:::

--- a/docs/reference/projects/reference.yml
+++ b/docs/reference/projects/reference.yml
@@ -1,0 +1,10 @@
+- title: "Projects"
+  links:
+    - text: Options
+      href: options.qmd
+    - text: Websites
+      href: websites.qmd
+    - text: Books
+      href: books.qmd
+    - text: Manuscripts
+      href: manuscripts.qmd


### PR DESCRIPTION
When clicking the `Formats` breadcrumb on `/docs/reference/formats/<page>.html`, the link led to `formats/html.html` (the first child) instead of a section landing. The `Reference > More` section had a similar issue and was not a coherent grouping for its contents.

Adds explicit landing pages for three Reference sidebar sections so the breadcrumb renders as a clickable link to a real page:

- `Formats` → new `docs/reference/formats/index.qmd`
- `Projects` → new `docs/reference/projects/index.qmd`
- `More` → renamed to `Metadata` and pointed at new `docs/reference/metadata/index.qmd`

The `More` → `Metadata` rename matches the grouping already used in `docs/reference/reference.yml` (the master listing the website renders) — Dates, Globs, Citations, Cross-References, and Brand are now grouped under `Metadata` in the sidebar too. The five items themselves are unchanged.

Each landing mirrors the existing `docs/reference/cells/` pattern: small `index.qmd` shell + a per-subdir `reference.yml` subset rendered by the existing `ejs/links.ejs` template. No new extension, shortcode, or filter. The master `docs/reference/reference.yml` is untouched.

Reported in quarto-dev/quarto-cli#14402. The underlying CLI fallback behavior (sidebar sections without `href:` use `contents[0].href`) is tracked separately at quarto-dev/quarto-cli#14454 and is not addressed here. Inner Guide sub-sections (HTML/PDF/MS Word/Typst/Markdown under Documents) and `Reference > Quarto CLI` continue to inherit the same fallback and are deferred.

A follow-up PR will fix the `Documents` section in the Guide sidebar.