### PR TITLE
Download table: put the full checksum in the DOM, truncate it with CSS

### DIFF
--- a/docs/download/_download.html
+++ b/docs/download/_download.html
@@ -74,11 +74,6 @@
 
           }
 
-          window.tippy("a.checksum[data-tippy-content]", {
-            interactive: true,
-            placement: "top-end",
-            maxWidth: "none",
-          });
         })
         .catch((err) => {
           console.log(err);
@@ -217,7 +212,15 @@
     }
 
     const table = createTable();
-    createHeadingRow(table, ["Platform", "Download", "Size", "SHA-256"]);
+    // Link the header to the release's checksums.txt: the full values stay
+    // reachable even where narrow screens truncate the hashes (WCAG 1.4.10).
+    const checksumsAsset = assets.find((asset) =>
+      asset.name.endsWith("-checksums.txt")
+    );
+    const shaHeading = checksumsAsset
+      ? `<a href="${checksumsAsset.download_url}">SHA-256</a>`
+      : "SHA-256";
+    createHeadingRow(table, ["Platform", "Download", "Size", shaHeading]);
 
     const tbody = table.createTBody();
     assets.forEach((asset) => {
@@ -228,11 +231,6 @@
     }
 
     downloadTableContainer.append(table);
-    window.tippy(".checksum[data-tippy-content]", {
-      interactive: true,
-      placement: "top-end",
-      maxWidth: "none",
-    });
   }
 
   function createTable() {
@@ -287,12 +285,9 @@
 
       const checksumCell = row.insertCell(i++);
       if (asset.checksum) {
-        const checkSumSlice = asset.checksum.slice(0, 7);
-
         const checksumEl = window.document.createElement("div");
         checksumEl.className = "checksum font-monospace";
-        checksumEl.setAttribute("data-tippy-content", asset.checksum);
-        checksumEl.innerText = checkSumSlice;
+        checksumEl.innerText = asset.checksum;
         checksumCell.appendChild(checksumEl);
       }
     }

--- a/styles.css
+++ b/styles.css
@@ -91,11 +91,16 @@ body.quarto-dark #quarto-header {
   margin-bottom: 0;
 }
 
+/* The cell holds the full hash; only the rendering truncates (ellipsis).
+   Screen readers, copying, and find-in-page all see the complete value,
+   and the header links to checksums.txt for the full values. */
 .download-table .checksum {
-  color: var(--bs-primary);
   font-size: .775em;
-  cursor: pointer;
   padding-top: 4px;
+  max-width: 9ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .download-button {


### PR DESCRIPTION
The site audit flagged two WCAG failures on `/docs/download/`, both on the checksum cells:

- **aria-allowed-attr** (critical, WCAG 4.1.2): tippy's interactive mode adds `aria-expanded` to the checksum `<div>`, which is invalid on an element with no role.
- **color-contrast** (serious, WCAG 1.4.3): the truncated hash used `--bs-primary` (3.97:1 on white; small text needs 4.5:1).

The deeper problem: the full SHA-256 lived only in a hover tooltip. Keyboard users could not reach it, screen readers never heard it, and copying it meant drag-selecting text inside a floating tooltip.

**The fix:** the cell's text is now the complete hash, and only the rendering truncates (`text-overflow: ellipsis`). The tooltip, tippy init, and JS truncation are gone. The SHA-256 column header links to the release's `checksums.txt`.

We tried a copy button, an `aria-describedby` span, and a `<details>` disclosure before settling here. This version won because it does both things at once with zero interactive machinery:

- **No visual clutter** — the table looks exactly as it does today.
- **The full hash is available to everyone** — screen readers announce all 64 characters, double-click selects the whole hash for copying, find-in-page matches it, and the header link shows the full values at any viewport (WCAG 1.4.10).

Net diff: +17/−17 lines. Axe scan of the page is clean at 1440×900 and 390×844, light and dark.
