### PR TITLE
docs(authoring): document hard line breaks

### DIFF
--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -39,6 +39,17 @@ This document provides examples of the most commonly used markdown syntax. See t
 | ```                                     |                                         |
 +-----------------------------------------+-----------------------------------------+
 
+## Line Breaks
+
+A newline within a paragraph produces a _soft break_, so the lines flow together in the rendered output. To force a _hard line break_ that starts a new line within the same paragraph, end the line with a backslash:
+
+``` markdown
+Roses are red,\
+Violets are blue.
+```
+
+Alternatively, end the line with two or more spaces to produce the same result. Because those trailing spaces are invisible in the source, the backslash is usually clearer.
+
 ## Headings {#headings}
 
 +------------------+-----------------------------------+

--- a/docs/authoring/markdown-basics.qmd
+++ b/docs/authoring/markdown-basics.qmd
@@ -48,8 +48,6 @@ Roses are red,\
 Violets are blue.
 ```
 
-Alternatively, end the line with two or more spaces to produce the same result. Because those trailing spaces are invisible in the source, the backslash is usually clearer.
-
 ## Headings {#headings}
 
 +------------------+-----------------------------------+


### PR DESCRIPTION
The Markdown Basics guide does not document how to create a hard line break, requested in quarto-dev/quarto-cli#8984.

This adds a **Line Breaks** section to `docs/authoring/markdown-basics.qmd`, after Text Formatting, explaining the difference between a soft break and a hard break and how to force a hard break by ending a line with a backslash.

The two-trailing-spaces form is intentionally left out, as it will not be supported in Quarto 2 (see quarto-dev/quarto-cli#8984).

Closes quarto-dev/quarto-cli#8984