### PR TITLE
Add quarto-bytefield to shortcodes-and-filters listing

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -107,7 +107,7 @@
     Revealjs presentations.
 
 - name: bytefield
-  path: https://github.com/crisbour/bytefield.git
+  path: https://github.com/crisbour/bytefield
   author: '[Cristian Bourceanu](https://github.com/crisbour)'
   description: >
     Generate byte field diagrams using the bytefield-svg Node module.

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -106,6 +106,12 @@
     Use [Bootstrap Icons](https://icons.getbootstrap.com/) in HTML documents and
     Revealjs presentations.
 
+- name: bytefield
+  path: https://github.com/crisbour/bytefield.git
+  author: '[Cristian Bourceanu](https://github.com/crisbour)'
+  description: >
+    Generate byte field diagrams using the bytefield-svg Node module.
+
 - name: callouty-theorem
   path: https://github.com/sun123zxy/quarto-callouty-theorem
   author: '[sun123zxy](https://github.com/sun123zxy/)'


### PR DESCRIPTION
Calling [bytefield-svg](https://github.com/Deep-Symmetry/bytefield-svg) Node module to generate svg byte field diagrams inline in Quarto using the DSL in a code block

Example:
````
```{.bytefield}
(draw-column-headers)
(draw-box "Address" {:span 4})
(draw-box "Size" {:span 2})
(draw-box 0 {:span 2})
(draw-gap "Payload")
(draw-bottom)
```
````

<img width="681" height="116" alt="image" src="https://github.com/user-attachments/assets/259c9ebb-d081-4139-9172-777a63bc4fc8" />