### PR TITLE
Stop interpolating event data into shell and script bodies

### DIFF
--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true # git-auto-commit-action pushes with these
 
       - name: Install oxipng
         env:

--- a/.github/workflows/port-to-prerelease.yml
+++ b/.github/workflows/port-to-prerelease.yml
@@ -31,6 +31,8 @@ jobs:
       )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true # backport-action pushes with these and has no token of its own
 
       - name: Create backport pull requests
         id: synced-pr
@@ -56,6 +58,8 @@ jobs:
       - name: Trigger deploy using a comment
         if: steps.synced-pr.outputs.was_successful == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CREATED_PULL_NUMBERS: ${{ steps.synced-pr.outputs.created_pull_numbers }}
         with:
           # special fine-grained token for issue comment trigger
           github-token: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}
@@ -63,6 +67,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: "${{ steps.synced-pr.outputs.created_pull_numbers }}",
+              issue_number: process.env.CREATED_PULL_NUMBERS,
               body: "/deploy-preview",
             });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,10 +34,12 @@ jobs:
         id: commenter-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
         run: |
-          commenter_role=$(gh api repos/$GITHUB_REPOSITORY/collaborators/${{ github.event.comment.user.login }}/permission --jq '.permission')
+          commenter_role=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$COMMENTER/permission" --jq '.permission')
           echo "commenter_role=$commenter_role" >> "$GITHUB_OUTPUT"
-          echo "author_association=${{ github.event.comment.author_association }}" >> "$GITHUB_OUTPUT"
+          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
         shell: bash
 
   build-deploy-preview:
@@ -68,6 +70,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+          persist-credentials: false # nothing here pushes
 
       # On issue_comment events (e.g. /deploy-preview), github.event.pull_request
       # is not populated so tj-actions/changed-files can't determine the base commit
@@ -77,9 +80,9 @@ jobs:
         id: pr-info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          pr_number=${{ github.event.issue.number }}
-          base_sha=$(gh -R $GITHUB_REPOSITORY pr view $pr_number --json baseRefOid --jq '.baseRefOid')
+          base_sha=$(gh -R "$GITHUB_REPOSITORY" pr view "$PR_NUMBER" --json baseRefOid --jq '.baseRefOid')
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
         shell: bash
 
@@ -99,13 +102,16 @@ jobs:
         id: prerelease-docs-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          if [ "${{ github.event.pull_request.base.ref }}" == "prerelease" ]; then
+          if [ "$PR_BASE_REF" == "prerelease" ]; then
             echo "is_prerelease_docs=true" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.issue.pull_request.url }}" ]; then
-            # This will trigger when not pull request event, so a PR comment event. 
+          elif [ -n "$ISSUE_PR_URL" ]; then
+            # This will trigger when not pull request event, so a PR comment event.
             # we need to get the base info from PR number the comment is made in
-            base_ref=$(gh -R $GITHUB_REPOSITORY pr view ${{ github.event.issue.number }} --json baseRefName --jq '.baseRefName')
+            base_ref=$(gh -R "$GITHUB_REPOSITORY" pr view "$ISSUE_NUMBER" --json baseRefName --jq '.baseRefName')
             if [ "$base_ref" == "prerelease" ]; then
               echo "is_prerelease_docs=true" >> "$GITHUB_OUTPUT"
             else
@@ -164,10 +170,11 @@ jobs:
       
       - name: Map changed images to doc pages
         id: image-pages
+        env:
+          CHANGED: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           # Build JSON mapping from image output paths to doc pages using manifest
           MANIFEST="_tools/screenshots/manifest.json"
