### PR TITLE
Add link-previews to shortcodes-and-filters listing

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -496,6 +496,13 @@
     documents (`format: html`) similar as how [`code-line-numbers`](https://quarto.org/docs/reference/formats/html.html#code)
     works for RevealJs.
 
+- name: link-previews
+  path: https://github.com/ravila4/quarto-link-previews
+  author: '[Ricardo Avila](https://github.com/ravila4)'
+  description: >
+    Hover previews for internal links on websites, in the style of
+    [Quartz](https://quartz.jzhao.xyz/) digital gardens.
+
 - name: linkate
   path: https://github.com/coatless-quarto/linkate
   author: '[James Joseph Balamuta](https://github.com/coatless/)'


### PR DESCRIPTION
Adds [link-previews](https://github.com/ravila4/quarto-link-previews) to the shortcodes-and-filters listing.

The filter gives a Quarto website hover previews for its internal links, the way Quartz digital gardens and Obsidian's page preview do. Hovering a link to another page opens a popover with that page's title block and content, and a link to a section opens the preview scrolled to that heading.

It reuses the tippy.js bundle Quarto already ships for footnote and cross-reference hovers, which is also where the popover theming comes from, so previews track the site theme in light and dark mode. Navigation chrome, external links, footnotes, cross-references and downloads are left alone.

Listing requirements: public GitHub repository, README with installation and usage, MIT license, tagged releases through v0.2.0, and a root `example.qmd`.

Live demo and docs, with the filter running on the site itself: <https://ravila4.github.io/quarto-link-previews/>

The entry is inserted alphabetically between `line-highlight` and `linkate`.
