### PR TITLE
Document categories in HTML metadata reference

### DIFF
--- a/docs/reference/formats/html.json
+++ b/docs/reference/formats/html.json
@@ -36,6 +36,10 @@
         "description": "Title used to label document abstract"
       },
       {
+        "name": "categories",
+        "description": "List of categories used to classify the document."
+      },
+      {
         "name": "doi",
         "description": "Displays the document Digital Object Identifier in the header."
       },


### PR DESCRIPTION
## Summary

- add `categories` to the HTML metadata attributes reference
- describe it as the list used to classify a document

## Verification

- `python3 -m json.tool docs/reference/formats/html.json`
- `git diff --check`

Closes quarto-dev/quarto-cli#13498
