### PR TITLE
docs(publish): ambiguous argument '#': move terminal comment to separate line

### DIFF
--- a/docs/publishing/github-pages.qmd
+++ b/docs/publishing/github-pages.qmd
@@ -84,7 +84,8 @@ You usually do not need to do this --- `quarto publish gh-pages` will create the
 
 ``` {.bash filename="Terminal"}
 git checkout --orphan gh-pages
-git reset --hard # make sure all changes are committed before running this!
+# make sure all changes are committed before running this!
+git reset --hard
 git commit --allow-empty -m "Initialising gh-pages branch"
 git push origin gh-pages
 ```


### PR DESCRIPTION
In the quarto publish > gh-pages page the current instructions for creating a gh-pages branch manually has this line:

```
git reset --hard # make sure all changes are committed before running this!
```
However when you run this command as-is you get an error

```
> git reset --hard # make sure all changes are committed before running this!

fatal: ambiguous argument '#': unknown revision or path not in the working tree. Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]'
```

This PR moves the comment on its own separate line before the `git reset` command so the entire chunk can be copy+pasted without an error.