### PR TITLE
Add bookly-typst template to custom formats

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -22,6 +22,12 @@
   description: >
     Quarto Typst template for the Awesome CV
 
+- name: bookly-typst
+  path: https://github.com/maucejo/quarto-bookly
+  author: '[Mathieu Aucejo](https://github.com/maucejo)'
+  description: >
+    Templates for writing books or theses via the bookly Typst package
+
 - name: bookup
   path: https://github.com/juba/bookup-html
   author: '[juba](https://github.com/juba)'


### PR DESCRIPTION
This PR aims at including that `bookly-typst` extension to the list of the available custom formats.