### PR TITLE
Filter: Mobile listing category drop-down

### DIFF
--- a/docs/extensions/listings/shortcodes-and-filters.yml
+++ b/docs/extensions/listings/shortcodes-and-filters.yml
@@ -712,6 +712,11 @@
   author: '[Beck Chan](https://github.com/beck-chan)'
   description: Quarto Extension for embedding iframes.
 
+- name: quarto-mobile-categories
+  path: https://github.com/beck-chan/quarto-mobile-categories
+  author: '[Beck Chan](https://github.com/beck-chan)'
+  description: Quarto Extension for mobile-friendly listing category filters.
+
 - name: quizdown
   path: https://github.com/parmsam/quarto-quizdown
   author: '[Sam Parmar](https://github.com/parmsam)'


### PR DESCRIPTION
New filter extension:

```yaml
- name: quarto-mobile-categories
  path: https://github.com/beck-chan/quarto-mobile-categories
  author: '[Beck Chan](https://github.com/beck-chan)'
  description: Quarto Extension for mobile-friendly listing category filters.
```

<img width="411" height="282" alt="category-dropdown" src="https://github.com/user-attachments/assets/6bee0941-9bda-40e7-896c-92d311f19e86" />
