### PR TITLE
Fix missing link on Documents breadcrumb in Guide sidebar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -218,6 +218,7 @@ website:
                 - docs/tools/neovim.qmd
                 - docs/tools/text-editors.qmd
             - section: "Documents"
+              href: docs/output-formats/all-formats.qmd
               contents:
                 - section: "HTML"
                   contents:


### PR DESCRIPTION
When clicking the `Documents` breadcrumb on Guide format pages (e.g., `docs/output-formats/html-basics.html`), the breadcrumb shows no link. The `Documents` section has no `href:` and its first child is itself a section, so the CLI fallback to `contents[0].href` produces nothing.

Add `href: docs/output-formats/all-formats.qmd` on the `Documents` section. The page already exists and is the natural landing for this group.

Inner Guide sub-sections (HTML, PDF, MS Word, Typst, Markdown) hit the same bug but need new overview content rather than just a navigation tweak, so they continue to inherit the unresolved CLI default tracked in quarto-dev/quarto-cli#14454.

Reported in quarto-dev/quarto-cli#14402.