### PR TITLE
Add axe-core to dependency lists

### DIFF
--- a/docs/faq/index.qmd
+++ b/docs/faq/index.qmd
@@ -70,6 +70,8 @@ Quarto's dependencies include:
 - [esbuild](https://esbuild.github.io/)
 - [Dart Sass](https://sass-lang.com/dart-sass/)
 
+See the [open source license page](/license.qmd#dependencies) for a fuller list of bundled components and their licenses.
+
 ## Licensing
 
 ### Is Quarto free to use?

--- a/license.qmd
+++ b/license.qmd
@@ -27,6 +27,7 @@ Quarto also makes use of several other open-source projects, the distribution of
 | [Observable Runtime](https://github.com/observablehq/runtime) | [ISC](https://github.com/observablehq/runtime/blob/main/LICENSE)         |
 | [Typst](https://typst.app/docs/)                              | [Apache License 2.0](https://github.com/typst/typst/blob/main/LICENSE)   |
 | [Juice](https://github.com/Automattic/juice)                  | [MIT](https://github.com/Automattic/juice/blob/master/LICENSE.md)        |
+| [axe-core](https://github.com/dequelabs/axe-core)             | [MPL 2.0](https://github.com/dequelabs/axe-core/blob/develop/LICENSE)    |
 
 
 ## Trademark


### PR DESCRIPTION
Documentation companion to quarto-dev/quarto-cli#14677, which vendors axe-core (MPL-2.0) as a bundled resource instead of loading it from the Skypack CDN.

- `license.qmd`: add axe-core to the dependencies table (MPL 2.0, linked to the project's LICENSE file, matching the style of the other rows).
- `docs/faq/index.qmd`: the "What are Quarto's dependencies?" list now points to the license page's table for the fuller inventory of bundled components, rather than growing its own copy.

Should land with (or after) quarto-dev/quarto-cli#14677.
