### PR TITLE
docs: relocate book-vs-website key note so it is reachable from the Analytics anchor

### DIFF
--- a/docs/books/_book-vs-website-key.qmd
+++ b/docs/books/_book-vs-website-key.qmd
@@ -1,10 +1,11 @@
-One important thing to note about using website tools is that while these tools are added to websites within the `website` key, in a book you should include the same options in the `book` key. For example, in a website you would include a favicon and twitter card as follows:
+One important thing to note about using website tools is that while these tools are added to websites within the `website` key, in a book you should include the same options in the `book` key. For example, in a website you would include a favicon, twitter card, and analytics as follows:
 
 ```yaml
 website:
   favicon: logo.png
   twitter-card: true
   site-url: https://example.com
+  plausible-analytics: XXXXXX
 ```
 
 In a book you'd use the `book` key instead:
@@ -14,5 +15,6 @@ book:
   favicon: logo.png
   twitter-card: true
   site-url: https://example.com
+  plausible-analytics: XXXXXX
 ```
 

--- a/docs/books/_book-vs-website-key.qmd
+++ b/docs/books/_book-vs-website-key.qmd
@@ -16,6 +16,7 @@ book:
   favicon: logo.png
   twitter-card: true
   site-url: https://example.com
-  plausible-analytics: XXXXXX
+  plausible-analytics:
+    path: _plausible_snippet.html
 ```
 

--- a/docs/books/_book-vs-website-key.qmd
+++ b/docs/books/_book-vs-website-key.qmd
@@ -5,7 +5,8 @@ website:
   favicon: logo.png
   twitter-card: true
   site-url: https://example.com
-  plausible-analytics: XXXXXX
+  plausible-analytics:
+    path: _plausible_snippet.html
 ```
 
 In a book you'd use the `book` key instead:

--- a/docs/websites/website-tools.qmd
+++ b/docs/websites/website-tools.qmd
@@ -2,6 +2,10 @@
 title: "Website Tools"
 ---
 
+{{< include ../books/_book-vs-website-key.qmd >}}
+
+As you read the documentation below, keep in mind to substitute `book` for `website` if you are authoring a book.
+
 ## Headers & Footers
 
 You can provide standard headers and footers for pages on your site. These can apply to the main document body or to the sidebar. Available options include:
@@ -63,10 +67,6 @@ You can enhance your website and the content that you publish to it by including
 -   Favicon
 -   Twitter Cards
 -   Open Graph
-
-{{< include ../books/_book-vs-website-key.qmd >}}
-
-As you read the documentation below, keep in mind to substitute `book` for `website` if you are authoring a book.
 
 ### Favicon
 
@@ -212,6 +212,8 @@ image: false
 ```
 
 ## Analytics
+
+If you are authoring a book, remember to set the analytics keys below under `book` instead of `website` (see the note at the top of this page).
 
 ### Plausible Analytics
 


### PR DESCRIPTION
quarto-dev/quarto-cli#14879 reported that `book: plausible-analytics` has no effect in a book project. The underlying config bug is fixed in quarto-dev/quarto-cli#14881, but the report also pointed at a real docs gap: the rule that book projects use `book:` instead of `website:` for these options was already documented in the book-vs-website key note, just not where a reader lands. The note sat under Social Metadata while Analytics is roughly 150 lines further down, so a reader arriving directly at the Analytics anchor never saw it.

This moves the note to a page-level intro so its generalizing sentence ("substitute `book` for `website`") actually holds for the whole page as written, and adds a short pointer inside Analytics for readers who land there via a deep link rather than reading top-down. The book-vs-website example also gains a `plausible-analytics` key so it concretely covers the reported case.

This note is accurate from 1.11 onward (the fix in quarto-dev/quarto-cli#14881), so it targets `prerelease` rather than `main`.

Related to quarto-dev/quarto-cli#14879, quarto-dev/quarto-cli#14881.