### PR TITLE
Add release-merge skill; keep the workflow rule lean

### DIFF
--- a/.claude/rules/quarto-web-workflow.md
+++ b/.claude/rules/quarto-web-workflow.md
@@ -8,7 +8,7 @@
 
 Always PR to `main` first for shared content. Never PR directly to `prerelease` for changes that apply to both stable and prerelease.
 
-Release-time `prerelease` → `main` merge: use the `release-merge` skill.
+Release-time `prerelease` → `main` merge: use the `/release-merge` skill.
 
 ## `_freeze/` Updates
 

--- a/.claude/rules/quarto-web-workflow.md
+++ b/.claude/rules/quarto-web-workflow.md
@@ -16,7 +16,21 @@ Any source change to a `.qmd` that has a `_freeze/` entry — even non-executabl
 
 **Before committing:** `git diff HEAD -- _freeze/` — every edited frozen `.qmd` must have a corresponding `_freeze/` change. (Use `HEAD` to show both staged and unstaged changes.)
 
-**If the freeze-check hook blocks a commit or push:** run `quarto render <file.qmd>` then commit the updated `_freeze/` output alongside the source change.
+**If the freeze-check hook blocks a commit or push:** first check the page's engine with `quarto inspect <file.qmd>`.
+
+- **Computational engine (`knitr`/`jupyter`/`julia`):** the page has a real freeze. Because the site is `freeze: true`, a plain `quarto render <file.qmd>` only *thaws* the existing freeze — it does not rewrite it. Re-execute to regenerate the freeze (render with execution forced), then commit the updated `_freeze/` output alongside the source change.
+- **Markdown engine (mermaid/`dot` diagrams, no `r`/`python`/`julia` cells):** the page produces no computational output, so an `execute-results/html.json` under `_freeze/` for it is **vestigial** — delete it rather than regenerate it. The check-freeze hook's `git show HEAD:` fallback currently re-flags an intentional freeze deletion, so clearing it needs the hook fix or a confirmed `--no-verify`.
+
+## Release: merging `prerelease` → `main`
+
+At release time the `prerelease` branch is merged into `main` to publish the new stable docs. The full release steps live in quarto-cli `dev-docs/checklist-make-a-new-quarto-release.md`; this covers the quarto-web mechanics.
+
+Two ways to do the merge:
+
+- **Direct merge + push to `main`** (the checklist default). A direct push does not trigger `port-to-prerelease.yml`, so no backport PR is created.
+- **Via a PR to `main`** — lets CI (`build-deploy-preview`) verify the site builds before it lands. Label the PR `no-sync-prerelease` so the backport action does not try to cherry-pick the whole prerelease history back onto `prerelease` (it would fail with a noisy comment). Merge with a **merge commit, not squash**, to preserve the topology so the branches don't re-diverge.
+
+Resolve conflicts to the **prerelease / new-stable** content, except where `main` is a strict superset (e.g. a direct-push edit the prerelease copy never received). Expect version-string and `quarto check` sample-output conflicts (resolve to the new version) and possible freeze conflicts (see `_freeze/` above). After merging, sync `main` back into `prerelease` per the checklist.
 
 ## Avoid duplicating doc content
 

--- a/.claude/rules/quarto-web-workflow.md
+++ b/.claude/rules/quarto-web-workflow.md
@@ -18,7 +18,7 @@ Any source change to a `.qmd` that has a `_freeze/` entry — even non-executabl
 
 **Before committing:** `git diff HEAD -- _freeze/` — every edited frozen `.qmd` must have a corresponding `_freeze/` change. (Use `HEAD` to show both staged and unstaged changes.)
 
-**If the freeze-check hook blocks a commit or push:** first check the page's engine with `quarto inspect <file.qmd>`.
+**If the freeze-check hook blocks a commit or push:** first check whether the page even executes code — `quarto inspect <file.qmd>` reports an `engines` array. `markdown` there means no code runs (so the page should carry no computational freeze); `knitr`/`jupyter`/`julia` mean it does.
 
 - **Computational engine (`knitr`/`jupyter`/`julia`):** the page has a real freeze. Because the site is `freeze: true`, a plain `quarto render <file.qmd>` only *thaws* the existing freeze — it does not rewrite it. Re-execute to regenerate the freeze (render with execution forced), then commit the updated `_freeze/` output alongside the source change.
 - **Markdown engine (mermaid/`dot` diagrams, no `r`/`python`/`julia` cells):** the page produces no computational output, so an `execute-results/html.json` under `_freeze/` for it is **vestigial** — delete it rather than regenerate it. The check-freeze hook's `git show HEAD:` fallback currently re-flags an intentional freeze deletion, so clearing it needs the hook fix or a confirmed `--no-verify`.

