### PR TITLE
Skip prerelease backport for PRs labeled no-sync-prerelease

### DIFF
--- a/.github/workflows/port-to-prerelease.yml
+++ b/.github/workflows/port-to-prerelease.yml
@@ -14,12 +14,15 @@ jobs:
   sync-to-prerelease:
     name: Backport pull request
     runs-on: ubuntu-latest
-    # Don't run on closed unmerged pull requests and only PRs to main
-    # or on comment made by Github Action Bot
+    # Don't run on closed unmerged pull requests and only PRs to main,
+    # skipping PRs labeled 'no-sync-prerelease' (e.g. release merges that
+    # would otherwise try to cherry-pick the whole prerelease history back).
+    # Also runs on a '/sync-prerelease' comment, ignoring the Github Action Bot.
     if: > 
       (
         github.event.pull_request.merged && 
-        github.event.pull_request.base.ref == 'main'
+        github.event.pull_request.base.ref == 'main' &&
+        !contains(github.event.pull_request.labels.*.name, 'no-sync-prerelease')
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&


### PR DESCRIPTION
When a release merge (prerelease into main) lands, the port-to-prerelease job tries to cherry-pick the entire prerelease history back onto prerelease and fails with a "backport failed" comment — as happened on #2122.

The job runs on every merged PR to `main` (`label_pattern: ''`, unconditional; `merge_commits: skip` only skips merge commits within the cherry-pick set, not the whole run). This adds a guard so a labeled PR opts out:

```yaml
!contains(github.event.pull_request.labels.*.name, 'no-sync-prerelease')
```

Label a release merge (or any PR you deliberately don't want synced) with `no-sync-prerelease` and the job is skipped. The label has been created in the repo.

## Test Plan

- [ ] Merge a normal `main` PR with no label — sync-to-prerelease PR is created as before
- [ ] Merge a `main` PR labeled `no-sync-prerelease` — backport job is skipped, no PR or failure comment
