### PR TITLE
docs(crossref): add axiom and assumption theorem types, fix algorithm style

### DIFF
--- a/docs/authoring/cross-references.qmd
+++ b/docs/authoring/cross-references.qmd
@@ -35,7 +35,7 @@ Note that cross reference identifiers must start with their type (e.g. `fig-` or
 
 Unless you are creating a cross-reference, avoid using the reserved cross-reference prefixes for code cell labels (e.g. set using the `label` code cell option) and element IDs (set using a `#` in an attribute). 
  
-The reserved prefixes are: `fig`, `tbl`, `lst`, `tip`, `nte`, `wrn`, `imp`, `cau`, `thm`, `lem`, `cor`, `prp`, `cnj`, `def`, `exm`, `exr`, `sol`, `rem`, `alg`, `eq`, `sec`.
+The reserved prefixes are: `fig`, `tbl`, `lst`, `tip`, `nte`, `wrn`, `imp`, `cau`, `thm`, `lem`, `cor`, `prp`, `cnj`, `def`, `exm`, `exr`, `sol`, `rem`, `alg`, `axm`, `asm`, `eq`, `sec`.
 
 Also avoid using underscores (`_`) in labels and IDs as this can cause problems when rendering to PDF with LaTeX.
 
@@ -345,6 +345,8 @@ There are a number of theorem variations supported, each with their own label pr
 | `#sol-`          | Solution         | solution              |
 | `#rem-`          | Remark           | remark                |
 | `#alg-`          | Algorithm        | algorithm             |
+| `#axm-`          | Axiom            | axiom                 |
+| `#asm-`          | Assumption       | assumption            | 
 
 The `proof` environment receives similar typesetting as theorems, however it is not numbered (and therefore cannot be cross-referenced). To create a proof add the `.proof` class to a div:
 

--- a/docs/authoring/language.qmd
+++ b/docs/authoring/language.qmd
@@ -115,7 +115,7 @@ fr:
 ### Cross-Reference Titles and Prefixes
 
 The same mechanism applies to cross-reference labels.
-Any key of the form `crossref-{type}-title` or `crossref-{type}-prefix` can be set under `language`, where `{type}` is a built-in float (`fig`, `tbl`, `lst`), a theorem environment (`thm`, `lem`, `cor`, `prp`, `cnj`, `def`, `exm`, `exr`), a callout (`nte`, `tip`, `wrn`, `imp`, `cau`), or a [custom cross-reference kind](cross-references-custom.qmd).
+Any key of the form `crossref-{type}-title` or `crossref-{type}-prefix` can be set under `language`, where `{type}` is a built-in float (`fig`, `tbl`, `lst`), a theorem environment (`thm`, `lem`, `cor`, `prp`, `cnj`, `def`, `exm`, `exr`, `alg`, `axm`, `asm`), a callout (`nte`, `tip`, `wrn`, `imp`, `cau`), or a [custom cross-reference kind](cross-references-custom.qmd).
 
 For floats and theorem environments, `crossref-{type}-prefix` falls back to `crossref-{type}-title` when omitted.
 

--- a/docs/prerelease/1.11/_highlights.qmd
+++ b/docs/prerelease/1.11/_highlights.qmd
@@ -1,1 +1,5 @@
-Quarto v1.11 was just released, nothing to see here -- yet!
+Quarto 1.11 includes the following new features:
+
+- [Theorems and Cross-Reference Types](/docs/authoring/cross-references.qmd#theorems-and-proofs):
+  - Added `axiom` (`#axm-`) and `assumption` (`#asm-`) theorem environments with localisation and custom option support.
+  - Updated `algorithm` (`#alg-`) environment to definition style.

--- a/docs/reference/metadata/crossref.json
+++ b/docs/reference/metadata/crossref.json
@@ -64,6 +64,18 @@
         "description": "The title prefix used for exercise captions."
       },
       {
+        "name": "alg-title",
+        "description": "The title prefix used for algorithm captions."
+      },
+      {
+        "name": "axm-title",
+        "description": "The title prefix used for axiom captions."
+      },
+      {
+        "name": "asm-title",
+        "description": "The title prefix used for assumption captions."
+      },
+      {
         "name": "fig-prefix",
         "description": "The prefix used for an inline reference to a figure."
       },
@@ -116,6 +128,18 @@
         "description": "The prefix used for an inline reference to an exercise."
       },
       {
+        "name": "alg-prefix",
+        "description": "The prefix used for an inline reference to an algorithm."
+      },
+      {
+        "name": "axm-prefix",
+        "description": "The prefix used for an inline reference to an axiom."
+      },
+      {
+        "name": "asm-prefix",
+        "description": "The prefix used for an inline reference to an assumption."
+      },
+      {
         "name": "fig-labels",
         "description": "The numbering scheme used for figures."
       },
@@ -166,6 +190,18 @@
       {
         "name": "exr-labels",
         "description": "The numbering scheme used for exercises."
+      },
+      {
+        "name": "alg-labels",
+        "description": "The numbering scheme used for algorithms."
+      },
+      {
+        "name": "axm-labels",
+        "description": "The numbering scheme used for axioms."
+      },
+      {
+        "name": "asm-labels",
+        "description": "The numbering scheme used for assumptions."
       },
       {
         "name": "lof-title",


### PR DESCRIPTION
## Description

Documentation companion PR for quarto-dev/quarto-cli#14800

- Document `axiom` (`#axm-`) and `assumption` (`#asm-`) theorem types in cross-references and language guides.
- Update reference metadata (`crossref.json`) for `alg`, `axm` and `asm` options.
- Add Quarto 1.11 pre-release feature highlights. 