### PR TITLE
fix(filters): fix include-dark with meta-resolved image paths

### DIFF
--- a/filters/include-dark.lua
+++ b/filters/include-dark.lua
@@ -3,7 +3,7 @@ local function dark_path(src)
   return path[1] .. "-dark" .. path[2]
 end
 
-local function new_image(img, src, class) 
+local function new_image(img, src, class)
   local new_classes = pandoc.List.filter(img.classes, function(c)
     return c ~= "include-dark"
   end)
@@ -15,10 +15,14 @@ end
 
 function Image(img)
   if img.classes:includes("include-dark") then
-    local dark_img = new_image(img, dark_path(img.src), "dark-content")
-    local light_img = new_image(img, img.src, "light-content")
+    local stem, ext = pandoc.path.split_extension(img.src)
+    local _, inner_ext = pandoc.path.split_extension(stem)
+    -- Quarto adds a spurious extension when src is resolved via {{< meta >}};
+    -- strip it when the same extension appears twice (e.g. foo.png.png).
+    local src = (inner_ext == ext) and stem or img.src
+    local dark_img = new_image(img, dark_path(src), "dark-content")
+    local light_img = new_image(img, src, "light-content")
     return {dark_img, light_img}
   end
   return img
 end
-


### PR DESCRIPTION
The Positron screenshot was broken on the Python, R, and Julia computations pages and images showed as missing.

The root cause is in how Quarto encodes shortcodes before handing the document to Pandoc. See quarto-dev/quarto-cli#14583 for details.

The filter now checks for the double-extension case (same extension appearing twice) and strips the outer spurious one before building the dark and light image paths. This makes the filter robust for any `{{< meta >}}` + `.include-dark` combination until the root cause is fixed upstream in the qmd reader. This is more a workaround than an actual fix, but it at least fix the issue in the documentation with minimal change.

Closes quarto-dev/quarto-cli#14583