### PR TITLE
Have dependabot maintain the action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7 # don't adopt a release the day it ships
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
The pins this repo carries went stale unnoticed because nothing was watching
them; that is how backport-action ended up four minors behind. Monthly grouped
updates keep the policy in zizmor.yml honest without a stream of bot PRs.

A seven-day cooldown deliberately delays adoption of fresh releases. Hash pins
protect against a tag being moved under us, but not against trusting a bad
release on the day it ships, which is the failure mode the tj-actions
compromise exercised. Nothing here needs same-day updates.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>