### PR TITLE
Add sidebar separators so page navigation stays within sections

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -159,6 +159,7 @@ website:
                           href: docs/authoring/cross-references-custom.qmd
                     - docs/authoring/create-citeable-articles.qmd
                     - docs/authoring/appendices.qmd
+            - text: "---"
             - section: "Computations"
               contents:
                 - docs/computations/python.qmd
@@ -169,6 +170,7 @@ website:
                 - docs/computations/render-scripts.qmd
                 - docs/computations/execution-options.qmd
                 - docs/computations/parameters.qmd
+            - text: "---"
             - section: "Tools"
               contents:
                 - section: "JupyterLab"
@@ -210,6 +212,7 @@ website:
                       href: docs/tools/vscode/notebook.qmd
                 - docs/tools/neovim.qmd
                 - docs/tools/text-editors.qmd
+            - text: "---"
             - section: "Documents"
               href: docs/output-formats/all-formats.qmd
               contents:
@@ -241,6 +244,7 @@ website:
                     - docs/output-formats/hugo.qmd
                     - docs/output-formats/docusaurus.qmd
                 - docs/output-formats/all-formats.qmd
+            - text: "---"
             - section: "Presentations"
               contents:
                 - text: "Overview"
@@ -255,6 +259,7 @@ website:
                 - docs/presentations/powerpoint.qmd
                 - docs/presentations/beamer.qmd
 
+            - text: "---"
             - section: "Dashboards"
               href: docs/dashboards/index.qmd
               contents:
@@ -301,6 +306,7 @@ website:
                 - text: Examples
                   href: docs/gallery/index.qmd#dashboards
 
+            - text: "---"
             - section: "Websites"
               href: docs/websites/website-basics.qmd
               contents:
@@ -318,6 +324,7 @@ website:
                     - docs/websites/website-listings.qmd
                     - docs/websites/website-listings-custom.qmd
 
+            - text: "---"
             - section: "Books"
               href: docs/books/book-basics.qmd
               contents:
@@ -327,6 +334,7 @@ website:
                 - text: "Customizing Output"
                   href: docs/books/book-output.qmd
 
+            - text: "---"
             - section: "Manuscripts"
               href: docs/manuscripts/index.qmd
               contents:
@@ -349,6 +357,7 @@ website:
                 - text: "Using Manuscripts"
                   href: docs/manuscripts/components.qmd
 
+            - text: "---"
             - section: "Interactivity"
               contents:
                 - text: "Overview"
@@ -401,6 +410,7 @@ website:
                     - docs/interactive/widgets/jupyter.qmd
                     - docs/interactive/widgets/htmlwidgets.qmd
                 - docs/interactive/layout.qmd
+            - text: "---"
             - section: "Publishing"
               contents:
                 - docs/publishing/index.qmd
@@ -414,6 +424,7 @@ website:
                 - docs/publishing/other.qmd
                 - text: "Publishing with CI"
                   href: docs/publishing/ci.qmd
+            - text: "---"
             - section: "Projects"
               contents:
                 - docs/projects/quarto-projects.qmd
@@ -424,6 +435,7 @@ website:
                 - docs/projects/scripts.qmd
                 - docs/projects/virtual-environments.qmd
                 - docs/projects/binder.qmd
+            - text: "---"
             - section: "Advanced"
               contents:
                 - docs/authoring/includes.qmd
@@ -571,6 +583,7 @@ website:
                       href: docs/reference/formats/tei.qmd
                     - text: "FictionBook"
                       href: docs/reference/formats/fb2.qmd
+            - text: "---"
             - section: "Code Cells"
               href: docs/reference/cells/index.qmd
               contents:
@@ -580,6 +593,7 @@ website:
                   href: docs/reference/cells/cells-knitr.qmd
                 - text: "Observable"
                   href: docs/reference/cells/cells-ojs.qmd
+            - text: "---"
             - section: "Projects"
               href: docs/reference/projects/index.qmd
               contents:
@@ -591,6 +605,7 @@ website:
                   href: docs/reference/projects/books.qmd
                 - text: "Manuscripts"
                   href: docs/reference/projects/manuscripts.qmd
+            - text: "---"
             - section: "Metadata"
               href: docs/reference/metadata/index.qmd
               contents:
@@ -604,6 +619,7 @@ website:
                   href: docs/reference/metadata/crossref.qmd
                 - text: "Brand"
                   href: docs/reference/metadata/brand.qmd
+            - text: "---"
             - section: "Quarto CLI"
               contents: docs/cli/*.qmd
     - id: prerelease


### PR DESCRIPTION
The prev/next links at the bottom of each page cross major section boundaries. For example, https://quarto.org/docs/interactive/ links back to "Using Manuscripts", a page in a different guide.

This PR adds `- text: "---"` separators between the top-level subsections of two sidebars in `_quarto.yml`:

- **Guide**: 12 separators, between Authoring, Computations, Tools, Documents, Presentations, Dashboards, Websites, Books, Manuscripts, Interactivity, Publishing, Projects, and Advanced.
- **Reference**: 4 separators, between Formats, Code Cells, Projects, Metadata, and Quarto CLI.

Page navigation drops a prev/next link when the adjacent sidebar item is a separator ([quarto-cli source](https://github.com/quarto-dev/quarto-cli/blob/abc6a78ed68f9e8bc9d54e27851093bd687a1cb7/src/project/types/website/website-navigation.ts#L1211-L1216)). The Extensions sidebar already uses separators this way.

**Visual change to judge**: each separator also renders as a horizontal rule in the sidebar, between the top-level subsections. This matches the look of the Extensions sidebar.

Verified with local renders (Quarto 1.10.18):

- `/docs/interactive/` no longer links back to "Using Manuscripts"; its "Observable JS" next link is unchanged.
- Within-section links are unchanged. For example, `/docs/interactive/ojs/` keeps its "Overview" and "Libraries" links.
- `/docs/reference/cells/cells-ojs` keeps its "Knitr" prev link and no longer links forward into Projects.

Note: AI implemented this change, grounded in local clones of quarto-web and quarto-cli.
