### PR TITLE
Add scientific-writing extension to listings

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -678,6 +678,16 @@
   description: >
     Publish blog posts or web pages on a schedule.
 
+- name: scientific-writing
+  path: https://github.com/lsbjordao/quarto-scientific-writing
+  author: '[Lucas S.B. Jordão](https://github.com/lsbjordao)'
+  description: >
+    Turn a rendered HTML manuscript into an in-browser writing reviewer:
+    linguistic diagnostics (long sentences, passive voice, hedging,
+    nominalizations, connectors), NLP-based analysis, readability scores, a 70+
+    metric panel, and scholarly-structure audits of citations, DOIs, figure/table
+    cross-references, and numeric evidence (parameterized vs. hard-coded values).
+
 - name: search-replace
   path: https://github.com/ute/search-replace
   author: '[Ute Hahn](https://github.com/ute/)'


### PR DESCRIPTION
Adds the [`scientific-writing`](https://github.com/lsbjordao/quarto-scientific-writing) extension to the shortcodes-and-filters listing.

The extension turns a rendered HTML manuscript into an in-browser writing reviewer: linguistic diagnostics (long sentences, passive voice, hedging, nominalizations, connectors), NLP-based analysis, readability scores, a 70+ metric panel, and scholarly-structure audits of citations, DOIs, figure/table cross-references, and numeric evidence (parameterized vs. hard-coded values).

The entry is placed in alphabetical order between `scheduled-docs` and `search-replace`.