### PR TITLE
Update nwtgck/actions-netlify from v3 to v4

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Deploy Preview to Netlify as preview
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v3
+        uses: nwtgck/actions-netlify@v4
         env:
           NETLIFY_SITE_ID: 2a3da659-672b-4e5b-8785-e10ebf79a962
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
         #   (we need to protect also from workflow_dispatch inherited from workflow_call event - where inputs.prerelease is defined)
         if: ${{ inputs.prerelease || (format('{0}', inputs.prerelease) != 'false' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/prerelease') }}
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v3
+        uses: nwtgck/actions-netlify@v4
         env:
           NETLIFY_SITE_ID: 2a3da659-672b-4e5b-8785-e10ebf79a962
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
GitHub Actions runners deprecated Node 20 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so workflow runs now warn:

`##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: nwtgck/actions-netlify@v3.`

Bump `nwtgck/actions-netlify` from v3 to v4 in `publish.yml` and `preview.yml`, which moves its declared runtime to node24. No input/output changes between v3.0.0 and v4.0.0 per the action's changelog and `action.yml`.
