### PR TITLE
Add paper-spin extension for RevealJS titles

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -605,6 +605,13 @@
   description: >
     A Quarto Extension that formats code cells into a tabset panel, displaying static and interactive code cells side-by-side with code cell options.
 
+- name: paper-spin
+  path: https://github.com/nickriches/paper-spin
+  author: "[Nick G. Riches](https://github.com/nickriches)"
+  description: |
+    A newspaper-style spin-in effect for RevealJS titles and image
+    screenshots, with a stacking layout for multiple images per slide.
+
 - name: partials
   path: https://github.com/gadenbuie/quarto-partials
   author: '[Garrick Aden-Buie](https://github.com/gadenbuie)'

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -606,7 +606,7 @@
     A Quarto Extension that formats code cells into a tabset panel, displaying static and interactive code cells side-by-side with code cell options.
 
 - name: paper-spin
-  path: https://github.com/nickriches/paper-spin
+  path: https://github.com/nickriches/quarto-paper-pile
   author: "[Nick G. Riches](https://github.com/nickriches)"
   description: |
     A newspaper-style spin-in effect for RevealJS titles and image


### PR DESCRIPTION
Added a new Quarto Extension for a newspaper-style spin-in effect.