### PR TITLE
Add livefigures to shortcodes-and-filters listing

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -508,6 +508,15 @@
   description: >
     Check for broken external links in your Quarto documents during rendering.
 
+- name: livefigures
+  path: https://github.com/seandavi/quarto-livefigures
+  author: '[Sean Davis](https://github.com/seandavi)'
+  description: >
+    Render editable, version-controlled figure sources (Excalidraw, Vega-Lite,
+    Graphviz, PlantUML, WaveDrom, D2, and more — 18 formats) at build time,
+    as file references or fenced blocks, with caching and native figure
+    semantics. Formats chosen so AI agents can author and revise figures as
+    plain text.
 - name: lordicon
   path: https://github.com/jmgirard/lordicon
   author: '[Jeffrey Girard](https://github.com/jmgirard)'

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -517,6 +517,7 @@
     as file references or fenced blocks, with caching and native figure
     semantics. Formats chosen so AI agents can author and revise figures as
     plain text.
+
 - name: lordicon
   path: https://github.com/jmgirard/lordicon
   author: '[Jeffrey Girard](https://github.com/jmgirard)'


### PR DESCRIPTION
Adds [quarto-livefigures](https://github.com/seandavi/quarto-livefigures) to the extensions listing.

livefigures renders editable, version-controlled figure sources — Excalidraw scenes, Vega-Lite specs, Graphviz, PlantUML, WaveDrom, D2, and more (18 formats) — during `quarto render`, via normal image syntax (`![](figures/arch.excalidraw)`) or fenced blocks, with content-addressed caching and native figure semantics (captions, crossrefs, lightbox). Complements Quarto's built-in Mermaid/dot code cells with file-referenced sources and editable-tool formats.

Listing requirements: GitHub-hosted ✓; README with installation, syntax, and examples ✓; MIT license ✓. Docs & live gallery: <https://livefigures.seandavis.net> · tagged releases through v0.7.1. Entry inserted alphabetically (between linkrot and lordicon).