### PR TITLE
Add the index extension to the shortcodes and filters listing

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -436,6 +436,13 @@
   description: >
     Filter to include code from source files.
 
+- name: index
+  path: https://github.com/jmgirard/quarto-index
+  author: '[Jeffrey Girard](https://github.com/jmgirard)'
+  description: >
+    Filter to build a book-quality subject index from format-neutral marks in
+    your text, with back-ends for LaTeX/PDF and HTML.
+
 - name: inline-svg
   path: https://github.com/coursekata/quarto-inline-svg
   author: '[Adam Blake](https://github.com/adamblake)'


### PR DESCRIPTION
Adds [quarto-index](https://github.com/jmgirard/quarto-index) to `shortcodes-and-filters.yml`, placed alphabetically between `include-code-files` and `inline-svg`.

The extension gives Quarto documents and books a subject index: authors mark terms with a format-neutral span (`[term]{.index}`, plus `entry=`, `see=`, `see-also=`, `sort=`, `mention=`, `range=` and `index=`), and per-format back-ends realize the index. LaTeX/PDF goes through `imakeidx`; HTML prints the entry tree with letter groups and links each locator back to the marked passage. A Quarto book gets one index for the whole book. In formats with no back-end the marks pass through and emit nothing.

Against the requirements in `docs/extensions/listings/README.md`:

- Hosted from a GitHub repository.
- [README.md](https://github.com/jmgirard/quarto-index/blob/main/README.md) covers installation and usage, with fuller documentation at <https://jmgirard.github.io/quarto-index/>.
- MIT licensed ([LICENSE](https://github.com/jmgirard/quarto-index/blob/main/LICENSE)).

Requires Quarto 1.4 or later. Current release is [v0.1.0](https://github.com/jmgirard/quarto-index/releases/tag/v0.1.0).
