### PR TITLE
docs: set github-actions steps version as variables

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -2,3 +2,5 @@ rstudio:
   min_version: "v2022.07"
 github-actions:
   checkout: v6
+  quarto-setup: v2
+  quarto-publish: v2

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,2 +1,4 @@
 rstudio:
   min_version: "v2022.07"
+github-actions:
+  checkout: v6

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,6 +1,12 @@
 rstudio:
   min_version: "v2022.07"
 github-actions:
-  checkout: v6
+  checkout: v7
   quarto-setup: v2
   quarto-publish: v2
+  setup-python: v7
+  setup-r: v2
+  setup-renv: v2
+  versions:
+    python: "3.14"
+    r: "4.6.1"

--- a/docs/publishing/_github-action-options.md
+++ b/docs/publishing/_github-action-options.md
@@ -4,7 +4,7 @@ It's possible to have a Quarto project in a large GitHub repository, where the Q
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id >}}
     path: subdirectory-to-use
@@ -14,7 +14,7 @@ By default, `quarto publish` will re-render your project before publishing it. H
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id >}}
     render: false

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -165,7 +165,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@{{< var github-actions.checkout >}}
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -203,7 +203,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@{{< var github-actions.checkout >}}
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -243,7 +243,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@{{< var github-actions.checkout >}}
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -209,9 +209,9 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@{{< var github-actions.setup-python >}}
         with:
-          python-version: '3.10'
+          python-version: '{{< var github-actions.versions.python >}}'
           cache: 'pip'
       - run: pip install jupyter
       - run: pip install -r requirements.txt
@@ -249,12 +249,12 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@{{< var github-actions.setup-r >}}
         with:
-          r-version: '4.2.0'
+          r-version: '{{< var github-actions.versions.r >}}'
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@{{< var github-actions.setup-renv >}}
         with:
           cache-version: 1
 

--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -168,10 +168,10 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}}
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id>}}
         env:
@@ -206,7 +206,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}}
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Install Python and Dependencies
         uses: actions/setup-python@v5
@@ -217,7 +217,7 @@ jobs:
       - run: pip install -r requirements.txt
 
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: gh-pages
         env:
@@ -246,7 +246,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}}
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -259,7 +259,7 @@ jobs:
           cache-version: 1
 
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: gh-pages
         env:
@@ -272,7 +272,7 @@ It's possible to have a Quarto project in a larger GitHub repository, where the 
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id>}}
     path: subdirectory-to-use
@@ -284,7 +284,7 @@ By default, `quarto publish` will re-render your project before publishing it. H
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id>}}
     render: false

--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -107,10 +107,10 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Render and Publish 
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id>}}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install Python and Dependencies
         uses: actions/setup-python@v5
@@ -171,7 +171,7 @@ jobs:
       - run: pip install -r requirements.txt
       
       - name: Render and Publish 
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id>}}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -210,7 +210,7 @@ jobs:
           cache-version: 1
       
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id>}}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -222,7 +222,7 @@ It's possible to have a Quarto project in a larger GitHub repository, where the 
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id>}}
     path: subdirectory-to-use
@@ -233,7 +233,7 @@ By default, `quarto publish` will re-render your project before publishing it. H
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id>}}
     render: false

--- a/docs/publishing/netlify.qmd
+++ b/docs/publishing/netlify.qmd
@@ -163,9 +163,9 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@{{< var github-actions.setup-python >}}
         with:
-          python-version: '3.10'
+          python-version: '{{< var github-actions.versions.python >}}'
           cache: 'pip'
       - run: pip install jupyter
       - run: pip install -r requirements.txt
@@ -200,12 +200,12 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@{{< var github-actions.setup-r >}}
         with:
-          r-version: '4.2.0'
+          r-version: '{{< var github-actions.versions.r >}}'
       
       - name: Install R Dependencies 
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@{{< var github-actions.setup-renv >}}
         with:
           cache-version: 1
       

--- a/docs/publishing/quarto-pub.qmd
+++ b/docs/publishing/quarto-pub.qmd
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -215,7 +215,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/quarto-pub.qmd
+++ b/docs/publishing/quarto-pub.qmd
@@ -128,10 +128,10 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Render and Publish 
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id >}}
           QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_AUTH_TOKEN }}
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install Python and Dependencies
         uses: actions/setup-python@v5
