### PR TITLE
Rework blog-post skill for the new blog home

### DIFF
--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -25,8 +25,13 @@ mechanics.
 3. Browse `content/blog/ported/quarto/` for prior Quarto posts. Recent ones
    (e.g. `2026-03-24-1.9-release/`) show the current frontmatter and structure
    conventions.
-4. If the post covers a Quarto feature, read the relevant docs page in this
-   repo for accurate terminology, and link to it with an absolute URL.
+4. If the post covers a Quarto feature, read its docs from this repo — not
+   from quarto.org — so drafting works even when the docs aren't live yet.
+   Docs for an unreleased version live on the `prerelease` branch: check the
+   working tree first, then `git fetch origin prerelease` and
+   `git show origin/prerelease:docs/<path>`. quarto.org serves `main`, so
+   anything prerelease-only won't be live until the release-time merge — see
+   § Links for how to link to it anyway.
 
 ## File Structure
 
@@ -128,11 +133,20 @@ project:
 
 ### Links
 
-**Docs links must be absolute**: `https://quarto.org/docs/...`, using the live
-page URL as served (copy it from the browser), never a `.qmd` source path or a
-site-root-relative path — the post no longer lives on quarto.org. Every
-feature mentioned links to its docs page. Pattern: explain briefly, show
-example, then link.
+**Docs links must be absolute**: `https://quarto.org/docs/...`, never a
+`.qmd` source path or a site-root-relative path — the post no longer lives on
+quarto.org. Derive the URL from the repo path:
+`docs/<path>/<page>.qmd` → `https://quarto.org/docs/<path>/<page>.html`.
+Every feature mentioned links to its docs page. Pattern: explain briefly,
+show example, then link.
+
+**Verify every quarto.org link resolves** (e.g.
+`curl -s -o /dev/null -w '%{http_code}' <url>`). A page whose docs exist only
+on the `prerelease` branch will 404 until the release-time
+`prerelease` → `main` merge. Keep the quarto.org URL anyway — never
+substitute the prerelease site's domain — and **flag every such
+pending-merge link when handing off the draft** so it's re-checked before the
+post publishes.
 
 **Other blog posts**: link with the permalink pattern `/blog/YYYY-MM-DD_slug/`
 (see the authoring guide), never content-directory paths.
@@ -209,8 +223,9 @@ and will be part of the upcoming X.Y release.
    In a Claude session started in that repo, the `/check-post` and
    `/review-post` commands run validation and a content review interactively.
 10. **Review**: direct opener? code blocks fenced with language? all images
-    alt-texted? absolute docs links? closing matches type convention?
-    frontmatter complete (`people`, `topics`, `source: quarto`)?
+    alt-texted? absolute docs links, each verified live or flagged as
+    pending-merge? closing matches type convention? frontmatter complete
+    (`people`, `topics`, `source: quarto`)?
 
 ## Publishing
 

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -164,6 +164,32 @@ the Hugo pipeline.
 
 Both are processed by Quarto at render time and work in open-source-website.
 
+**Displaying literal shortcode syntax** (showing readers what to type) takes
+three ingredients — this is how every such example in the ported Quarto posts
+works (verified empirically):
+
+1. **Put the syntax in code** — a fenced block or inline code, never prose.
+   An escape in prose reaches Hugo as a live shortcode: a name Hugo knows
+   silently renders its output in place of your example; an unknown name
+   fails the entire site build.
+2. **Escape it so Quarto doesn't execute it**: triple braces
+   (`{{{< meta state >}}}`), or the `shortcodes="false"` attribute on a
+   fenced block (`{.markdown shortcodes="false"}`). Unescaped syntax in code
+   is swallowed at the Quarto stage, leaving empty code.
+3. **Opt into the site's escape filter** in the post frontmatter:
+
+   ```yaml
+   filters:
+     - escape-shortcodes
+   ```
+
+   The filter (`content/_extensions/escape-shortcodes`) rewrites `{{<` to
+   Hugo's comment escape in code contexts, so Hugo displays the syntax
+   instead of executing it. Ported Quarto posts get it automatically via
+   `content/blog/ported/quarto/_metadata.yml`; new posts must opt in.
+
+In prose, refer to shortcodes by name instead ("the `video` shortcode").
+
 **`{{< prerelease-callout >}}` does NOT exist there** — it's a quarto-web
 extension. For a post about an unreleased feature, write a static callout
 instead, and remove it once the version ships:

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -1,70 +1,78 @@
 ---
 name: quarto-blog-post
