### PR TITLE
add focus-mode extension to listings

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -301,6 +301,13 @@
   description: >
     Style code in rendered chunks.
 
+- name: focus-mode
+  path: https://github.com/lsbjordao/quarto-focus-mode
+  author: '[lsbjordao](https://github.com/lsbjordao)'
+  description: >
+    Enable Focus Mode (distraction-free reading) and Presentation Mode
+    (keyboard-driven section-by-section navigation) for Quarto Book and Website HTML outputs.
+
 - name: fontawesome
   path: https://github.com/quarto-ext/fontawesome
   author: '[quarto-ext](https://github.com/quarto-ext)'


### PR DESCRIPTION
Adds the `focus-mode` extension for Quarto Book HTML output.

- Repo: https://github.com/lsbjordao/quarto-focus-mode
- Live example: https://lsbjordao.github.io/quarto-book-focus-mode-example/
