### PR TITLE
Add proofread-comments extension to listings

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -596,6 +596,12 @@
   description: >
     A Quarto extension to add preview colour as a coloured symbol next to colour code in HTML, PDF, Typst, Docx, Reveal.js, Beamer, and PowerPoint.
 
+- name: proofread-comments
+  path: https://github.com/zinc75/quarto-proofread-comments
+  author: '[Eric Bavu](https://github.com/zinc75)'
+  description: >
+    This extension adds collaboration-friendly annotations to Quarto documents. You can insert margin notes anywhere, or highlight existing text and attach a note to it.  Comments, todos, notes, or questions. Annotations render as styled margin callouts and flowing in-text marks in HTML, as [`todonotes`](https://ctan.org/pkg/todonotes) margin notes + marker-pen highlights in PDF/LaTeX. They can be toggled globally and coloured per reviewer.
+
 - name: pseudocode
   path: https://github.com/leovan/quarto-pseudocode
   author: '[范叶亮 > Leo Van](https://github.com/leovan)'


### PR DESCRIPTION
Added proofread-comments extension with detailed description.

Repo : https://github.com/zinc75/quarto-proofread-comments 

Documentation and demo : https://zinc75.github.io/quarto-proofread-comments/