### PR TITLE
Add touying-typst to the custom formats extension listing

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -148,6 +148,12 @@
   author: '[nmfs-opensci](https://github.com/nmfs-opensc)'
   description: PDF format with custom title page or book cover.
 
+- name: touying-typst
+  path: https://github.com/kazuyanagimoto/quarto-touying-typst
+  author: '[Kazuharu Yanagimoto](https://github.com/kazuyanagimoto)'
+  description: >
+    Quarto extension for building slides with Touying, the Beamer-like presentation framework for Typst
+
 - name: Tufte-Inspired
   path: https://github.com/fredguth/tufte-inspired
   author: '[Fred Guth](https://github.com/fredguth/)'


### PR DESCRIPTION
This PR adds [touying-typst](https://github.com/kazuyanagimoto/quarto-touying-typst) to the custom formats listing.

It is a Quarto extension for building slides with [Touying](https://touying-typ.github.io), the Beamer-like presentation framework for Typst. It maps Quarto's slide syntax onto Touying and supports all built-in Touying themes as well as custom/external ones (e.g. via Typst Universe packages). Docs: [tutorial and gallery](https://kazuyanagimoto.com/quarto-touying-typst/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)