### PR TITLE
Grant workflows only the token scopes they use

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,8 @@ on:
 
 name: Deploy Preview
 
+permissions: {} # each job opts in below
+
 concurrency:
   # Use github.event.pull_request.number on pull requests, so it's unique per pull request
   # Use github.event.issue.number on issue comments, so it's unique per comment
@@ -20,28 +22,11 @@ jobs:
     # Be helpful with reviewer and remind them to trigger a deploy preview if the PR is from a fork.
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
     runs-on: ubuntu-latest
-    # Only writes a workflow annotation.
-    permissions: {}
+    permissions: {} # only writes an annotation
     steps:
       - name: Error with message for manual deploy
         run: |
           echo "::error title=Manual action required for preview::PR from fork can't be deployed as preview to Netlify automatically. Use '/deploy-preview' command in comments to trigger the preview manually."
-        shell: bash
-
-  role-of-commenter:
-    if: github.event.issue.pull_request
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if commenter is a member, owner or collaborator
-        id: commenter-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENTER: ${{ github.event.comment.user.login }}
-          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
-        run: |
-          commenter_role=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$COMMENTER/permission" --jq '.permission')
-          echo "commenter_role=$commenter_role" >> "$GITHUB_OUTPUT"
-          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
         shell: bash
 
   build-deploy-preview:
@@ -67,12 +52,10 @@ jobs:
       ) 
       
     runs-on: ubuntu-latest
-    # contents to check out the merge ref, statuses for the Netlify deploy
-    # status, pull-requests to post the preview comment.
     permissions:
       contents: read
-      statuses: write
-      pull-requests: write
+      statuses: write # for the Netlify deploy status
+      pull-requests: write # so it can post the preview comment
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,8 @@ jobs:
     # Be helpful with reviewer and remind them to trigger a deploy preview if the PR is from a fork.
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
     runs-on: ubuntu-latest
+    # Only writes a workflow annotation.
+    permissions: {}
     steps:
       - name: Error with message for manual deploy
         run: |
@@ -65,6 +67,12 @@ jobs:
       ) 
       
     runs-on: ubuntu-latest
+    # contents to check out the merge ref, statuses for the Netlify deploy
+    # status, pull-requests to post the preview comment.
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,9 @@ on:
 
 name: Quarto Publish
 
-# Deploys via NETLIFY_AUTH_TOKEN, so the GitHub token only needs to read the
-# tree and post the deploy's commit status.
 permissions:
   contents: read
-  statuses: write
+  statuses: write # for the Netlify deploy status
 
 concurrency:
   group: ${{ format('{0} - {1} - {2}', github.workflow, github.ref, inputs.prerelease && 'prerelease' || 'main') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,12 @@ on:
 
 name: Quarto Publish
 
+# Deploys via NETLIFY_AUTH_TOKEN, so the GitHub token only needs to read the
+# tree and post the deploy's commit status.
+permissions:
+  contents: read
+  statuses: write
+
 concurrency:
   group: ${{ format('{0} - {1} - {2}', github.workflow, github.ref, inputs.prerelease && 'prerelease' || 'main') }}
   cancel-in-progress: true

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   update-downloads:
     runs-on: ubuntu-latest
+    # Commits the regenerated download JSON to main and syncs it to prerelease.
+    permissions:
+      contents: write
     outputs:
       changes_detected: ${{ steps.auto-commit.outputs.changes_detected }}
       commit: ${{ steps.auto-commit.outputs.commit_hash }}
@@ -74,6 +77,11 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/publish.yml
+    # A called workflow cannot exceed its caller's grant, so this mirrors the
+    # permissions publish.yml declares for itself.
+    permissions:
+      contents: read
+      statuses: write
     with:
       ref: ${{ needs.update-downloads.outputs.commit }}
       prerelease: false
@@ -87,6 +95,11 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/publish.yml
+    # A called workflow cannot exceed its caller's grant, so this mirrors the
+    # permissions publish.yml declares for itself.
+    permissions:
+      contents: read
+      statuses: write
     with:
       ref: ${{ needs.update-downloads.outputs.commit_prerelease }}
       prerelease: true
@@ -99,6 +112,10 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/update-prerelease-reference.yml
+    # Mirrors update-prerelease-reference.yml's own permissions.
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       version: ${{ needs.update-downloads.outputs.prerelease_version }}
     secrets:

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -7,9 +7,8 @@ on:
 jobs:
   update-downloads:
     runs-on: ubuntu-latest
-    # Commits the regenerated download JSON to main and syncs it to prerelease.
     permissions:
-      contents: write
+      contents: write # commits the regenerated JSON and syncs it to prerelease
     outputs:
       changes_detected: ${{ steps.auto-commit.outputs.changes_detected }}
       commit: ${{ steps.auto-commit.outputs.commit_hash }}
@@ -77,8 +76,7 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/publish.yml
-    # A called workflow cannot exceed its caller's grant, so this mirrors the
-    # permissions publish.yml declares for itself.
+    # A called workflow cannot exceed its caller's grant.
     permissions:
       contents: read
       statuses: write
@@ -95,8 +93,7 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/publish.yml
-    # A called workflow cannot exceed its caller's grant, so this mirrors the
-    # permissions publish.yml declares for itself.
+    # A called workflow cannot exceed its caller's grant.
     permissions:
       contents: read
       statuses: write
@@ -112,7 +109,7 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/update-prerelease-reference.yml
-    # Mirrors update-prerelease-reference.yml's own permissions.
+    # A called workflow cannot exceed its caller's grant.
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -17,11 +17,9 @@ on:
       ISSUE_COMMENT_TRIGGER_PAT:
         required: true
 
-# Pushes the rolling auto/prerelease-reference branch and opens, edits,
-# assigns and comments on its PR.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write # so it can push the rolling branch
+  pull-requests: write # so it can open and comment on the PR
 
 concurrency:
   group: prerelease-reference-update

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -17,6 +17,12 @@ on:
       ISSUE_COMMENT_TRIGGER_PAT:
         required: true
 
+# Pushes the rolling auto/prerelease-reference branch and opens, edits,
+# assigns and comments on its PR.
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: prerelease-reference-update
   cancel-in-progress: false


### PR DESCRIPTION
Four workflows had no `permissions:` block, so they ran with the repository default token. The zizmor check added in #2157 fails on that, so the scopes have to be settled before it can land.

Each job now declares what it actually does: publish and the preview build read the tree and write a commit status, the download job writes contents because it commits and pushes, and the reference job also writes pull requests because it opens and comments on one. The two reusable-workflow calls repeat their callee's permissions rather than inheriting a wider set, since a called workflow is capped by its caller's grant and would otherwise fail on a scope the callee legitimately needs.

The second commit drops `preview.yml`'s `role-of-commenter` job. It wrote two step outputs that nothing read, and it queried the collaborator permission API, which needs push-level access that no `GITHUB_TOKEN` scope matches. Keeping it green would have meant granting `contents: write` to a job that writes nothing, so removing it lets that workflow default to no permissions at all. It was a diagnostic for the MEMBER-seen-as-CONTRIBUTOR mismatch described in the FIXME just below it, and is a few lines to reinstate if that gets picked up again.

None of these scopes can be exercised from this PR, since `preview.yml` ignores `.github/**`. `update-downloads` runs on a schedule and pushes to two branches, so it exercises itself shortly after merge.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
