### PR TITLE
fix(preview): expand yml tracking and page mappings

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -151,7 +151,7 @@ jobs:
             license.qmd
             docs/**/[^_]*.qmd
             docs/**/[^_]*.md
-            docs/extensions/listings/*.yml
+            docs/**/*.yml
             docs/reference/**/*.json
             docs/cli/*.json
             docs/**/images/*.png
@@ -204,11 +204,26 @@ jobs:
             if (changedFiles.length > 0) {
               // Explicit mapping for files that don't follow standard naming conventions
               const specialFileMapping = {
+                // Extensions listings → extensions index
                 'docs/extensions/listings/shortcodes-and-filters.yml': 'docs/extensions/index.html',
                 'docs/extensions/listings/journal-articles.yml': 'docs/extensions/index.html',
                 'docs/extensions/listings/custom-formats.yml': 'docs/extensions/index.html',
                 'docs/extensions/listings/revealjs-formats.yml': 'docs/extensions/index.html',
                 'docs/extensions/listings/revealjs.yml': 'docs/extensions/index.html',
+                // Gallery data files → gallery index
+                'docs/gallery/carousel.yml': 'docs/gallery/index.html',
+                'docs/gallery/gallery.yml': 'docs/gallery/index.html',
+                // Guide listing → guide index
+                'docs/guide/guide.yml': 'docs/guide/index.html',
+                // Download data → download index
+                'docs/download/_download-older.yml': 'docs/download/index.html',
+                // Reference data files → reference section indexes
+                'docs/reference/reference.yml': 'docs/reference/index.html',
+                'docs/reference/cells/reference.yml': 'docs/reference/cells/index.html',
+                'docs/reference/formats/reference.yml': 'docs/reference/formats/index.html',
+                'docs/reference/metadata/reference.yml': 'docs/reference/metadata/index.html',
+                'docs/reference/projects/reference.yml': 'docs/reference/projects/index.html',
+                // CLI data → reference index
                 'docs/cli/cli-info.json': 'docs/reference/index.html',
               };
 


### PR DESCRIPTION
PR #2061 changed `docs/gallery/gallery.yml` but generated no preview link — that file wasn't tracked by the changed-files step and had no `specialFileMapping` entry.

Broadens the tracked yml pattern from `docs/extensions/listings/*.yml` to `docs/**/*.yml`, then adds `specialFileMapping` entries for all known data-driving yml files across gallery, guide, download, and reference sections. Unmapped yml files are silently skipped by the comment-generation logic, so the broad pattern carries no false-positive risk.