--- a/.claude/rules/quarto-web-workflow.md
+++ b/.claude/rules/quarto-web-workflow.md
@@ -8,6 +8,8 @@
 
 Always PR to `main` first for shared content. Never PR directly to `prerelease` for changes that apply to both stable and prerelease.
 
+Release-time `prerelease` → `main` merge: use the `release-merge` skill.
+
 ## `_freeze/` Updates
 
 Any source change to a `.qmd` that has a `_freeze/` entry — even non-executable content like text or includes — invalidates the freeze hash. A stale hash causes the deploy preview to show the old cached page.
@@ -20,17 +22,6 @@ Any source change to a `.qmd` that has a `_freeze/` entry — even non-executabl
 
 - **Computational engine (`knitr`/`jupyter`/`julia`):** the page has a real freeze. Because the site is `freeze: true`, a plain `quarto render <file.qmd>` only *thaws* the existing freeze — it does not rewrite it. Re-execute to regenerate the freeze (render with execution forced), then commit the updated `_freeze/` output alongside the source change.
 - **Markdown engine (mermaid/`dot` diagrams, no `r`/`python`/`julia` cells):** the page produces no computational output, so an `execute-results/html.json` under `_freeze/` for it is **vestigial** — delete it rather than regenerate it. The check-freeze hook's `git show HEAD:` fallback currently re-flags an intentional freeze deletion, so clearing it needs the hook fix or a confirmed `--no-verify`.
-
-## Release: merging `prerelease` → `main`
-
-At release time the `prerelease` branch is merged into `main` to publish the new stable docs. The full release steps live in quarto-cli `dev-docs/checklist-make-a-new-quarto-release.md`; this covers the quarto-web mechanics.
-
-Two ways to do the merge:
-
-- **Direct merge + push to `main`** (the checklist default). A direct push does not trigger `port-to-prerelease.yml`, so no backport PR is created.
-- **Via a PR to `main`** — lets CI (`build-deploy-preview`) verify the site builds before it lands. Label the PR `no-sync-prerelease` so the backport action does not try to cherry-pick the whole prerelease history back onto `prerelease` (it would fail with a noisy comment). Merge with a **merge commit, not squash**, to preserve the topology so the branches don't re-diverge.
-
-Resolve conflicts to the **prerelease / new-stable** content, except where `main` is a strict superset (e.g. a direct-push edit the prerelease copy never received). Expect version-string and `quarto check` sample-output conflicts (resolve to the new version) and possible freeze conflicts (see `_freeze/` above). After merging, sync `main` back into `prerelease` per the checklist.
 
 ## Avoid duplicating doc content
 

--- a/.claude/skills/release-merge/SKILL.md
+++ b/.claude/skills/release-merge/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: release-merge
+description: Use when merging the quarto-web prerelease branch into main for a Quarto release (publishing new stable docs), or when a release-time merge hits conflicts, backport-action noise, or _freeze hook failures. Not for ordinary PRs to main.
+---
+
+# Release merge (prerelease → main)
+
+## Overview
+
+At release time the `prerelease` branch is merged into `main` to publish the new stable docs. Rare operation, with a few quarto-web-specific hazards worth knowing before you start.
+
+## When to use
+
+- Doing a Quarto release — bringing new-stable docs onto `main`.
+- A release merge hit conflicts, backport-action noise, or a `_freeze` hook block.
+
+Not for ordinary content PRs — those follow the normal Stable → Prerelease flow (see `.claude/rules/quarto-web-workflow.md`).
+
+## Canonical checklist
+
+The authoritative release steps live in quarto-cli `dev-docs/checklist-make-a-new-quarto-release.md`. This skill covers only the quarto-web merge mechanics.
+
+## Steps
+
+1. Choose the merge path — direct push, or a PR to `main` for CI build verification.
+2. Resolve conflicts to the new-stable content.
+3. Handle `_freeze` conflicts.
+4. Regenerate `cli-info.json` against the stable tag.
+5. Sync `main` back into `prerelease`.
+
+## Details
+
+**REQUIRED:** read `references/release-merge.md` before executing — it carries the label, merge-commit, conflict, and freeze specifics.

--- a/.claude/skills/release-merge/references/release-merge.md
+++ b/.claude/skills/release-merge/references/release-merge.md
@@ -17,7 +17,7 @@ Resolve to the **prerelease / new-stable** content, except where `main` is a str
 
 ## Freeze on a release merge
 
