### PR TITLE
docs: document default-image-extension per format and Typst static image support

### DIFF
--- a/.claude/rules/docs-authoring.md
+++ b/.claude/rules/docs-authoring.md
@@ -14,3 +14,7 @@ When documenting a feature introduced in a specific Quarto version, add at the t
 ```
 
 Shows a pre-release callout before X.Y ships, disappears automatically after — never remove them manually. For blog posts use `type="blog"`. For URLs use `{{< prerelease-docs-url X.Y >}}`. See `_extensions/prerelease/` for details.
+
+## Format name convention
+
+When referring to a Quarto format by its identifier (the value used in `format:` YAML), use inline code with lowercase: `` `html` ``, `` `pdf` ``, `` `typst` ``, `` `docx` ``, etc. Use prose (HTML, PDF, Typst) only when referring to the file type generically — not the format identifier. This avoids ambiguity (e.g., "PDF" could describe output from both `format: pdf` and `format: typst`).

--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -105,15 +105,15 @@ Quarto will look for a file matching the extension associated with the target ou
 
 | Format | Default extension |
 |--------|-------------------|
-| HTML, EPUB, DOCX, PPTX, and most others | `.png` |
-| PDF (via LaTeX / Beamer) | `.pdf` |
-| Typst | `.svg` |
+| `html`, `epub`, `docx`, `pptx`, and most others | `.png` |
+| `pdf` (via LaTeX / Beamer) | `.pdf` |
+| `typst` | `.svg` |
 
 So for `![](elephant)`:
 
-- Rendering to HTML looks for `elephant.png`
-- Rendering to PDF (LaTeX) looks for `elephant.pdf`
-- Rendering to Typst looks for `elephant.svg`
+- Rendering to `html` looks for `elephant.png`
+- Rendering to `pdf` (LaTeX) looks for `elephant.pdf`
+- Rendering to `typst` looks for `elephant.svg`
 
 You can override the default per format using the `default-image-extension` option:
 

--- a/docs/authoring/figures.qmd
+++ b/docs/authoring/figures.qmd
@@ -95,13 +95,27 @@ as detailed in [the Pandoc documentation](https://pandoc.org/MANUAL.html#extensi
 
 ### Multiformat Figures
 
-You can write markdown that provides a distinct image file format depending on the target output format. To do this simply leave-off the extension, for example:
+You can write markdown that provides a distinct image file format depending on the target output format. To do this simply leave off the extension, for example:
 
 ``` markdown
 ![](elephant)
 ```
 
-By default this will look for `elephant.png`, however if you are rendering to PDF it will look for `elephant.pdf`. You can customize this behavior using the `default-image-extension` option. For example:
+Quarto will look for a file matching the extension associated with the target output format. The default extension per format is:
+
+| Format | Default extension |
+|--------|-------------------|
+| HTML, EPUB, DOCX, PPTX, and most others | `.png` |
+| PDF (via LaTeX / Beamer) | `.pdf` |
+| Typst | `.svg` |
+
+So for `![](elephant)`:
+
+- Rendering to HTML looks for `elephant.png`
+- Rendering to PDF (LaTeX) looks for `elephant.pdf`
+- Rendering to Typst looks for `elephant.svg`
+
+You can override the default per format using the `default-image-extension` option:
 
 ``` yaml
 format:
@@ -109,6 +123,16 @@ format:
     default-image-extension: svg
   pdf:
     default-image-extension: tex
+  typst:
+    default-image-extension: png
+```
+
+If you have images with no extension at all (e.g. remote URLs like badge URLs), set `default-image-extension` to an empty string to prevent Quarto from appending one:
+
+``` yaml
+format:
+  html:
+    default-image-extension: ""
 ```
 
 ### Lightbox Figures

--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -434,17 +434,29 @@ format:
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
-## Computation Figure Format
+## Image Formats
 
-Typst has great support for SVG graphics, so `format: typst` defaults to `fig-format: svg`. This configuration means executable code cells that produce images will produce `.svg` output. 
+### Static Images
 
-If you prefer to include raster graphics, set `fig-format` to another value, like for example: 
+Typst natively supports SVG, PNG, JPG/JPEG, GIF, and PDF image formats for static image includes. For example, you can include a PDF figure directly:
+
+``` markdown
+![My figure](figure.pdf)
+```
+
+### Computation Figure Format
+
+Typst has great support for SVG graphics, so `format: typst` defaults to `fig-format: svg`. This configuration means executable code cells that produce images will produce `.svg` output.
+
+If you prefer to include raster graphics, set `fig-format` to another value, like for example:
 
 ```yaml
 format:
   typst:
     fig-format: png
 ```
+
+Because Typst uses `.svg` as the default extension for extension-less image paths (e.g. `![](elephant)`), this also applies to [Multiformat Figures](/docs/authoring/figures.qmd#multiformat-figures).
 
 See other figure options on the [Typst reference page](/docs/reference/formats/typst.qmd#figures)
 

--- a/docs/output-formats/typst.qmd
+++ b/docs/output-formats/typst.qmd
@@ -444,6 +444,9 @@ Typst natively supports SVG, PNG, JPG/JPEG, GIF, and PDF image formats for stati
 ![My figure](figure.pdf)
 ```
 
+The default extension for extension-less image paths (e.g. `![](elephant)`) is `.svg`.
+To use a different extension, set `default-image-extension` as described in [Multiformat Figures](/docs/authoring/figures.qmd#multiformat-figures).
+
 ### Computation Figure Format
 
 Typst has great support for SVG graphics, so `format: typst` defaults to `fig-format: svg`. This configuration means executable code cells that produce images will produce `.svg` output.
@@ -455,8 +458,6 @@ format:
   typst:
     fig-format: png
 ```
-
-Because Typst uses `.svg` as the default extension for extension-less image paths (e.g. `![](elephant)`), this also applies to [Multiformat Figures](/docs/authoring/figures.qmd#multiformat-figures).
 
 See other figure options on the [Typst reference page](/docs/reference/formats/typst.qmd#figures)
 


### PR DESCRIPTION
The `default-image-extension` option and its per-format defaults were not documented. Users relying on multiformat figures (extension-less image paths) had no reference for what extension each format resolves to, no example of overriding for Typst, and no documented workaround for extensionless URLs such as badge images.

The Typst page similarly lacked any mention of what static image formats are natively supported.

## Changes

- `docs/authoring/figures.qmd`: Multiformat Figures section now includes a per-format default extension table (`.png` for most, `.pdf` for LaTeX/Beamer, `.svg` for Typst), concrete resolution examples per format, an override example including Typst, and the `default-image-extension: ""` workaround for extensionless URLs.
- `docs/output-formats/typst.qmd`: New Image Formats section documenting that Typst natively supports SVG, PNG, JPG/JPEG, GIF, and PDF for static image includes, with a cross-reference to Multiformat Figures for the `.svg` default-image-extension behavior.

Closes quarto-dev/quarto-cli#6092, closes quarto-dev/quarto-cli#8185