### PR TITLE
Add quartable filter

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -621,6 +621,16 @@
   description: >
     Run standalone React components in your project!
 
+- name: quartable
+  path: https://github.com/zinc75/quarto-quartable
+  author: '[Eric Bavu](https://github.com/zinc75)'
+  description: >
+    Filter that adds column spans, row spans, midrules, partial clines,
+    vertical lines and per-cell alignment overrides to Markdown pipe
+    tables. Targets HTML, Reveal.js and PDF/LaTeX from a single source.
+    Heavily inspired by the LaTeX
+    [booktabs](https://ctan.org/pkg/booktabs?lang=en) package.
+
 - name: quizdown
   path: https://github.com/parmsam/quarto-quizdown
   author: '[Sam Parmar](https://github.com/parmsam)'


### PR DESCRIPTION
Adds [quartable](https://github.com/zinc75/quarto-quartable), a Quarto filter that extends Markdown pipe tables with column spans, row spans, midrules, partial clines (cmidrules), vertical lines and per-cell alignment overrides — targeting HTML, Reveal.js and PDF/LaTeX from a single source. The design is heavily inspired by the LaTeX [booktabs](https://ctan.org/pkg/booktabs?lang=en) package (rule weights, no per-row borders, partial rules via `\cmidrule`, etc.).

- Repository: https://github.com/zinc75/quarto-quartable
- Live demos (HTML / PDF / Reveal): https://zinc75.github.io/quarto-quartable/
- License: MIT
- Already listed in [mcanouil/quarto-extensions](https://github.com/mcanouil/quarto-extensions).