### PR TITLE
Remove dangling signup.html reference from blog posts metadata

### DIFF
--- a/docs/blog/posts/_metadata.yml
+++ b/docs/blog/posts/_metadata.yml
@@ -4,8 +4,4 @@ comments:
     category: Blog
 title-block-banner: true
 toc-location: left
-format:
-  html:
-    include-after-body:
-      - ../signup.html
 search: false


### PR DESCRIPTION
The signup.html file was removed in #2017 when the Mailchimp form was retired, but `blog/posts/_metadata.yml` still pulled it in via `include-after-body`.