### PR TITLE
Fix broken redirect code

### DIFF
--- a/docs/get-started/_redirect.html
+++ b/docs/get-started/_redirect.html
@@ -2,7 +2,7 @@
   /* This code exists but is no longer used in the "happy path" for our webpage. If someone lands here it
   will still work but redirect to the main guide, which itself will no longer use redirection.
 
-  The issue with redirection is it causes a FOUC
+  The issue with redirection is it causes a FOUC */
 
   const toolPage = window.localStorage.getItem("tutorialToolGetStarted") || "jupyter.html";
   window.location.replace(toolPage);


### PR DESCRIPTION
At the bottom of https://quarto.org/docs/get-started/ there's link to https://quarto.org/docs/get-started/hello/ which doesn't correctly redirect and shows a mostly empty page. I think it's just a missing closing comment symbol that means the redirect isn't actually executing. 