### PR TITLE
Sync CI action refresh and workflow hardening to prerelease

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7 # don't adopt a release the day it ships
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/audit-workflows.yml
+++ b/.github/workflows/audit-workflows.yml
@@ -1,0 +1,35 @@
+name: Audit Workflows
+
+on:
+  pull_request:
+    paths: ['.github/**']
+  push:
+    branches: [main, prerelease]
+    paths: ['.github/**']
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows with zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Scoped to our own workflows: the repo root also holds the
+          # quarto-demo subtree, refreshed wholesale from upstream.
+          inputs: .github/
+          collect: all # the default mode skips dependabot.yml
+          advanced-security: false # annotations instead, so no SARIF upload
+          annotations: true

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get changed PNG files
         id: changed-pngs
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: '**/*.png'
           separator: '\n'
@@ -55,7 +55,7 @@ jobs:
           done
 
       - name: Commit optimized images
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Optimize PNG images with oxipng"
           commit_user_name: github-actions[bot]

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true # git-auto-commit-action pushes with these
 
       - name: Install oxipng
         env:

--- a/.github/workflows/port-to-prerelease.yml
+++ b/.github/workflows/port-to-prerelease.yml
@@ -30,12 +30,12 @@ jobs:
         startsWith(github.event.comment.body, '/sync-prerelease')
       )
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create backport pull requests
         id: synced-pr
-        # https://github.com/korthout/backport-action/releases/tag/v4.2.0
-        uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02
+        # https://github.com/korthout/backport-action/releases/tag/v4.6.0
+        uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:
           cherry_picking: auto
           branch_name: sync-${pull_number}-to-${target_branch}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Trigger deploy using a comment
         if: steps.synced-pr.outputs.was_successful == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # special fine-grained token for issue comment trigger
           github-token: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}

--- a/.github/workflows/port-to-prerelease.yml
+++ b/.github/workflows/port-to-prerelease.yml
@@ -31,6 +31,8 @@ jobs:
       )
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true # backport-action pushes with these and has no token of its own
 
       - name: Create backport pull requests
         id: synced-pr
@@ -56,6 +58,8 @@ jobs:
       - name: Trigger deploy using a comment
         if: steps.synced-pr.outputs.was_successful == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CREATED_PULL_NUMBERS: ${{ steps.synced-pr.outputs.created_pull_numbers }}
         with:
           # special fine-grained token for issue comment trigger
           github-token: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}
@@ -63,6 +67,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: "${{ steps.synced-pr.outputs.created_pull_numbers }}",
+              issue_number: process.env.CREATED_PULL_NUMBERS,
               body: "/deploy-preview",
             });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,8 @@ on:
 
 name: Deploy Preview
 
+permissions: {} # each job opts in below
+
 concurrency:
   # Use github.event.pull_request.number on pull requests, so it's unique per pull request
   # Use github.event.issue.number on issue comments, so it's unique per comment
@@ -20,26 +22,11 @@ jobs:
     # Be helpful with reviewer and remind them to trigger a deploy preview if the PR is from a fork.
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
     runs-on: ubuntu-latest
+    permissions: {} # only writes an annotation
     steps:
       - name: Error with message for manual deploy
         run: |
           echo "::error title=Manual action required for preview::PR from fork can't be deployed as preview to Netlify automatically. Use '/deploy-preview' command in comments to trigger the preview manually."
-        shell: bash
-
-  role-of-commenter:
-    if: github.event.issue.pull_request
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if commenter is a member, owner or collaborator
-        id: commenter-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENTER: ${{ github.event.comment.user.login }}
-          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
-        run: |
-          commenter_role=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$COMMENTER/permission" --jq '.permission')
-          echo "commenter_role=$commenter_role" >> "$GITHUB_OUTPUT"
-          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
         shell: bash
 
   build-deploy-preview:
@@ -65,6 +52,10 @@ jobs:
       ) 
       
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write # for the Netlify deploy status
+      pull-requests: write # so it can post the preview comment
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,10 +34,12 @@ jobs:
         id: commenter-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
         run: |
