### PR TITLE
Adding shifu-academic-quarto

### DIFF
--- a/docs/extensions/listings/custom-formats.yml
+++ b/docs/extensions/listings/custom-formats.yml
@@ -44,7 +44,7 @@
   author: '[Eric Bavu](https://github.com/zinc75)'
   description: >
     Quarto template / set of extensions for Cnam (Conservatoire national des arts et métiers) doctoral theses.
-    PDF/A-1b + navigable HTML - Produces a PDF that conforms to the official Cnam 2024–2025 template 
+    PDF/A-1b + navigable HTML - Produces a PDF that conforms to the official Cnam 2024–2025 template
     and a navigable HTML version for online sharing and accessibility.
 
 - name: diaquarto
@@ -124,6 +124,12 @@
   author: '[Matti Vuorre](https://github.com/mvuorre)'
   description: >
     A clean & opinionated Typst (PDF) format with improved support for Typst functionality beyond Quarto's standard template.
+
+- name: shifu-academic-quarto
+  path: https://github.com/C-Monaghan/shifu-academic-quarto
+  author: '[Cormac Monaghan](https://github.com/C-Monaghan)'
+  description: >
+    An opinionated Typst (PDF) academic manuscript template.
 
 - name: sketchy-html
   path: https://github.com/schochastics/quarto-sketchy-html


### PR DESCRIPTION
This PR adds [shifu-academic-quarto](https://github.com/C-Monaghan/shifu-academic-quarto) to the custom formats listing.

It is a Quarto extension for a Typst based academic manuscript template with inspiration taken from both the works of [Andrew Heiss](https://www.andrewheiss.com/) and [Christopher Kenny](https://github.com/christopherkenny).