-          CHANGED='${{ steps.changed-files.outputs.all_changed_files }}'
           if [ -f "$MANIFEST" ]; then
             # Extract {output: doc.file} pairs, match against changed files
             IMAGE_PAGES=$(echo "$CHANGED" | jq -r --slurpfile manifest "$MANIFEST" '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ on:
         description: 'Whether to deploy prerelease or release site'
         type: boolean
         default: false
+    secrets:
+      NETLIFY_AUTH_TOKEN:
+        required: true
+        description: 'Netlify token used to deploy both the production and prerelease sites'
 
 name: Quarto Publish
 
@@ -31,6 +35,7 @@ jobs:
         with:
           # if called from workflow_call event, checkout the ref otherwise use default
           ref: ${{ inputs.ref || '' }}
+          persist-credentials: false # deploys with NETLIFY_AUTH_TOKEN, never pushes
 
       - name: Get latest pre-release from github
         id: github-release

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-#        with:
+        with:
+          persist-credentials: true # git-auto-commit-action and the push to prerelease use these
 #          token: ${{ secrets.COMMIT_PAT }}
 
       - name: Regenerate Download Json
@@ -48,10 +49,11 @@ jobs:
       - name: Sync generated downloads to prerelease branch
         id: sync-prerelease
         if: ${{ steps.auto-commit.outputs.changes_detected == 'true' }}
+        env:
+          MAIN_SHA: ${{ steps.auto-commit.outputs.commit_hash }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          MAIN_SHA=${{ steps.auto-commit.outputs.commit_hash }}
           git checkout prerelease
           # _redirects is authoritative on main (manual redirects reach prerelease
           # via the backport workflow), so overwrite the generated files outright
@@ -75,7 +77,8 @@ jobs:
     with:
       ref: ${{ needs.update-downloads.outputs.commit }}
       prerelease: false
-    secrets: inherit
+    secrets:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
   # If a new commit has been made with updated downloads,
   # then publish the changes using the new commit as ref to checkout
@@ -87,7 +90,8 @@ jobs:
     with:
       ref: ${{ needs.update-downloads.outputs.commit_prerelease }}
       prerelease: true
-    secrets: inherit
+    secrets:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
   # If a new commit has been made with updated downloads,
   # trigger the reference page update workflow
@@ -97,4 +101,5 @@ jobs:
     uses: ./.github/workflows/update-prerelease-reference.yml
     with:
       version: ${{ needs.update-downloads.outputs.prerelease_version }}
-    secrets: inherit
+    secrets:
+      ISSUE_COMMENT_TRIGGER_PAT: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: prerelease
+          persist-credentials: true # git push --force for the rolling branch uses these
 
       # --- Safety checks ---
 
@@ -98,8 +99,10 @@ jobs:
         run: quarto --version
 
       - name: Clone quarto-cli at matching tag
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          git clone --depth 1 --branch v${{ inputs.version }} \
+          git clone --depth 1 --branch "v$VERSION" \
             https://github.com/quarto-dev/quarto-cli.git \
             ../quarto-cli
 
@@ -134,11 +137,13 @@ jobs:
 
       - name: Check for changes
         id: check-changes
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No changes detected - reference pages are already up to date for v${{ inputs.version }}"
+            echo "::notice::No changes detected - reference pages are already up to date for v$VERSION"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "Changes detected:"
@@ -152,10 +157,13 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          EXISTING_PR_NUMBER: ${{ steps.check-pr.outputs.existing_pr_number }}
+          EXISTING_PR_URL: ${{ steps.check-pr.outputs.existing_pr_url }}
         run: |
-          version="${{ inputs.version }}"
+          version="$VERSION"
           branch="auto/prerelease-reference"
-          existing_pr_number="${{ steps.check-pr.outputs.existing_pr_number }}"
+          existing_pr_number="$EXISTING_PR_NUMBER"
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -198,7 +206,7 @@ jobs:
             git push --force origin "$branch"
             gh pr edit "$existing_pr_number" --body-file "$RUNNER_TEMP/pr-body.md"
 
-            pr_url="${{ steps.check-pr.outputs.existing_pr_url }}"
+            pr_url="$EXISTING_PR_URL"
             echo "Updated existing PR: $pr_url"
           else
             # Create new PR
@@ -219,12 +227,14 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.push-pr.outputs.pr_url }}
         run: |
-          gh pr edit "${{ steps.push-pr.outputs.pr_url }}" --add-assignee cwickham
+          gh pr edit "$PR_URL" --add-assignee cwickham
 
       - name: Trigger preview deployment
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}
+          PR_URL: ${{ steps.push-pr.outputs.pr_url }}
         run: |
-          gh pr comment "${{ steps.push-pr.outputs.pr_url }}" --body "/deploy-preview"
+          gh pr comment "$PR_URL" --body "/deploy-preview"


### PR DESCRIPTION
Every `${{ }}` that reached a run block or a github-script body is now bound
to an env var and referenced through the shell or process.env instead. Six of
these were high severity: a commenter's login went straight into a `gh api`
argument, and a workflow input went into `git clone --branch`. Neither is
exploitable today, since GitHub logins are restricted to a safe character set
and the input paths need write access to reach, but the pattern is one edit
away from being exploitable and there is no reason to keep it.

Every checkout now states its credential handling. Publish and preview set
persist-credentials: false, because neither pushes -- both authenticate to
Netlify with a token. The other four push with plain git and rely on exactly
those credentials, so they set persist-credentials: true with the pusher named.

Explicit true is zizmor's documented remediation for a credential that is
genuinely needed. The audit exists to catch the implicit default, so declaring
the intent answers it rather than suppressing it: no ignore entry to maintain,
and a checkout added later without the line is still reported.

Worth recording for anyone reading the audit's severity: checkout v6 and later
keep the credential under RUNNER_TEMP rather than in the workspace's
.git/config, so the artifact-exfiltration path the audit is named for no longer
runs through the checked-out tree.

The three `secrets: inherit` call sites now name what they pass, which needed
publish.yml to declare NETLIFY_AUTH_TOKEN on its workflow_call so a caller can
pass it by name at all.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>