-          commenter_role=$(gh api repos/$GITHUB_REPOSITORY/collaborators/${{ github.event.comment.user.login }}/permission --jq '.permission')
+          commenter_role=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$COMMENTER/permission" --jq '.permission')
           echo "commenter_role=$commenter_role" >> "$GITHUB_OUTPUT"
-          echo "author_association=${{ github.event.comment.author_association }}" >> "$GITHUB_OUTPUT"
+          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
         shell: bash
 
   build-deploy-preview:
@@ -68,6 +70,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+          persist-credentials: false # nothing here pushes
 
       # On issue_comment events (e.g. /deploy-preview), github.event.pull_request
       # is not populated so tj-actions/changed-files can't determine the base commit
@@ -77,9 +80,9 @@ jobs:
         id: pr-info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          pr_number=${{ github.event.issue.number }}
-          base_sha=$(gh -R $GITHUB_REPOSITORY pr view $pr_number --json baseRefOid --jq '.baseRefOid')
+          base_sha=$(gh -R "$GITHUB_REPOSITORY" pr view "$PR_NUMBER" --json baseRefOid --jq '.baseRefOid')
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
         shell: bash
 
@@ -99,13 +102,16 @@ jobs:
         id: prerelease-docs-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          if [ "${{ github.event.pull_request.base.ref }}" == "prerelease" ]; then
+          if [ "$PR_BASE_REF" == "prerelease" ]; then
             echo "is_prerelease_docs=true" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ github.event.issue.pull_request.url }}" ]; then
-            # This will trigger when not pull request event, so a PR comment event. 
+          elif [ -n "$ISSUE_PR_URL" ]; then
+            # This will trigger when not pull request event, so a PR comment event.
             # we need to get the base info from PR number the comment is made in
-            base_ref=$(gh -R $GITHUB_REPOSITORY pr view ${{ github.event.issue.number }} --json baseRefName --jq '.baseRefName')
+            base_ref=$(gh -R "$GITHUB_REPOSITORY" pr view "$ISSUE_NUMBER" --json baseRefName --jq '.baseRefName')
             if [ "$base_ref" == "prerelease" ]; then
               echo "is_prerelease_docs=true" >> "$GITHUB_OUTPUT"
             else
@@ -164,10 +170,11 @@ jobs:
       
       - name: Map changed images to doc pages
         id: image-pages
+        env:
+          CHANGED: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           # Build JSON mapping from image output paths to doc pages using manifest
           MANIFEST="_tools/screenshots/manifest.json"
