### PR TITLE
docs(authoring): document backslash math delimiters

### DIFF
--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -387,7 +387,27 @@ $$
 :::
 ```
 
-For HTML math processed using [MathJax](https://docs.mathjax.org/) (the default) you can use the `\def`, `\newcommand`, `\renewcommand`, `\newenvironment`, `\renewenvironment`, and `\let` commands to create your own macros and environments.  
+For HTML math processed using [MathJax](https://docs.mathjax.org/) (the default) you can use the `\def`, `\newcommand`, `\renewcommand`, `\newenvironment`, `\renewenvironment`, and `\let` commands to create your own macros and environments.
+
+You can also use LaTeX-style `\(...\)` delimiters for inline math and `\[...\]` for display math by enabling the `tex_math_single_backslash` Pandoc extension via the `from` option:
+
+``` yaml
+from: markdown+tex_math_single_backslash
+```
+
++-------------------------------+-------------------------+
+| Markdown Syntax               | Output                  |
++===============================+=========================+
+| ``` markdown                  |                         |
+| inline math: \(E = mc^{2}\)  | inline math: $E=mc^{2}$ |
+| ```                           |                         |
++-------------------------------+-------------------------+
+| ``` markdown                  |                         |
+| display math:                 | display math:           |
+|                               |                         |
+| \[E = mc^{2}\]                | $$E = mc^{2}$$          |
+| ```                           |                         |
++-------------------------------+-------------------------+
 
 ## Diagrams
 


### PR DESCRIPTION
Add a note to the Equations section of the Markdown Basics page documenting that `\(...\)` and `\[...\]` math delimiters are supported via Pandoc's `tex_math_single_backslash` extension.

Closes quarto-dev/quarto-cli#12263