### PR TITLE
Add cnam-thesis template for Quarto

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -39,6 +39,14 @@
   author: '[Kazuharu Yanagimoto](https://github.com/kazuyanagimoto)'
   description: A minimalistic presentation theme for Quarto + Typst by Touying
 
+- name: cnam-thesis
+  path: https://github.com/zinc75/quarto-cnam-thesis
+  author: '[Eric Bavu](https://github.com/zinc75)'
+  description: >
+    Quarto template / set of extensions for Cnam (Conservatoire national des arts et métiers) doctoral theses.
+    PDF/A-1b + navigable HTML - Produces a PDF that conforms to the official Cnam 2024–2025 template 
+    and a navigable HTML version for online sharing and accessibility.
+
 - name: diaquarto
   path: https://github.com/skriptum/diatypst/blob/main/diaquarto
   author: "[marten](https://github.com/skriptum)"


### PR DESCRIPTION
Added cnam-thesis template for Cnam doctoral theses with PDF/A-1b and HTML support.

- Repo : https://github.com/zinc75/quarto-cnam-thesis 
- Full documentation generated with the template (HTML + PDF) : https://zinc75.github.io/quarto-cnam-thesis/ 
