### PR TITLE
Add gbt9704 to custom formats listing

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -58,6 +58,13 @@
   description: >
     A PDF format that brings LaTeX's `fancyhdr` package into Quarto for miscellaneous documents.
 
+- name: gbt9704
+  path: https://github.com/songwupei/quarto-gbt9704
+  author: '[songwupei](https://github.com/songwupei)'
+  description: >
+    GB/T 9704 Chinese government document format (党政机关公文格式)
+    with support for PDF (XeLaTeX), DOCX, and ConTeXt output.
+
 - name: hikmah-pdf
   path: https://github.com/andrewheiss/hikmah-academic-quarto
   author: '[andrewheiss](https://github.com/andrewheiss)'


### PR DESCRIPTION
GB/T 9704 Chinese government document format extension.