### PR TITLE
Fix WCAG AA color contrast: muted text and appendix links (light theme)

### DIFF
--- a/theme.scss
+++ b/theme.scss
@@ -22,8 +22,8 @@ $code-block-bg: #eff2f5;
 // AA 1.4.3 failure (axe color-contrast-733538). Undo the fade; selectors
 // mirror Quarto's so this wins by cascade order in the light theme, while
 // the dark stylesheet (loaded after this one) re-asserts Quarto's .9 —
-// the dark link color passes even faded. Remove once quarto-cli dims
-// appendix content via color rather than opacity.
+// the dark link color passes even faded. Remove if quarto-cli fixes
+// this upstream.
 #quarto-appendix.default section {
   *[role="doc-endnotes"],
   > *:not(a) {

--- a/theme.scss
+++ b/theme.scss
@@ -17,15 +17,18 @@ $code-block-bg: #eff2f5;
 
 /*-- scss:rules --*/
 
-// Quarto renders appendix content (footnotes, citation, reuse) at opacity .9,
+// Quarto dims appendix content (footnotes, citation, reuse) to opacity .9,
 // which fades $link-color to an effective #4d80a8 = 4.22:1 on white — a WCAG
-// AA 1.4.3 failure (axe color-contrast-733538). A darker link keeps the
-// blended color at ~5.2:1. Overriding the Bootstrap var rather than `color`
-// preserves the a:hover color swap. Scoped to body.quarto-light because in
-// dark mode this (light) stylesheet stays enabled underneath the dark one,
-// and an unscoped custom property would leak through.
-body.quarto-light #quarto-appendix.default section {
-  --bs-link-color-rgb: 47, 96, 138; // #2f608a; shows as #447096 after the fade
+// AA 1.4.3 failure (axe color-contrast-733538). Undo the fade; selectors
+// mirror Quarto's so this wins by cascade order in the light theme, while
+// the dark stylesheet (loaded after this one) re-asserts Quarto's .9 —
+// the dark link color passes even faded. Remove once quarto-cli dims
+// appendix content via color rather than opacity.
+#quarto-appendix.default section {
+  *[role="doc-endnotes"],
+  > *:not(a) {
+    opacity: 1;
+  }
 }
 
 .layout-example {

--- a/theme.scss
+++ b/theme.scss
@@ -2,6 +2,13 @@
 $link-color: #39729E;
 $text-muted: #6a737b;
 
+// Quarto's body-secondary mixin (blockquotes, captions, asides, header
+// section numbers) defaults to theme-dim($body-color, 25%) = #6d7a86, only
+// 4.39:1 on white — a WCAG AA 1.4.3 failure (axe color-contrast-7ed054).
+// Defining $body-secondary makes the mixin use it instead; $text-muted is
+// 4.83:1.
+$body-secondary: $text-muted;
+
 // Code-block background: the darkest tint of the site's cosmo blue-gray that
 // still keeps every a11y-light syntax color at WCAG AA (>=4.5:1). a11y-light's
 // palette is tuned for a near-white background, so this stays pale; one step
@@ -9,6 +16,17 @@ $text-muted: #6a737b;
 $code-block-bg: #eff2f5;
 
 /*-- scss:rules --*/
+
+// Quarto renders appendix content (footnotes, citation, reuse) at opacity .9,
+// which fades $link-color to an effective #4d80a8 = 4.22:1 on white — a WCAG
+// AA 1.4.3 failure (axe color-contrast-733538). A darker link keeps the
+// blended color at ~5.2:1. Overriding the Bootstrap var rather than `color`
+// preserves the a:hover color swap. Scoped to body.quarto-light because in
+// dark mode this (light) stylesheet stays enabled underneath the dark one,
+// and an unscoped custom property would leak through.
+body.quarto-light #quarto-appendix.default section {
+  --bs-link-color-rgb: 47, 96, 138; // #2f608a; shows as #447096 after the fade
+}
 
 .layout-example {
   background: $gray-500;


### PR DESCRIPTION
Fixes two WCAG conformance failures from the axe-core site audit (follow-up to #2095 / #2097). Both are `color-contrast` (WCAG 2.0 AA 1.4.3, impact: serious), light theme only.

## The findings

Both on <https://quarto.org/docs/authoring/markdown-basics.html>

| finding | element(s) | rendered | ratio | needs |
|---|---|---|---|---|
| `color-contrast-7ed054` | blockquote text, `figcaption` (also captions, asides, header section numbers) | `#6d7a86` on white | 4.39:1 | 4.5:1 |
| `color-contrast-733538` | footnote back-links (`a.footnote-back`) | `#4d80a8` on white | 4.22:1 | 4.5:1 |

## Root causes and fixes

**Muted text.** Quarto's `body-secondary` mixin colors these elements `theme-dim($body-color, 25%)` = `#6d7a86` — but honors a `$body-secondary` SCSS variable when defined. Setting `$body-secondary: $text-muted` (`#6a737b`, 4.83:1) fixes every element the mixin touches with one variable in `scss:defaults`.

**Footnote back-links.** Quarto renders appendix content at `opacity: .9`, fading `$link-color` `#39729E` (5.15:1) to an effective 4.22:1. The fix undoes the fade: a rule mirroring Quarto's appendix selector sets `opacity: 1`, restoring full contrast for all appendix links and text with no hardcoded colors. Dark mode is unaffected — the dark stylesheet loads after this one and re-asserts Quarto's `.9` by cascade (the dark link color passes even faded); and since raising opacity can only increase contrast, the override is risk-free even if the cascade ever changes. The visual cost is losing the 10% fade on light-mode appendix content, which is near-imperceptible.

Both root causes are Quarto CLI defaults; upstream issues to follow. Once fixed there, this override can be removed.

## Verification

Rendered `docs/authoring/markdown-basics.qmd` and scanned with the axe harness (from `feat/axe-a11y-harness`) across both viewports and both light/dark themes: both findings gone, no new findings — every remaining finding on the page matches the prior audit baseline.

Also manually checked deploy preview.

`theme.scss` is not frozen content, so no `_freeze/` updates are needed.