### PR TITLE
Add quarto-study-flow to shortcodes-and-filters listing

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -716,6 +716,14 @@
   description: >
     Quarto Extension for Embedding Render Information about the Document
 
+- name: study-flow
+  path: https://github.com/tiagojct/quarto-study-flow
+  author: '[Tiago Jacinto](https://github.com/tiagojct)'
+  description: >
+    Render CONSORT, STROBE, PRISMA 2020, TRIPOD+AI, and STARD
+    participant-flow diagrams from structured YAML in the document frontmatter.
+    Inline SVG for HTML, native TikZ for LaTeX/PDF; no external dependencies.
+
 - name: style-text
   path: https://github.com/leovan/quarto-style-text
   author: '[范叶亮 > Leo Van](https://github.com/leovan)'


### PR DESCRIPTION
Adds [`quarto-study-flow`](https://github.com/tiagojct/quarto-study-flow) — a Quarto shortcode extension that renders participant-flow diagrams for the major biomedical reporting guidelines (CONSORT 2025, STROBE, PRISMA 2020, TRIPOD+AI 2024, STARD 2015) from structured YAML in the document frontmatter.

- Inline SVG for HTML output, native TikZ for LaTeX/PDF output.
- Pure Lua; no `rsvg-convert`, Graphviz, or other external dependencies.
- MIT licensed; README with install instructions and a full schema reference.
- Released as v1.1.0 on 2026-05-11.

Entry placed alphabetically between `stamp` and `style-text` in `docs/extensions/listings/shortcodes-and-filters.yml`.