### PR TITLE
Update licensing details in license.qmd

### DIFF
--- a/license.qmd
+++ b/license.qmd
@@ -10,7 +10,7 @@ The [Quarto CLI](https://github.com/quarto-dev/quarto-cli) is licensed under the
 
 ### VS Code Extension and Visual Editor
 
-The Quarto [VS Code extension](https://github.com/quarto-dev/quarto/tree/main/apps/vscode) and the [visual editor](https://github.com/quarto-dev/quarto/tree/main/packages/editor) used in VS Code, Positron, and RStudio are licensed under the [GNU AGPL v3](https://www.gnu.org/licenses/agpl-3.0.en.html).
+The Quarto [VS Code extension](https://github.com/quarto-dev/quarto/tree/main/apps/vscode) is licensed user the [MIT License](https://opensource.org/license/mit/). The [visual editor](https://github.com/quarto-dev/quarto/tree/main/packages/editor) used in the extension and RStudio is licensed under the [GNU LGPL v3](https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 ### Dependencies
 


### PR DESCRIPTION
Correct licensing information for Quarto VS Code extension and visual editor.