-          CHANGED='${{ steps.changed-files.outputs.all_changed_files }}'
           if [ -f "$MANIFEST" ]; then
             # Extract {output: doc.file} pairs, match against changed files
             IMAGE_PAGES=$(echo "$CHANGED" | jq -r --slurpfile manifest "$MANIFEST" '

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Deploy Preview to Netlify as preview
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v4
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0.0
         env:
           NETLIFY_SITE_ID: 2a3da659-672b-4e5b-8785-e10ebf79a962
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           base_sha: ${{ github.event.pull_request.base.sha || steps.pr-info.outputs.base_sha }}
           files: |
@@ -186,7 +186,7 @@ jobs:
 
       - name: Create custom PR comment
         if: github.event.pull_request || github.event.issue.pull_request
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DEPLOY_URL: ${{ steps.netlify-deploy.outputs.deploy-url }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,10 @@ on:
         description: 'Whether to deploy prerelease or release site'
         type: boolean
         default: false
+    secrets:
+      NETLIFY_AUTH_TOKEN:
+        required: true
+        description: 'Netlify token used to deploy both the production and prerelease sites'
 
 name: Quarto Publish
 
@@ -31,6 +35,7 @@ jobs:
         with:
           # if called from workflow_call event, checkout the ref otherwise use default
           ref: ${{ inputs.ref || '' }}
+          persist-credentials: false # deploys with NETLIFY_AUTH_TOKEN, never pushes
 
       - name: Get latest pre-release from github
         id: github-release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,10 @@ on:
 
 name: Quarto Publish
 
+permissions:
+  contents: read
+  statuses: write # for the Netlify deploy status
+
 concurrency:
   group: ${{ format('{0} - {1} - {2}', github.workflow, github.ref, inputs.prerelease && 'prerelease' || 'main') }}
   cancel-in-progress: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # if called from workflow_call event, checkout the ref otherwise use default
           ref: ${{ inputs.ref || '' }}
@@ -97,7 +97,7 @@ jobs:
         #   (we need to protect also from workflow_dispatch inherited from workflow_call event - where inputs.prerelease is defined)
         if: ${{ inputs.prerelease || (format('{0}', inputs.prerelease) != 'false' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.ref == 'refs/heads/prerelease') }}
         id: netlify-deploy
-        uses: nwtgck/actions-netlify@v4
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668 # v4.0.0
         env:
           NETLIFY_SITE_ID: 2a3da659-672b-4e5b-8785-e10ebf79a962
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -14,7 +14,7 @@ jobs:
       prerelease_version: ${{ steps.get-versions.outputs.prerelease_version }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 #        with:
 #          token: ${{ secrets.COMMIT_PAT }}
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Commit Changes to main branch
         id: auto-commit
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           repository: .
           commit_user_name: Github Action Runner

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-#        with:
+        with:
+          persist-credentials: true # git-auto-commit-action and the push to prerelease use these
 #          token: ${{ secrets.COMMIT_PAT }}
 
       - name: Regenerate Download Json
@@ -48,10 +49,11 @@ jobs:
       - name: Sync generated downloads to prerelease branch
         id: sync-prerelease
         if: ${{ steps.auto-commit.outputs.changes_detected == 'true' }}
+        env:
+          MAIN_SHA: ${{ steps.auto-commit.outputs.commit_hash }}
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          MAIN_SHA=${{ steps.auto-commit.outputs.commit_hash }}
           git checkout prerelease
           # _redirects is authoritative on main (manual redirects reach prerelease
           # via the backport workflow), so overwrite the generated files outright
@@ -75,7 +77,8 @@ jobs:
     with:
       ref: ${{ needs.update-downloads.outputs.commit }}
       prerelease: false
-    secrets: inherit
+    secrets:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
   # If a new commit has been made with updated downloads,
   # then publish the changes using the new commit as ref to checkout
@@ -87,7 +90,8 @@ jobs:
     with:
       ref: ${{ needs.update-downloads.outputs.commit_prerelease }}
       prerelease: true
-    secrets: inherit
+    secrets:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
   # If a new commit has been made with updated downloads,
   # trigger the reference page update workflow
@@ -97,4 +101,5 @@ jobs:
     uses: ./.github/workflows/update-prerelease-reference.yml
     with:
       version: ${{ needs.update-downloads.outputs.prerelease_version }}
-    secrets: inherit
+    secrets:
+      ISSUE_COMMENT_TRIGGER_PAT: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}

--- a/.github/workflows/update-downloads.yml
+++ b/.github/workflows/update-downloads.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   update-downloads:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # commits the regenerated JSON and syncs it to prerelease
     outputs:
       changes_detected: ${{ steps.auto-commit.outputs.changes_detected }}
       commit: ${{ steps.auto-commit.outputs.commit_hash }}
@@ -74,6 +76,10 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/publish.yml
+    # A called workflow cannot exceed its caller's grant.
+    permissions:
+      contents: read
+      statuses: write
     with:
       ref: ${{ needs.update-downloads.outputs.commit }}
       prerelease: false
@@ -87,6 +93,10 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/publish.yml
+    # A called workflow cannot exceed its caller's grant.
+    permissions:
+      contents: read
+      statuses: write
     with:
       ref: ${{ needs.update-downloads.outputs.commit_prerelease }}
       prerelease: true
@@ -99,6 +109,10 @@ jobs:
     needs: [ update-downloads ]
     if: ${{ needs.update-downloads.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/update-prerelease-reference.yml
+    # A called workflow cannot exceed its caller's grant.
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       version: ${{ needs.update-downloads.outputs.prerelease_version }}
     secrets:

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -17,6 +17,10 @@ on:
       ISSUE_COMMENT_TRIGGER_PAT:
         required: true
 
+permissions:
+  contents: write # so it can push the rolling branch
+  pull-requests: write # so it can open and comment on the PR
+
 concurrency:
   group: prerelease-reference-update
   cancel-in-progress: false

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout prerelease branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: prerelease
 

--- a/.github/workflows/update-prerelease-reference.yml
+++ b/.github/workflows/update-prerelease-reference.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: prerelease
+          persist-credentials: true # git push --force for the rolling branch uses these
 
       # --- Safety checks ---
 
@@ -98,8 +99,10 @@ jobs:
         run: quarto --version
 
       - name: Clone quarto-cli at matching tag
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          git clone --depth 1 --branch v${{ inputs.version }} \
+          git clone --depth 1 --branch "v$VERSION" \
             https://github.com/quarto-dev/quarto-cli.git \
             ../quarto-cli
 
@@ -134,11 +137,13 @@ jobs:
 
       - name: Check for changes
         id: check-changes
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No changes detected - reference pages are already up to date for v${{ inputs.version }}"
+            echo "::notice::No changes detected - reference pages are already up to date for v$VERSION"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "Changes detected:"
@@ -152,10 +157,13 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          EXISTING_PR_NUMBER: ${{ steps.check-pr.outputs.existing_pr_number }}
+          EXISTING_PR_URL: ${{ steps.check-pr.outputs.existing_pr_url }}
         run: |
-          version="${{ inputs.version }}"
+          version="$VERSION"
           branch="auto/prerelease-reference"
-          existing_pr_number="${{ steps.check-pr.outputs.existing_pr_number }}"
+          existing_pr_number="$EXISTING_PR_NUMBER"
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -198,7 +206,7 @@ jobs:
             git push --force origin "$branch"
             gh pr edit "$existing_pr_number" --body-file "$RUNNER_TEMP/pr-body.md"
 
-            pr_url="${{ steps.check-pr.outputs.existing_pr_url }}"
+            pr_url="$EXISTING_PR_URL"
             echo "Updated existing PR: $pr_url"
           else
             # Create new PR
@@ -219,12 +227,14 @@ jobs:
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.push-pr.outputs.pr_url }}
         run: |
-          gh pr edit "${{ steps.push-pr.outputs.pr_url }}" --add-assignee cwickham
+          gh pr edit "$PR_URL" --add-assignee cwickham
 
       - name: Trigger preview deployment
         if: steps.check-changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.ISSUE_COMMENT_TRIGGER_PAT }}
