### PR TITLE
Accessibility fixes: nav link label, code-block contrast, footer link name

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -31,7 +31,7 @@ website:
   page-footer:
     left: |
       Proudly supported by
-      [![](/images/Posit-Logos-2024_horiz-full-color.svg){fig-alt="Posit" width=65px .light-content}](https://posit.co) [![](/images/Posit-Logos-2024_horiz-full-color-white-text.svg){fig-alt="Posit" width=65px .dark-content}](https://posit.co)
+      [![](/images/Posit-Logos-2024_horiz-full-color.svg){fig-alt="Posit" width=65px .light-content}![](/images/Posit-Logos-2024_horiz-full-color-white-text.svg){fig-alt="Posit" width=65px .dark-content}](https://posit.co)
     center:
       - text: "About"
         href: about.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -73,6 +73,7 @@ website:
       - text: "Blog"
         icon: box-arrow-up-right
         href: https://opensource.posit.co/blog/q/quarto/
+        aria-label: "external link"
       - text: "Help"
         menu:
           - text: "Report a Bug"

--- a/theme.scss
+++ b/theme.scss
@@ -2,6 +2,12 @@
 $link-color: #39729E;
 $text-muted: #6a737b;
 
+// Code-block background: the darkest tint of the site's cosmo blue-gray that
+// still keeps every a11y-light syntax color at WCAG AA (>=4.5:1). a11y-light's
+// palette is tuned for a near-white background, so this stays pale; one step
+// darker (#eef1f4) drops the worst token (red #d91e18) below 4.5:1.
+$code-block-bg: #eff2f5;
+
 /*-- scss:rules --*/
 
 .layout-example {


### PR DESCRIPTION
Three independent accessibility fixes surfaced by an axe-core audit of the rendered site.

## 1. Add `aria-label` to the external-link icon on the nav "Blog" link (`498cad3`)

The Blog navbar entry links out to the Posit blog with an external-link icon; the icon had no accessible text. Adds an `aria-label` so assistive tech announces it.

## 2. Light-mode code-block background for contrast (`af1b20c`)

The site uses `a11y` syntax highlighting, whose token colors are tuned for the theme's *own* near-white background. Quarto's default code-block background is a semi-transparent gray that, over shaded sections, composited down to `#eceef1` and dropped the orange attribute token (`#a55a00`) to **4.44:1** — below WCAG AA (4.5:1).

Fix pins `$code-block-bg` to `#eff2f5` — the darkest tint of the site's cosmo blue-gray that keeps *every* a11y-light token ≥ 4.5:1 (the binding constraint is the red keyword `#d91e18`). Because WCAG contrast depends on luminance only, this stays pale regardless of hue. Dark mode was checked and already passes comfortably (7–13:1), so it's untouched.

## 3. Fix empty footer link (`53b2924`) — `link-name`, serious

The footer had two separate links to `posit.co`, one per theme (light/dark logo). Because the off-theme logo is `display:none`, its `alt` didn't count toward the link's accessible name, leaving an empty focusable link in the tab order (fires in dark mode; would fire in light for the other link). Merged into a single link wrapping both logos, so exactly one visible, alt-bearing image names the link in either theme. Verified the accessible name resolves to "Posit" in dark mode.

## Screenshots — light-mode code block (fix #2)

| Before | After |
|--------|-------|
|  <img width="610" height="496" alt="markdown-basics-codeblock-before" src="https://github.com/user-attachments/assets/fcc8c30e-d418-45d5-a05e-56c392335b86" /> |  <img width="610" height="496" alt="markdown-basics-codeblock-after" src="https://github.com/user-attachments/assets/56433244-2aaa-432b-a0f7-2d7a74222ea4" /> |
