### PR TITLE
Update reference for navigation text field markdown support

### DIFF
--- a/docs/reference/projects/announcement.json
+++ b/docs/reference/projects/announcement.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "content",
-    "description": "The content of the announcement"
+    "description": "The content of the announcement. Supports markdown formatting."
   },
   {
     "name": "dismissable",

--- a/docs/reference/projects/navbar.json
+++ b/docs/reference/projects/navbar.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "title",
-    "description": "The navbar title. Uses the project title if none is specified."
+    "description": "The navbar title. Uses the project title if none is specified. Supports markdown formatting."
   },
   {
     "name": "logo",

--- a/docs/reference/projects/navitem.json
+++ b/docs/reference/projects/navitem.json
@@ -17,7 +17,7 @@
   },
   {
     "name": "text",
-    "description": "Text to display for item (defaults to the\ndocument title if not provided)\n"
+    "description": "Text to display for item (defaults to the\ndocument title if not provided). Supports markdown formatting.\n"
   },
   {
     "name": "rel",

--- a/docs/reference/projects/pagefooter.json
+++ b/docs/reference/projects/pagefooter.json
@@ -1,15 +1,15 @@
 [
   {
     "name": "left",
-    "description": "Footer left content"
+    "description": "Footer left content. Supports markdown formatting."
   },
   {
     "name": "right",
-    "description": "Footer right content"
+    "description": "Footer right content. Supports markdown formatting."
   },
   {
     "name": "center",
-    "description": "Footer center content"
+    "description": "Footer center content. Supports markdown formatting."
   },
   {
     "name": "border",

--- a/docs/reference/projects/sidebar.json
+++ b/docs/reference/projects/sidebar.json
@@ -5,7 +5,7 @@
   },
   {
     "name": "title",
-    "description": "The sidebar title. Uses the project title if none is specified."
+    "description": "The sidebar title. Uses the project title if none is specified. Supports markdown formatting."
   },
   {
     "name": "logo",


### PR DESCRIPTION
Regenerates `docs/reference/projects/*.json` so the reference pages reflect quarto-dev/quarto-cli#14503 (closes quarto-dev/quarto-cli#6858):

- `navitem.json` — `navigation-item.text`
- `navbar.json` — `navbar.title`
- `sidebar.json` — `sidebar.title`
- `announcement.json` — `announcement.content`
- `pagefooter.json` — `page-footer.left/center/right`

All five now note that the field supports markdown formatting, which matches what `website-navigation-md.ts` actually does.

Generated via `quarto run _tools/reference.ts` against quarto-cli main. Targets `prerelease` because the schema change ships in 1.10; the rolling `auto/prerelease-reference` workflow would pick this up on the next prerelease tag, but no need to wait for a one-line description fix.