-A release merge can surface `_freeze/` conflicts. Resolve them per the `_freeze/` section of `.claude/rules/quarto-web-workflow.md` (always loaded) — most often it's a markdown-engine page carrying a vestigial freeze entry to delete.
+A release merge can surface `_freeze/` conflicts. Resolve them per the `_freeze/` section of `.claude/rules/quarto-web-workflow.md` — most often it's a markdown-engine page carrying a vestigial freeze entry to delete.
 
 ## After merging
 

--- a/.claude/skills/release-merge/references/release-merge.md
+++ b/.claude/skills/release-merge/references/release-merge.md
@@ -1,0 +1,26 @@
+# Release merge — details
+
+## Merge paths
+
+Two ways to merge `prerelease` into `main`:
+
+- **Direct push to `main`** (the quarto-cli checklist default). A direct push does not trigger `port-to-prerelease.yml`, so no backport PR is created.
+- **PR to `main`** — lets CI (`build-deploy-preview`) verify the site builds before it lands. Label the PR `no-sync-prerelease` so the backport action does not try to cherry-pick the whole prerelease history back onto `prerelease` (it fails with a noisy comment otherwise). Merge with a **merge commit, not squash**, to preserve the merge topology so the branches don't re-diverge.
+
+## Resolving conflicts
+
+Resolve to the **prerelease / new-stable** content, except where `main` is a strict superset (e.g. a direct-push edit that `prerelease` never received). Expect version-string and `quarto check` sample-output conflicts — take the new version.
+
+## cli-info.json
+
+`docs/cli/cli-info.json` is generated, not hand-edited. Regenerate it against the stable release tag after the merge; otherwise it ships the development/prerelease version content.
+
+## Freeze on a release merge
+
+The site is `freeze: true`, so `quarto render <file>` only *thaws* the existing freeze — it does not rewrite it.
+
+Markdown-engine pages (mermaid/`dot` diagrams, no `r`/`python`/`julia` cells — confirm with `quarto inspect <file>`) produce no computational output, so an `execute-results/html.json` under `_freeze/` for such a page is vestigial: delete it rather than regenerate it. The check-freeze hook's `git show HEAD:` fallback currently re-flags an intentional freeze deletion, so clearing it needs the hook fix or a confirmed `--no-verify`.
+
+## After merging
+
+Sync `main` back into `prerelease` per the checklist.

--- a/.claude/skills/release-merge/references/release-merge.md
+++ b/.claude/skills/release-merge/references/release-merge.md
@@ -17,9 +17,7 @@ Resolve to the **prerelease / new-stable** content, except where `main` is a str
 
 ## Freeze on a release merge
 
-The site is `freeze: true`, so `quarto render <file>` only *thaws* the existing freeze — it does not rewrite it.
-
-Markdown-engine pages (mermaid/`dot` diagrams, no `r`/`python`/`julia` cells — confirm with `quarto inspect <file>`) produce no computational output, so an `execute-results/html.json` under `_freeze/` for such a page is vestigial: delete it rather than regenerate it. The check-freeze hook's `git show HEAD:` fallback currently re-flags an intentional freeze deletion, so clearing it needs the hook fix or a confirmed `--no-verify`.
+A release merge can surface `_freeze/` conflicts. Resolve them per the `_freeze/` section of `.claude/rules/quarto-web-workflow.md` (always loaded) — most often it's a markdown-engine page carrying a vestigial freeze entry to delete.
 
 ## After merging
 


### PR DESCRIPTION
Documents the quarto-web release-merge process (learnings from #2122) as a skill rather than always-loaded rule content — releases are rare, so the detail should load only when the skill is invoked, not sit in every session's context.

- New `release-merge` skill: `SKILL.md` (index — overview, when-to-use, pointer to quarto-cli's `dev-docs/checklist-make-a-new-quarto-release.md` as the canonical checklist) and `references/release-merge.md` (merge paths, the `no-sync-prerelease` label, merge-commit-not-squash, conflict resolution, release-time freeze handling).
- `.claude/rules/quarto-web-workflow.md`: a one-line breadcrumb to the skill, plus a correction to the `_freeze/` section (kept in the rule since it applies to any frozen-page edit, not just releases) — under `freeze: true` a plain render only *thaws*, and markdown-engine pages (mermaid/`dot`) carry vestigial `_freeze` entries that should be deleted.

Complements the release-checklist update in quarto-cli.