@@ -192,7 +192,7 @@ jobs:
       - run: pip install -r requirements.txt
       
       - name: Render and Publish 
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id >}}
           QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_AUTH_TOKEN }}
@@ -218,7 +218,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -231,7 +231,7 @@ jobs:
           cache-version: 1
       
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: {{< meta provider.id >}}
           QUARTO_PUB_AUTH_TOKEN: ${{ secrets.QUARTO_PUB_AUTH_TOKEN }}
@@ -243,7 +243,7 @@ It's possible to have a Quarto project in a larger GitHub repository, where the 
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id >}}
     path: subdirectory-to-use
@@ -254,7 +254,7 @@ By default, `quarto publish` will re-render your project before publishing it. H
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: {{< meta provider.id >}}
     render: false

--- a/docs/publishing/quarto-pub.qmd
+++ b/docs/publishing/quarto-pub.qmd
@@ -184,9 +184,9 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@{{< var github-actions.setup-python >}}
         with:
-          python-version: '3.10'
+          python-version: '{{< var github-actions.versions.python >}}'
           cache: 'pip'
       - run: pip install jupyter
       - run: pip install -r requirements.txt
@@ -221,12 +221,12 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@{{< var github-actions.setup-r >}}
         with:
-          r-version: '4.2.0'
+          r-version: '{{< var github-actions.versions.r >}}'
       
       - name: Install R Dependencies 
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@{{< var github-actions.setup-renv >}}
         with:
           cache-version: 1
       

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -251,10 +251,10 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
 
       - name: Render and Publish 
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: connect
           CONNECT_SERVER: https://connect.example.com
@@ -295,7 +295,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install Python and Dependencies
         uses: actions/setup-python@v5
@@ -306,7 +306,7 @@ jobs:
       - run: pip install -r requirements.txt
       
       - name: Render and Publish 
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: connect
           CONNECT_SERVER: https://connect.example.com
@@ -333,7 +333,7 @@ jobs:
         uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install R
         uses: r-lib/actions/setup-r@v2
@@ -346,7 +346,7 @@ jobs:
           cache-version: 1
       
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
         with:
           target: connect
           CONNECT_SERVER: https://connect.example.com
@@ -359,7 +359,7 @@ It's possible to have a Quarto project in a larger GitHub repository, where the 
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: connect
     path: subdirectory-to-use
@@ -371,7 +371,7 @@ By default, `quarto publish` will re-render your project before publishing it. H
 
 ``` yaml
 - name: Render and Publish
-  uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@{{< var github-actions.quarto-publish >}}
   with:
     target: connect
     render: false

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -292,7 +292,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4 
+        uses: actions/checkout@{{< var github-actions.checkout >}} 
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/docs/publishing/rstudio-connect.qmd
+++ b/docs/publishing/rstudio-connect.qmd
@@ -298,9 +298,9 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install Python and Dependencies
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@{{< var github-actions.setup-python >}}
         with:
-          python-version: '3.10'
+          python-version: '{{< var github-actions.versions.python >}}'
           cache: 'pip'
       - run: pip install jupyter
       - run: pip install -r requirements.txt
@@ -336,12 +336,12 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@{{< var github-actions.quarto-setup >}}
         
       - name: Install R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@{{< var github-actions.setup-r >}}
         with:
-          r-version: '4.2.0'
+          r-version: '{{< var github-actions.versions.r >}}'
       
       - name: Install R Dependencies 
-        uses: r-lib/actions/setup-renv@v2
+        uses: r-lib/actions/setup-renv@{{< var github-actions.setup-renv >}}
         with:
           cache-version: 1
       


### PR DESCRIPTION
Setup variables to keep the github actions steps up to date with a single change to one file.

Covered steps: `actions/checkout`, `quarto-dev/quarto-actions/setup`, `quarto-dev/quarto-actions/publish`, `actions/setup-python`, `r-lib/actions/setup-r`, and `r-lib/actions/setup-renv`. The Python and R versions that the example workflows pin are variables too.

Each value is bumped to the current stable release: `actions/checkout@v7`, `actions/setup-python@v7`, Python `3.14`, and R `4.6.1`. The other steps stay at `v2`, which is still their latest major.

Note that there is a "tool" also using an outdated version of the checkout step `_tools/screenshots/examples/quarto-demo/.github/workflows/publish.yml`. That directory is a git subtree of quarto-dev/quarto-demo, so the fix belongs upstream.

Resolves quarto-dev/quarto-cli#14796