### PR TITLE
Fail the build on new workflow security findings

### DIFF
--- a/.github/workflows/audit-workflows.yml
+++ b/.github/workflows/audit-workflows.yml
@@ -1,0 +1,35 @@
+name: Audit Workflows
+
+on:
+  pull_request:
+    paths: ['.github/**']
+  push:
+    branches: [main, prerelease]
+    paths: ['.github/**']
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows with zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Scoped to our own workflows: the repo root also holds the
+          # quarto-demo subtree, refreshed wholesale from upstream.
+          inputs: .github/
+          collect: all # the default mode skips dependabot.yml
+          advanced-security: false # annotations instead, so no SARIF upload
+          annotations: true


### PR DESCRIPTION
The pinning policy and the fixes below it are only worth as much as whatever
keeps them from eroding, so this gates merges rather than reporting after the
fact. The preceding layers bring the finding count to zero, so this starts
green.

Scoped to .github/ deliberately. At repository root zizmor also collects the
quarto-demo copy under _tools/screenshots/examples/, which is a git subtree
refreshed wholesale from upstream; gating our merges on code we never edit here
would break the build the first time upstream touches an action.

collect: all is needed for dependabot.yml to be audited, which is not
hypothetical -- that file produced a real cooldown finding when it was added.

Annotations instead of a SARIF upload keeps this working without code scanning
enabled and without granting security-events: write.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>