### PR TITLE
Refresh action versions and adopt an explicit pinning policy

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get changed PNG files
         id: changed-pngs
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: '**/*.png'
           separator: '\n'
@@ -55,7 +55,7 @@ jobs:
           done
 
       - name: Commit optimized images
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Optimize PNG images with oxipng"
           commit_user_name: github-actions[bot]

--- a/.github/workflows/port-to-prerelease.yml
+++ b/.github/workflows/port-to-prerelease.yml
@@ -30,12 +30,12 @@ jobs:
         startsWith(github.event.comment.body, '/sync-prerelease')
       )
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create backport pull requests
         id: synced-pr
-        # https://github.com/korthout/backport-action/releases/tag/v4.2.0
-        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02
+        # https://github.com/korthout/backport-action/releases/tag/v4.6.0
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           cherry_picking: auto
           branch_name: sync-${pull_number}-to-${target_branch}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Trigger deploy using a comment
         if: steps.synced-pr.outputs.was_successful == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # special fine-grained token for issue comment trigger
           github-token: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Deploy Preview to Netlify as preview
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v4
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0.0
         env:
           NETLIFY_SITE_ID: 2a3da659-672b-4e5b-8785-e10ebf79a962
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           base_sha: ${{ github.event.pull_request.base.sha || steps.pr-info.outputs.base_sha }}
           files: |
@@ -186,7 +186,7 @@ jobs:
 
       - name: Create custom PR comment
         if: github.event.pull_request || github.event.issue.pull_request
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DEPLOY_URL: ${{ steps.netlify-deploy.outputs.deploy-url }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # if called from workflow_call event, checkout the ref otherwise use default
           ref: ${{ inputs.ref || '' }}
@@ -97,7 +97,7 @@ jobs:
         #   (we need to protect also from workflow_dispatch inherited from workflow_call event - where inputs.prerelease is defined)
         if: ${{ inputs.prerelease || (format('{0}', inputs.prerelease) != 'false' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/prerelease') }}
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v4
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0.0
         env:
           NETLIFY_SITE_ID: 2a3da659-672b-4e5b-8785-e10ebf79a962
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -14,7 +14,7 @@ jobs:
       prerelease_version: ${{ steps.get-versions.outputs.prerelease_version }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 #        with:
 #          token: ${{ secrets.COMMIT_PAT }}
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Commit Changes to main branch
         id: auto-commit
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           repository: .
           commit_user_name: Github Action Runner

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout prerelease branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: prerelease
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  unpinned-uses:
+    config:
+      # quarto-dev and r-lib may use a moving major tag; everything else is hash-pinned.
+      policies:
+        "quarto-dev/*": ref-pin
+        "r-lib/*": ref-pin
+        "*": hash-pin
+
+  dangerous-triggers:
+    ignore:
+      - port-to-prerelease.yml # needs write access to open the sync PR


### PR DESCRIPTION
Our SHA pins had drifted -- backport-action was four minors behind -- and the
style was inconsistent: one workflow hash-pinned everything while the rest
used floating major tags, so a new entry had no rule to be checked against.

Settle on hash-pinning every third-party action, GitHub's own included.
optimize-images already hash-pinned checkout, and relaxing that to a major tag
for the sake of consistency would have given up a real guarantee to gain a
tidier diff. Floating major tags stay only for quarto-dev, which is ours, and
r-lib, which Posit maintains. zizmor.yml encodes this as the unpinned-uses
policy so a new entry is checked rather than trusted. Note that ref-pin permits
any symbolic ref, branches included, so those two exemptions rest on publisher
trust and are not an enforced tag pattern.

checkout moves to v7 and github-script to v9. Both are majors with behaviour
changes that were checked against these workflows first. v7 refuses to check
out fork PR code under pull_request_target and workflow_run; neither exposed
workflow does that, since port-to-prerelease takes the base ref and preview
runs on pull_request and issue_comment, so the guard never fires. v9 is
ESM-only and drops require('@actions/github'); both our scripts use only the
injected github.rest and context.

pull_request_target in port-to-prerelease is deliberate, so it is recorded as
a zizmor ignore with its rationale instead of being left to resurface.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>