-description: Use when writing, drafting, or editing blog posts for quarto.org, creating Quarto feature or release announcements, or reviewing blog post drafts for the Quarto website.
+description: Use when writing, drafting, or editing Quarto blog posts, creating Quarto feature or release announcements, or reviewing Quarto blog post drafts. Quarto posts publish on the Posit Open Source blog (posit-dev/open-source-website), not on quarto.org.
 ---
 
 # Quarto Blog Post
 
-Write blog posts for `quarto.org/blog` matching the voice, structure, and conventions
-from 40+ existing posts.
+Write Quarto blog posts matching the voice, structure, and conventions of 40+
+prior posts. Since May 2026 the Quarto blog lives on the
+[Posit Open Source website](https://opensource.posit.co/blog/q/quarto/):
+posts are authored and published in the
+[`posit-dev/open-source-website`](https://github.com/posit-dev/open-source-website)
+repo, not in quarto-web. This skill carries the Quarto-specific knowledge
+(post types, voice, thumbnails); defer to that repo's own guides for its
+mechanics.
 
 ## Setup
 
-1. `ls docs/blog/posts/` — browse existing posts for reference
-2. Read `docs/blog/posts/_metadata.yml` — inherited by all posts (Giscus comments,
-   title-block-banner, left TOC, signup widget, `search: false`)
-3. If the post covers a Quarto feature, read the relevant docs page for accurate
-   terminology and linking.
+1. Locate a local clone of `posit-dev/open-source-website` — conventionally a
+   sibling of this repo (`../open-source-website`). Clone it if missing.
+   Check `git status` before branching.
+2. Read, in its `content/blog/` directory:
+   - `CLAUDE.md` — frontmatter schema and taxonomies
+   - `_authoring-guide.md` — format choice, rendering, preview, and PR flow
+3. Browse `content/blog/ported/quarto/` for prior Quarto posts. Recent ones
+   (e.g. `2026-03-24-1.9-release/`) show the current frontmatter and structure
+   conventions.
+4. If the post covers a Quarto feature, read the relevant docs page in this
+   repo for accurate terminology, and link to it with an absolute URL.
 
 ## File Structure
 
+In the open-source-website clone, on a branch named `blog/<slug>`:
+
 ```
-docs/blog/posts/YYYY-MM-DD-slug/
-  index.qmd        # The post (required)
-  thumbnail.png    # Listing card image (required)
+content/blog/<slug>/
+  index.qmd        # Source (required)
+  index.md         # Rendered output — always commit alongside the source
+  thumbnail.png    # Hero + listing card image, 1920×1080 (required)
   *.png, *.jpg     # Additional images
-  _contribs.md     # Contributor list (release posts only)
 ```
 
-Directory name: `YYYY-MM-DD-slug` — date matches frontmatter, slug is short kebab-case.
+The folder name is the URL slug: short kebab-case, no date prefix
+(e.g. `quarto-1-10`). The published URL becomes `/blog/YYYY-MM-DD_<slug>/`
+from the frontmatter `date`. Never scaffold under `content/blog/ported/` —
+that tree is for migrated legacy posts.
 
 ## Frontmatter
 
-```yaml
----
-title: "Post Title"
-description: |
-  One to three sentences for listing cards and social sharing.
-author: Author Name
-date: "YYYY-MM-DD"
-categories:
-  - Category1
-  - Category2
-image: thumbnail.png
-image-alt: "Descriptive alt text for the thumbnail."
----
-```
+Don't write the frontmatter from memory — scaffold it from the repo's Hugo
+archetype (`archetypes/blog.md`, the source of truth for the schema; see
+Workflow step 2) and fill it in. Field meanings and taxonomies are documented
+in open-source-website's `content/blog/CLAUDE.md`.
 
-**title**: Short. Release posts: `"Quarto X.Y"`. Backtick code spans OK.
+Quarto-post specifics when filling in the scaffold:
 
-**description**: Self-contained summary (makes sense without the title). Always `|` block scalar.
+**source: quarto** — required, and not in the archetype. Places the post on
+the [Quarto project listing](https://opensource.posit.co/blog/q/quarto/),
+where old quarto.org blog URLs redirect. Set `software: quarto` too.
 
-**author**: Plain string for staff (`Charlotte Wickham`). Two authors: `Name and Name`.
-Guest authors use structured form with `name:` and optional `url:`.
+**date**: a future date schedules the post — Hugo hides it until a daily
+build (8 AM UTC) on the publish date, so set the date the PR is expected to
+merge (or later). No date-fixing script needed.
 
-**date**: ISO 8601 `"YYYY-MM-DD"`. Must match directory name.
+**image / image-alt**: set `image: thumbnail.png`, 1920×1080 (16:9) — used as
+both the hero and the listing card. `image-alt` is mandatory.
+See `references/thumbnail-guide.md` for the decision between the two
+production paths (Typst, or HTML+SVG) and the HTML+SVG flow. For the Typst
+path, see `references/typst-thumbnail.md`.
 
-**categories**: 2-3 per post. Use existing values — scan recent posts to check. Common:
-`Releases`, `Quarto X.Y`, `Features`, `Authoring`, `Learn`, `Workshop`, `Conference`,
-`Tip`, `Extensions`, `Tables`, `Teaching`, `Jupyter`.
+**people**: full names, individuals only — never a team name.
 
-**image / image-alt**: `thumbnail.png` preferred. `image-alt` is mandatory.
-See `references/thumbnail-guide.md` for the decision between the two production
-paths (Typst, or HTML+SVG) and the HTML+SVG flow. For the Typst path, see
-`references/typst-thumbnail.md`.
-
-**Optional**: `lightbox: true` (many screenshots), `draft: true` (while developing).
-Do not use `subtitle:` (phased out after 2023).
+Never add `ported_from` or `port_status` (migration metadata), and don't carry
+over the old quarto.org schema: no `categories`, no `subtitle`, no
+`_metadata.yml` inheritance.
 
 ## Post Types
 
@@ -103,8 +111,9 @@ Every image must have `fig-alt=` text — non-negotiable accessibility standard.
 ![](screenshot.png){fig-alt="Description of what the screenshot shows."}
 ```
 
-Multi-image layouts use Quarto's layout system (`{layout-ncol="2"}`).
-For many images, add `{.lightbox group="name"}`.
+Multi-image layouts use Quarto's layout system (`{layout-ncol="2"}`) — a Lua
+filter in open-source-website converts these for Hugo. Don't use `.lightbox`;
+that's a quarto.org HTML feature with no equivalent in the Hugo pipeline.
 
 ### Code Blocks
 
@@ -119,29 +128,66 @@ project:
 
 ### Links
 
-Every feature mentioned links to its docs page. Pattern: explain briefly, show example,
-then link. Use site-root-relative paths: `[Feature](/docs/path.qmd)`.
+**Docs links must be absolute**: `https://quarto.org/docs/...`, using the live
+page URL as served (copy it from the browser), never a `.qmd` source path or a
+site-root-relative path — the post no longer lives on quarto.org. Every
+feature mentioned links to its docs page. Pattern: explain briefly, show
+example, then link.
+
+**Other blog posts**: link with the permalink pattern `/blog/YYYY-MM-DD_slug/`
+(see the authoring guide), never content-directory paths.
 
 ### Callouts
 
 Use sparingly: `.callout-tip` for post origin context, `.callout-warning` for caveats,
-`.callout-note` for prerequisites. Release posts typically skip callouts.
+`.callout-note` for prerequisites. Quarto callouts render correctly through
+the Hugo pipeline.
 
 ### Shortcodes
 
-- `{{< prerelease-callout X.Y type="blog" >}}` — pre-release banner (auto-disappears)
 - `{{< video URL >}}` — video embed
 - `{{< include file.md >}}` — include generated content
+
+Both are processed by Quarto at render time and work in open-source-website.
+
+**`{{< prerelease-callout >}}` does NOT exist there** — it's a quarto-web
+extension. For a post about an unreleased feature, write a static callout
+instead, and remove it once the version ships:
+
+```markdown
+::: {.callout-note}
+This feature is available in the
+[pre-release version of Quarto](https://quarto.org/docs/download/prerelease.html)
+and will be part of the upcoming X.Y release.
+:::
+```
 
 ## Workflow
 
 1. **Identify post type** → read `references/post-types.md` for that type
-2. **Create directory**: `docs/blog/posts/YYYY-MM-DD-slug/`
-3. **Write frontmatter** per schema above
-4. **Draft body** following type-specific structure
+2. **Branch and scaffold** in the open-source-website clone, off up-to-date
+   `main`, mirroring its `/new-post` command:
+
+   ```bash
+   git checkout -b blog/<slug>
+   hugo new blog/<slug>/index.md
+   mv content/blog/<slug>/index.md content/blog/<slug>/index.qmd
+   ```
+
+   `hugo new` fills the frontmatter from `archetypes/blog.md`, so the schema
+   stays in sync with the site. If `hugo` isn't installed, copy the
+   frontmatter from `archetypes/blog.md` by hand instead — same source of
+   truth. (In a Claude session started in that repo, the `/new-post` command
+   runs this flow interactively.)
+3. **Fill in the frontmatter**: replace the placeholder `title`, `people`,
+   and `description`; trim `topics`, `languages`, and `tags` to what applies;
+   delete unused optional fields; and set the Quarto specifics above
+   (`source: quarto`, `image`/`image-alt`, `date`)
+4. **Draft body** following type-specific structure. Body headings start at
+   `##` — the H1 comes from `title`.
 5. **Add images** with `fig-alt=` on every one
-6. **Link to docs** for every feature mentioned
-7. **Create thumbnail**:
+6. **Link to docs** with absolute quarto.org URLs for every feature mentioned
+7. **Create thumbnail** (1920×1080):
    1. Read `references/thumbnail-guide.md` § Choosing your path
    2. **Always present both options as a question to the user**, even if one
       path is the obvious recommendation. State the recommendation with
@@ -151,21 +197,26 @@ Use sparingly: `.callout-tip` for post origin context, `.callout-warning` for ca
    3. Read the chosen path's reference and execute
       (`references/typst-thumbnail.md` for Typst, rest of `thumbnail-guide.md`
       for HTML+SVG)
-8. **Review**: direct opener? code blocks fenced with language? all images alt-texted?
-   docs links present? closing matches type convention? categories correct?
+8. **Render**: from the post directory, `quarto render index.qmd` — this
+   produces the `index.md` Hugo builds from. Commit `index.qmd`, `index.md`,
+   and any generated outputs together.
+9. **Validate**: from the open-source-website root:
+
+   ```bash
+   uv run scripts/validate-blog-posts.py content/blog/<slug>/index.md
+   ```
+
+   In a Claude session started in that repo, the `/check-post` and
+   `/review-post` commands run validation and a content review interactively.
+10. **Review**: direct opener? code blocks fenced with language? all images
+    alt-texted? absolute docs links? closing matches type convention?
+    frontmatter complete (`people`, `topics`, `source: quarto`)?
 
 ## Publishing
 
-When ready to publish, set the post date to today and rename the directory:
-
-```bash
-quarto run _tools/publish-date.ts docs/blog/posts/YYYY-MM-DD-slug
-```
-
-This updates `date:` in frontmatter and renames the directory to match. Run it
-on the day you intend to merge — avoids manual date edits if the publish date slips.
-
-## PR Workflow
-
-PR to `main` first. On merge, auto-backport creates cherry-pick PR to `prerelease`.
-Push branches to `upstream` remote (quarto-dev/quarto-web), not `origin`.
+Open a PR against `main` in `posit-dev/open-source-website` — never push
+directly to `main`. Posit org members push branches to the repo itself (no
+fork needed); a Netlify preview is posted on the PR automatically, and merging
+requires one approving review from someone with Write access. To schedule a
+post, set a future `date` and merge — it goes live on that date's morning
+build. Details: `content/blog/_authoring-guide.md` § Publishing your post.

--- a/.claude/skills/blog-post/SKILL.md
+++ b/.claude/skills/blog-post/SKILL.md
@@ -75,6 +75,13 @@ path, see `references/typst-thumbnail.md`.
 
 **people**: full names, individuals only — never a team name.
 
+**tags**: freeform — this is where the old quarto.org `categories` vocabulary
+lives on (`Releases`, `Quarto X.Y`, `Features`, `Authoring`, `Learn`,
+`Workshop`, `Tip`, ...; the port moved each post's categories into its tags).
+Reuse tags already present in `content/blog/ported/quarto/` sources rather
+than coining synonyms, and skip a bare `Quarto` tag — `source` and `software`
+already cover it.
+
 Never add `ported_from` or `port_status` (migration metadata), and don't carry
 over the old quarto.org schema: no `categories`, no `subtitle`, no
 `_metadata.yml` inheritance.

--- a/.claude/skills/blog-post/assets/thumbnail-diagram.typ
+++ b/.claude/skills/blog-post/assets/thumbnail-diagram.typ
@@ -1,9 +1,9 @@
 #import "@preview/cetz:0.3.4"
 
 #set page(
-  width: 1200pt,
-  height: 630pt,
-  margin: 50pt,
+  width: 1920pt,
+  height: 1080pt,
+  margin: 80pt,
   fill: rgb("#447099"),
 )
 
@@ -15,17 +15,17 @@
 #align(center)[
   #stack(
     dir: ltr,
-    spacing: 16pt,
-    align(horizon)[#image("quarto-logo-trademark-light.svg", height: 90pt)],
-    align(horizon)[#text(baseline: -8pt, size: 90pt, weight: "bold")[2]],
+    spacing: 26pt,
+    align(horizon)[#image("quarto-logo-trademark-light.svg", height: 144pt)],
+    align(horizon)[#text(baseline: -13pt, size: 144pt, weight: "bold")[2]],
   )
 
-  #v(10pt)
-  #text(size: 56pt, weight: "bold")[Replace this title]
+  #v(16pt)
+  #text(size: 90pt, weight: "bold")[Replace this title]
 
-  #v(10pt)
+  #v(16pt)
 
-  #cetz.canvas(length: 45pt, {
+  #cetz.canvas(length: 72pt, {
     import cetz.draw: *
 
     // Ellipse node — white fill, dark blue label.
@@ -38,12 +38,12 @@
         stroke: white,
         name: name,
       )
-      content((x, y), text(fill: rgb("#1f3a52"), weight: "bold", size: 20pt)[#label])
+      content((x, y), text(fill: rgb("#1f3a52"), weight: "bold", size: 32pt)[#label])
     }
 
     // Edge — white line connecting two named nodes.
     let edge(a, b) = {
-      line(a, b, stroke: (paint: white, thickness: 1.5pt))
+      line(a, b, stroke: (paint: white, thickness: 2.5pt))
     }
 
     // Replace the placeholder graph below with your own nodes + edges.

--- a/.claude/skills/blog-post/assets/thumbnail-text.typ
+++ b/.claude/skills/blog-post/assets/thumbnail-text.typ
@@ -1,7 +1,7 @@
 #set page(
-  width: 1200pt,
-  height: 630pt,
-  margin: 50pt,
+  width: 1920pt,
+  height: 1080pt,
+  margin: 80pt,
   fill: rgb("#447099"),
 )
 
@@ -13,14 +13,14 @@
 #align(center + horizon)[
   #stack(
     dir: ltr,
-    spacing: 16pt,
-    align(horizon)[#image("quarto-logo-trademark-light.svg", height: 90pt)],
-    align(horizon)[#text(baseline: -8pt, size: 90pt, weight: "bold")[2]],
+    spacing: 26pt,
+    align(horizon)[#image("quarto-logo-trademark-light.svg", height: 144pt)],
+    align(horizon)[#text(baseline: -13pt, size: 144pt, weight: "bold")[2]],
   )
 
-  #v(20pt)
-  #text(size: 56pt, weight: "bold")[Replace this title]
+  #v(32pt)
+  #text(size: 90pt, weight: "bold")[Replace this title]
 
-  #v(10pt)
-  #text(size: 32pt)[Replace this subtitle (optional)]
+  #v(16pt)
+  #text(size: 52pt)[Replace this subtitle (optional)]
 ]

--- a/.claude/skills/blog-post/references/post-types.md
+++ b/.claude/skills/blog-post/references/post-types.md
@@ -58,7 +58,9 @@ the very end.
 **Callouts**: release posts typically skip them.
 
 **Frontmatter**: `title` is `"Quarto X.Y"`; `source: quarto` always; `topics`
-from the fixed set (release posts have used `Publishing`).
+from the fixed set (release posts have used `Publishing`); `tags` are
+`Quarto X.Y` and `Releases` — the old categories convention, carried by every
+ported release post.
 
 ---
 

--- a/.claude/skills/blog-post/references/post-types.md
+++ b/.claude/skills/blog-post/references/post-types.md
@@ -20,11 +20,24 @@ the changes in this version in the
 [Release Notes](https://quarto.org/docs/download/changelog/1.9/).
 ```
 
+The summary paragraph between the download link and the feature sections names
+each major feature as a short noun phrase ("more refined HTML accessibility
+checks") — one clause per feature, no capability details. The detail belongs in
+the feature sections.
+
 **Feature sections**: Each major feature gets a `##` heading named after the feature
 (not "What's New"). Order by importance. Each section:
 - Explain in 2-3 sentences
 - Code example or screenshot (or both)
 - Link to docs: "Learn more at [Feature Name](https://quarto.org/docs/path.html)."
+
+Keep feature prose lean — state what changed plainly:
+- Cut "why this matters" clauses and parenthetical examples (`e.g.`,
+  `such as`); the docs link carries that detail.
+- Scope claims precisely: if a behavior applies only under a particular
+  option, say so ("When using `output: document`, violations are…").
+- Cover the headline change only. Adjacent minor wins (a platform port, a
+  related small fix) can be dropped — the changelog has them.
 
 **Other Highlights**: `## Other Highlights` bundles smaller improvements. Format:
 

--- a/.claude/skills/blog-post/references/post-types.md
+++ b/.claude/skills/blog-post/references/post-types.md
@@ -3,6 +3,9 @@
 Detailed structure guidance for each blog post type. Read the section that matches
 your post — you rarely need all four.
 
+All docs links in examples are absolute (`https://quarto.org/docs/...`) — the
+blog no longer lives on quarto.org, so site-relative paths break.
+
 ## Release Announcements
 
 The most structured type. Readers expect consistency across releases.
@@ -12,21 +15,21 @@ download and changelog links. No preamble.
 
 ```markdown
 Quarto 1.9 is out! You can get the current release from the
-[download page](/docs/download/index.qmd). Read the full
-[changelog](https://github.com/quarto-dev/quarto-cli/releases/tag/v1.9)
-for a complete list of changes.
+[download page](https://quarto.org/docs/download/index.html). You can find all
+the changes in this version in the
+[Release Notes](https://quarto.org/docs/download/changelog/1.9/).
 ```
 
 **Feature sections**: Each major feature gets a `##` heading named after the feature
 (not "What's New"). Order by importance. Each section:
 - Explain in 2-3 sentences
 - Code example or screenshot (or both)
-- Link to docs: "Learn more at [Feature Name](/docs/path)."
+- Link to docs: "Learn more at [Feature Name](https://quarto.org/docs/path.html)."
 
 **Other Highlights**: `## Other Highlights` bundles smaller improvements. Format:
 
 ```markdown
-- [Feature Name](/docs/path)---Short description of what it does.
+- [Feature Name](https://quarto.org/docs/path.html)---Short description of what it does.
 ```
 
 Note the em-dash (`---`) between link and description.
@@ -35,10 +38,14 @@ Note the em-dash (`---`) between link and description.
 Highlights if applicable.
 
 **Closing**: Always `## Acknowledgements`. Thank contributors. Recent releases use
-`{{< include _contribs.md >}}`. Release posts with emoji thumbnails include OpenMoji
-attribution at the very end.
+`{{< include _contribs.md >}}`, with `_contribs.md` committed in the post
+folder. Release posts with emoji thumbnails include OpenMoji attribution at
+the very end.
 
-**Categories**: Always `Quarto X.Y` + `Releases`.
+**Callouts**: release posts typically skip them.
+
+**Frontmatter**: `title` is `"Quarto X.Y"`; `source: quarto` always; `topics`
+from the fixed set (release posts have used `Publishing`).
 
 ---
 
@@ -47,10 +54,16 @@ attribution at the very end.
 Spotlight a specific feature, often published before the corresponding release. More
 varied structure than release posts.
 
-**Opening**: If unreleased, add prerelease callout at the very top:
+**Opening**: If the feature is unreleased, add a static callout at the very top
+(the quarto.org `{{< prerelease-callout >}}` shortcode doesn't exist in
+open-source-website), and remove it once the version ships:
 
 ```markdown
-{{< prerelease-callout 1.10 type="blog" >}}
+::: {.callout-note}
+This feature is available in the
+[pre-release version of Quarto](https://quarto.org/docs/download/prerelease.html)
+and will be part of the upcoming X.Y release.
+:::
 ```
 
 Then a direct statement of what the feature does. Get to the point — readers clicked
@@ -62,8 +75,8 @@ headings name the concept being explained.
 Problem/Solution framing works well for features that address a pain point: explain
 the problem first, then show how the feature solves it.
 
-**Closing**: Link to the documentation. "Learn more on the [Feature Name](/docs/path)
-page." No acknowledgements section.
+**Closing**: Link to the documentation. "Learn more on the
+[Feature Name](https://quarto.org/docs/path.html) page." No acknowledgements section.
 
 ---
 

--- a/.claude/skills/blog-post/references/thumbnail-guide.md
+++ b/.claude/skills/blog-post/references/thumbnail-guide.md
@@ -1,6 +1,7 @@
 # Thumbnail Guide
 
-Design conventions for blog post listing card images, derived from 40 existing posts.
+Design conventions for blog post thumbnails — used as both the post hero and
+the listing card image — derived from 40+ existing posts.
 
 ## Choosing your path
 
@@ -16,19 +17,21 @@ Two production paths exist for thumbnails. Pick before you start designing.
 > from 1.4 through current. Switching to Typst for a release is a stylistic
 > choice — confirm with the team before deviating. New release posts that match
 > the template should reuse the existing HTML+SVG flow so all release thumbnails
-> stay visually consistent.
+> stay visually consistent — rebuilt at 1920x1080, since pre-move release
+> thumbnails were 1200x630.
 
 For Typst, see [`typst-thumbnail.md`](typst-thumbnail.md). The rest of this
 guide covers the HTML+SVG path.
 
 ## Dimensions and Format
 
-- **Size**: 1200x630 px (Open Graph / social card standard)
-- **Format**: PNG preferred (34 of 40 posts use PNG)
-- **HiDPI**: Some posts use 2400x1260 (2x) — same aspect ratio, sharper on retina
+- **Size**: 1920x1080 px (16:9) — the Posit Open Source blog standard; the
+  image serves as both the post hero and the listing card
+- **Format**: PNG or JPG (GIF is supported and will animate)
+- **HiDPI**: 3840x2160 (2x) — same aspect ratio, sharper on retina
 
-The 1200x630 ratio (~1.9:1) is the current standard for all post types from 2024 onward.
-Earlier posts used inconsistent sizes — don't follow those as examples.
+Posts published before the May 2026 blog move used 1200x630 (~1.9:1, the old
+quarto.org / Open Graph standard) — don't copy dimensions from those examples.
 
 ## Quarto Brand Colors
 
@@ -106,21 +109,21 @@ at the right dimensions.
 
 ### HTML/CSS + screenshot approach (recommended)
 
-Create an HTML file sized to 1200x630 with the design, then screenshot it:
+Create an HTML file sized to 1920x1080 with the design, then screenshot it:
 
 1. **Source SVG icons** — good free sources:
    - [svgrepo.com](https://www.svgrepo.com) — many Public Domain (PD) icons, no attribution needed
    - [icon-icons.com](https://icon-icons.com) — CC BY 4.0 icons, attribution required
-2. **Build an HTML file** — set `body` to 1200x630, embed SVG icons inline, use
+2. **Build an HTML file** — set `body` to 1920x1080, embed SVG icons inline, use
    flexbox for layout. Choose background color based on post type (see above).
-3. **Serve and screenshot** — serve the HTML locally and screenshot at 1200x630.
+3. **Serve and screenshot** — serve the HTML locally and screenshot at 1920x1080.
    Use any local HTTP server + headless browser screenshot tool. Examples:
 
    With `agent-browser` + a local server:
    ```bash
    # Serve with any static server (python, npx serve, simple-http-server, etc.)
    python -m http.server 8181 -d path/to/post/dir &
-   agent-browser batch "set viewport 1200 630" \
+   agent-browser batch "set viewport 1920 1080" \
      "open http://127.0.0.1:8181/thumbnail.html" \
      "screenshot path/to/thumbnail.png"
    agent-browser close
@@ -129,7 +132,7 @@ Create an HTML file sized to 1200x630 with the design, then screenshot it:
    With `file://` protocol (no server needed, requires `--allow-file-access`):
    ```bash
    agent-browser close  # Ensure clean daemon start
-   agent-browser --allow-file-access batch "set viewport 1200 630" \
+   agent-browser --allow-file-access batch "set viewport 1920 1080" \
      "open file:///absolute/path/to/thumbnail.html" \
      "screenshot path/to/thumbnail.png"
    agent-browser close
@@ -141,11 +144,11 @@ Create an HTML file sized to 1200x630 with the design, then screenshot it:
    Keep the SVG for future reference.
 
 **Always use PNG as the thumbnail (`image: thumbnail.png`), never SVG.** Standalone
-SVGs don't center properly in Quarto listing cards or social card previews — the
+SVGs don't center properly in listing cards or social card previews — the
 HTML uses flexbox for centering which SVG can't replicate without duplicating all
 the layout logic. The SVG is only a source file for regenerating the PNG.
 
-The Quarto logo SVG is at the repo root: `quarto-icon.svg` (fill color `#74AADB`
+The Quarto logo SVG is at the quarto-web repo root: `quarto-icon.svg` (fill color `#74AADB`
 — recolor to `#5286AB` for thumbnails or `white` for dark backgrounds).
 
 ### Attribution

--- a/.claude/skills/blog-post/references/typst-thumbnail.md
+++ b/.claude/skills/blog-post/references/typst-thumbnail.md
@@ -42,9 +42,12 @@ Copy the template and the logo SVG from the skill's `assets/` directory into
 your post directory. Both files must live alongside `thumbnail.typ` because the
 template uses a co-located filename for the logo.
 
+The post directory lives in the open-source-website clone (conventionally a
+sibling of this repo):
+
 ```powershell
 $skill = ".claude/skills/blog-post/assets"
-$post  = "docs/blog/posts/YYYY-MM-DD-slug"
+$post  = "../open-source-website/content/blog/my-post-slug"
 Copy-Item "$skill/thumbnail-diagram.typ" "$post/thumbnail.typ"   # or thumbnail-text.typ
 Copy-Item "$skill/quarto-logo-trademark-light.svg" $post         # white-fill, for #447099 / dark backgrounds
 ```
@@ -71,8 +74,9 @@ the thumbnail on a fresh checkout.
 
 Both bundled templates use:
 
-- Page size: `1200pt` × `630pt` (Open Graph / social card standard)
-- Margin: `50pt`
+- Page size: `1920pt` × `1080pt` (16:9, the Posit Open Source blog standard —
+  one page point per pixel at `--ppi 72`)
+- Margin: `80pt`
 - Background fill: `rgb("#447099")` — Quarto release-thumbnail blue
 
 Quarto brand palette (mirror of `thumbnail-guide.md`):
@@ -143,7 +147,7 @@ edge("doc", "header")
 edge("doc", "str")
 ```
 
-Position uses cetz coordinate units; `length: 45pt` on `cetz.canvas` scales
+Position uses cetz coordinate units; `length: 72pt` on `cetz.canvas` scales
 units to layout points. Adjust coordinates to spread nodes out.
 
 ### Snippet 2 — rectangle nodes with custom colors
@@ -161,7 +165,7 @@ let box(pos, label, name) = {
     stroke: white,
     name: name,
   )
-  content((x, y), text(fill: rgb("#1f3a52"), weight: "bold", size: 20pt)[#label])
+  content((x, y), text(fill: rgb("#1f3a52"), weight: "bold", size: 32pt)[#label])
 }
 
 box((0, 0), "input.qmd",   "src")
@@ -174,7 +178,7 @@ Replace `edge` with a variant that draws an arrowhead:
 
 ```typst
 let arrow(a, b) = {
-  line(a, b, mark: (end: ">"), stroke: (paint: white, thickness: 1.5pt))
+  line(a, b, mark: (end: ">"), stroke: (paint: white, thickness: 2.5pt))
 }
 
 arrow("src", "out")
@@ -184,7 +188,7 @@ For a label on the edge, place a `content()` at the midpoint:
 
 ```typst
 content(((src.x + out.x) / 2, (src.y + out.y) / 2 + 0.4),
-        text(fill: white, size: 16pt)[render])
+        text(fill: white, size: 26pt)[render])
 ```
 
 For richer cetz patterns (anchors, transformations, plot integration) consult
@@ -195,12 +199,13 @@ the cetz manual at <https://typst.app/universe/package/cetz/>.
 Run from the post directory:
 
 ```powershell
-cd docs/blog/posts/YYYY-MM-DD-slug
+cd ../open-source-website/content/blog/my-post-slug
 quarto typst compile thumbnail.typ thumbnail.png -f png --ppi 144
 ```
 
-`--ppi 144` produces a 2400×1260 PNG (twice the 1200×630 base) — the HiDPI/2x
-retina convention noted in `thumbnail-guide.md`.
+`--ppi 144` produces a 3840×2160 PNG (twice the 1920×1080 base) — the HiDPI/2x
+retina convention noted in `thumbnail-guide.md`. Use `--ppi 72` for an exact
+1920×1080 output instead.
 
 ## Anti-patterns
 


### PR DESCRIPTION
The Quarto blog moved to [posit-dev/open-source-website](https://github.com/posit-dev/open-source-website) in May 2026, but `.claude/skills/blog-post/` still described the old `docs/blog/posts/` workflow. This reworks the skill so posts are authored where they publish, while keeping the Quarto-specific knowledge (post types, voice, thumbnail production) here.

## Changes

- **Publishing target**: posts are created in an open-source-website clone at `content/blog/<slug>/` on a `blog/<slug>` branch; `index.qmd` + rendered `index.md` are committed together; PR to its `main` for a Netlify preview. The old quarto.org scaffolding, `categories`, `_metadata.yml`, `subtitle`, `_tools/publish-date.ts`, and backport sections are dropped.
- **Frontmatter is never hardcoded**: scaffolding runs `hugo new` against open-source-website's `archetypes/blog.md` (mirroring its `/new-post` command), so the schema can't drift out of sync. The skill keeps only Quarto-specific additions (`source: quarto`, thumbnail conventions, date-based scheduling).
- **Docs sourcing vs. linking**: terminology is read from this repo (working tree, then `origin/prerelease`), while posts link with absolute `https://quarto.org/docs/...` URLs derived from repo paths — each verified, with pending-merge links flagged for a re-check at publish time.
- **Thumbnails**: 1920×1080 (16:9, hero + card) replaces 1200×630; the bundled Typst templates are rescaled and re-verified (`--ppi 72` → exact size, `--ppi 144` → 2x).
- **Release-post specifics** (title convention, `_contribs.md`, summary-paragraph and lean-prose guidance) move out of the general sections into `references/post-types.md`.

## Validation

Prototyped by drafting the Quarto 1.10 release post with the reworked skill from a cold session (posit-dev/open-source-website#363); the prose lessons from that run are folded into `references/post-types.md`.