+          PR_URL: ${{ steps.push-pr.outputs.pr_url }}
         run: |
-          gh pr comment "${{ steps.push-pr.outputs.pr_url }}" --body "/deploy-preview"
+          gh pr comment "$PR_URL" --body "/deploy-preview"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  unpinned-uses:
+    config:
+      # quarto-dev and r-lib may use a moving major tag; everything else is hash-pinned.
+      policies:
+        "quarto-dev/*": ref-pin
+        "r-lib/*": ref-pin
+        "*": hash-pin
+
+  dangerous-triggers:
+    ignore:
+      - port-to-prerelease.yml # needs write access to open the sync PR


### PR DESCRIPTION
Cherry-picks #2153, #2154, #2155, #2156 and #2157 onto `prerelease`, in that order.

Those five merged to `main` as a stack and all carried `no-sync-prerelease`, so none of them auto-backported. Letting them backport individually would have opened five PRs cut from the same `prerelease` tip: one of them does not apply on its own, because the `persist-credentials` edits in #2155 sit against the pinned `uses:` lines that #2153 introduces, and the other four would have landed in whatever order they were merged. `audit-workflows.yml` arriving before the findings it gates on are fixed would leave the check failing on `prerelease` until the rest caught up. One ordered sync avoids all of that.

`.github/` was byte-identical between `main` and `prerelease` beforehand, so all five apply without conflicts and the result matches `main` exactly. zizmor reports no findings on the synced tree, same as on `main`.

The workflows themselves are verified on `main` rather than in theory: `publish` via a dispatch on a non-deploying ref, `update-downloads` via a dispatch on `main`, and `preview` end to end on #2150, which covered `checkout@v7`, `changed-files` v47.0.6, `github-script@v9` and the three narrowed token scopes. What is still unexercised anywhere is the reusable-workflow `secrets:` blocks that replaced `secrets: inherit`, since those only evaluate when a new Quarto prerelease is published.
