### PR TITLE
Treat any non-markdown engine as computational in freeze guidance

### DIFF
--- a/.claude/rules/quarto-web-workflow.md
+++ b/.claude/rules/quarto-web-workflow.md
@@ -18,9 +18,9 @@ Any source change to a `.qmd` that has a `_freeze/` entry — even non-executabl
 
 **Before committing:** `git diff HEAD -- _freeze/` — every edited frozen `.qmd` must have a corresponding `_freeze/` change. (Use `HEAD` to show both staged and unstaged changes.)
 
-**If the freeze-check hook blocks a commit or push:** first check whether the page even executes code — `quarto inspect <file.qmd>` reports an `engines` array. `markdown` there means no code runs (so the page should carry no computational freeze); `knitr`/`jupyter`/`julia` mean it does.
+**If the freeze-check hook blocks a commit or push:** first check whether the page even executes code — `quarto inspect <file.qmd>` reports an `engines` array. `markdown` there means no code runs (so the page should carry no computational freeze); any other engine — `knitr`, `jupyter`, `julia`, or a custom Engine Extension — means it executes code.
 
-- **Computational engine (`knitr`/`jupyter`/`julia`):** the page has a real freeze. Because the site is `freeze: true`, a plain `quarto render <file.qmd>` only *thaws* the existing freeze — it does not rewrite it. Re-execute to regenerate the freeze (render with execution forced), then commit the updated `_freeze/` output alongside the source change.
+- **Computational engine (any non-`markdown` engine — e.g. `knitr`, `jupyter`, `julia`, an Engine Extension):** the page has a real freeze. Because the site is `freeze: true`, a plain `quarto render <file.qmd>` only *thaws* the existing freeze — it does not rewrite it. Re-execute to regenerate the freeze (render with execution forced), then commit the updated `_freeze/` output alongside the source change.
 - **Markdown engine (mermaid/`dot` diagrams, no `r`/`python`/`julia` cells):** the page produces no computational output, so an `execute-results/html.json` under `_freeze/` for it is **vestigial** — delete it rather than regenerate it. The check-freeze hook's `git show HEAD:` fallback currently re-flags an intentional freeze deletion, so clearing it needs the hook fix or a confirmed `--no-verify`.
 
 ## Avoid duplicating doc content


### PR DESCRIPTION
The `_freeze/` guidance in `.claude/rules/quarto-web-workflow.md` named `knitr`/`jupyter`/`julia` as the executing engines. But since Quarto 1.9's Engine Extensions a document can use a custom engine beyond those, and `markdown` is the only non-executing engine (the no-op default when nothing else claims the file).

With the old allow-list phrasing, a custom-engine page would be misread as non-computational — and its real freeze could be deleted as "vestigial".

Reframe as an invariant: `quarto inspect`'s `engines` array is `markdown` ⇒ no execution; any other engine ⇒ the page executes code (with knitr/jupyter/julia as examples, not an exhaustive list).

Follows #2124.
