### PR TITLE
Add passage-xref extension

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -595,6 +595,13 @@
   description: A shortcode to include partial content templates using the mustache
     templating syntax.
 
+- name: passage-xref
+  path: https://github.com/jiangyun-fun/quarto-passage-xref
+  author: '[Yun Jiang](https://github.com/jiangyun-fun)'
+  description: Cross-reference arbitrary inline text passages with automatic
+    numbering, clickable links, and hover previews, complementing Quarto's
+    native cross-reference system.
+
 - name: preview-colour
   path: https://github.com/mcanouil/quarto-preview-colour
   author: '[Mickaël CANOUIL](https://github.com/mcanouil)'


### PR DESCRIPTION
This adds the **passage-xref** extension to the `shortcodes-and-filters` listing.

## About

`passage-xref` is a Lua filter that adds cross-references for **arbitrary inline text passages** — something Quarto's native cross-reference system doesn't support.

Features:
- Auto-numbered inline passage targets: `[text]{.passage #pas-xxx}`
- Clickable numbered references: `[Passage]{.pref pas="pas-xxx"}`
- Custom prefix / no-prefix options
- HTML hover previews (reuses Quarto's built-in tippy.js)
- Forward references (collect + resolve passes)
- Tolerant of bracket text and attributes split across lines

## Listing requirements

- ✅ Hosted on GitHub: https://github.com/jiangyun-fun/quarto-passage-xref
- ✅ `README.md` with installation instructions and usage examples
- ✅ Open-source license: MIT (`LICENSE`)
- ✅ Installs cleanly via `quarto add jiangyun-fun/quarto-passage-xref`

## Live preview

https://jiangyun-fun.github.io/quarto-passage-xref/

The entry is inserted alphabetically between `partials` and `preview-colour`.