### PR TITLE
Filters: foldcode & iframe

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -696,6 +696,11 @@
     tables. Targets HTML, Reveal.js and PDF/LaTeX from a single source.
     Heavily inspired by the LaTeX
     [booktabs](https://ctan.org/pkg/booktabs?lang=en) package.
+  
+  - name: QuartoCards
+  path: https://github.com/WEHI-ResearchComputing/QuartoCards
+  author: '[multimeric](https://github.com/multimeric)'
+  description: Generate cards for displaying URLs in your Quarto presentations.
 
 - name: quarto-foldcode
   path: https://github.com/beck-chan/quarto-foldcode
@@ -936,11 +941,6 @@
   author: '[dragonstyle](https://github.com/dragonstyle)'
   description: >
     Shortcode to use Unsplash images within documents.
-
-- name: QuartoCards
-  path: https://github.com/WEHI-ResearchComputing/QuartoCards
-  author: '[multimeric](https://github.com/multimeric)'
-  description: Generate cards for displaying URLs in your Quarto presentations.
 
 - name: watermark
   path: https://github.com/leovan/quarto-watermark

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -949,3 +949,15 @@
   author: '[Andrew Heiss](https://github.com/andrewheiss/)'
   description: Quarto extension for calculating accurate word counts
 
+- name: quarto-iframe
+  path: https://github.com/beck-chan/quarto-iframe
+  author: '[Beck Chan](https://github.com/beck-chan)'
+  description: Quarto Extension for embedding iframes.
+
+- name: quarto-foldcode
+  path: https://github.com/beck-chan/quarto-foldcode
+  author: '[Beck Chan](https://github.com/beck-chan)'
+  description: Quarto Extension for folding non-executed code blocks.
+
+
+

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -697,7 +697,7 @@
     Heavily inspired by the LaTeX
     [booktabs](https://ctan.org/pkg/booktabs?lang=en) package.
   
-  - name: QuartoCards
+- name: QuartoCards
   path: https://github.com/WEHI-ResearchComputing/QuartoCards
   author: '[multimeric](https://github.com/multimeric)'
   description: Generate cards for displaying URLs in your Quarto presentations.
@@ -958,6 +958,4 @@
   path: https://github.com/andrewheiss/quarto-wordcount
   author: '[Andrew Heiss](https://github.com/andrewheiss/)'
   description: Quarto extension for calculating accurate word counts
-
-
 

--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -697,6 +697,16 @@
     Heavily inspired by the LaTeX
     [booktabs](https://ctan.org/pkg/booktabs?lang=en) package.
 
+- name: quarto-foldcode
+  path: https://github.com/beck-chan/quarto-foldcode
+  author: '[Beck Chan](https://github.com/beck-chan)'
+  description: Quarto Extension for folding non-executed code blocks.
+  
+- name: quarto-iframe
+  path: https://github.com/beck-chan/quarto-iframe
+  author: '[Beck Chan](https://github.com/beck-chan)'
+  description: Quarto Extension for embedding iframes.
+
 - name: quizdown
   path: https://github.com/parmsam/quarto-quizdown
   author: '[Sam Parmar](https://github.com/parmsam)'
@@ -948,16 +958,6 @@
   path: https://github.com/andrewheiss/quarto-wordcount
   author: '[Andrew Heiss](https://github.com/andrewheiss/)'
   description: Quarto extension for calculating accurate word counts
-
-- name: quarto-iframe
-  path: https://github.com/beck-chan/quarto-iframe
-  author: '[Beck Chan](https://github.com/beck-chan)'
-  description: Quarto Extension for embedding iframes.
-
-- name: quarto-foldcode
-  path: https://github.com/beck-chan/quarto-foldcode
-  author: '[Beck Chan](https://github.com/beck-chan)'
-  description: Quarto Extension for folding non-executed code blocks.
 
 
 


### PR DESCRIPTION
Added two new filter extensions:

```yaml
- name: quarto-iframe
  path: https://github.com/beck-chan/quarto-iframe
  author: '[Beck Chan](https://github.com/beck-chan)'
  description: Quarto Extension for embedding iframes.
```

<img width="838" height="711" alt="Screenshot 2026-08-31 234928" src="https://github.com/user-attachments/assets/5db6855d-d078-47f3-8a68-01f650ea1a60" />


```yaml
- name: quarto-foldcode
  path: https://github.com/beck-chan/quarto-foldcode
  author: '[Beck Chan](https://github.com/beck-chan)'
  description: Quarto Extension for folding non-executed code blocks.
```

<img width="623" height="576" alt="Screenshot 2026-08-31 234941" src="https://github.com/user-attachments/assets/50d97d39-c366-430d-96c6-73687e934700" />
