### PR TITLE
Add conditional-vars extension and fix author name in focus-mode

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -169,6 +169,12 @@
   description: >
     Filter to create collapsible callouts with [`social-embeds`](https://github.com/sellorm/quarto-social-embeds) for HTML format.
 
+- name: conditional-vars
+  path: https://github.com/lsbjordao/quarto-conditional-vars
+  author: '[Lucas S.B. Jordão](https://github.com/lsbjordao)'
+  description: >
+    A Quarto extension for conditional content based on project-level variables defined in `_variables.yml`.
+
 - name: countdown
   path: https://github.com/gadenbuie/countdown
   author: '[Garrick Aden-Buie](https://github.com/gadenbuie/) and [James Joseph Balamuta](https://github.com/coatless/)'
@@ -303,7 +309,7 @@
 
 - name: focus-mode
   path: https://github.com/lsbjordao/quarto-focus-mode
-  author: '[lsbjordao](https://github.com/lsbjordao)'
+  author: '[Lucas S.B. Jordão](https://github.com/lsbjordao)'
   description: >
     Enable Focus Mode (distraction-free reading) and Presentation Mode
     (keyboard-driven section-by-section navigation) for Quarto Book and Website HTML outputs.


### PR DESCRIPTION
This PR adds the `conditional-vars` extension and fixes the author name in the `focus-mode` extension.

## conditional-vars

Adds support for conditional content blocks based on variables defined in `_variables.yml`.

Unlike `.when`, which operates on profiles, this extension enables conditional rendering driven by project-level variables.

## focus-mode

- Fixes author name metadata